### PR TITLE
increase allowed offset on SRU endpoint

### DIFF
--- a/lib/sru.rb
+++ b/lib/sru.rb
@@ -89,7 +89,7 @@ module Sru
       if self.maximumRecords == 0
         return {:code => 6, :message => "unsupported parameter value"}
       end
-      if self.offset.to_i > 999999
+      if self.offset.to_i > 1999999
         return {:code => 61, :message => "first record out of range"}
       end
       unless self.model


### PR DESCRIPTION
Currently (01/2020) the number of results for a wildcard query is
1191491, which exceeds the limit of 999999 and leads to a
info:srw/diagnostic/1/61 (first record out of range), which is a bit
irritating.

Example:

* https://muscat.rism.info/sru?maximumRecords=100&operation=searchRetrieve&query=*&recordSchema=marc&startRecord=1000026&version=1.1