### PR TITLE
Add sqlite3 gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,9 @@ gem 'rails', '>= 5.1', '< 5.2'
 # https://github.com/rails/rails/issues/21544
 gem 'mysql2'
 
+# Use sqlite3 for testing db
+gem 'sqlite3'
+
 # Use SCSS for stylesheets
 gem 'sass-rails'#, '~> 4.0.0'
 


### PR DESCRIPTION
sqlite3 is used for testing db.  Add the requirement. 

The error raises, at least, when dropping and recreating db after a Muscat upgrade (not strictly needed, but in my case I wanted to clear it anyway).

```
~/download/muscat/muscat-5.2.1$ rails db:drop

Dropped database 'muscat_development'
Dropped database 'db/test.sqlite3'

~/download/muscat/muscat-5.2.1$ rails db:create
Created database 'muscat_development'
Specified 'sqlite3' for database adapter, but the gem is not loaded. Add `gem 'sqlite3'` to your Gemfile (and ensure its version is at the minimum required by ActiveRecord).
Couldn't create database for {"adapter"=>"sqlite3", "database"=>"db/test.sqlite3", "pool"=>5, "timeout"=>5000}
rails aborted!
Gem::LoadError: Specified 'sqlite3' for database adapter, but the gem is not loaded. Add `gem 'sqlite3'` to your Gemfile (and ensure its version is at the minimum required by ActiveRecord).
```