### PR TITLE
Issue #633 - symbolic links to RISM logo as default large logo

### DIFF
--- a/public/images/logo-large-default.png
+++ b/public/images/logo-large-default.png
@@ -1,0 +1,1 @@
+logo-large-ch.png


### PR DESCRIPTION
Adds a default large logo by using a symbolic link to the existing RISM-CH large logo.