### PR TITLE
Provide a fallback for unspecified record type

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,9 +9,6 @@ gem 'rails', '>= 5.1', '< 5.2'
 # https://github.com/rails/rails/issues/21544
 gem 'mysql2'
 
-# Use sqlite3 for testing db
-gem 'sqlite3'
-
 # Use SCSS for stylesheets
 gem 'sass-rails'#, '~> 4.0.0'
 

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,9 @@ gem 'rails', '>= 5.1', '< 5.2'
 # https://github.com/rails/rails/issues/21544
 gem 'mysql2'
 
+# Use sqlite3 for testing db
+gem 'sqlite3'
+
 # Use SCSS for stylesheets
 gem 'sass-rails'#, '~> 4.0.0'
 

--- a/config/marc/default/source/template_configuration.yml
+++ b/config/marc/default/source/template_configuration.yml
@@ -60,6 +60,7 @@ display:
 default_mapping:
   collection: "000_collection"
   source: "002_source"
+  unspecified: "002_source"
   edition_content: "013_edition_content"
   libretto_source: "004_libretto_source"
   libretto_edition: "015_libretto_edition"


### PR DESCRIPTION
Records of unspecified type assume a default value of 0:

https://github.com/rism-ch/muscat/blob/develop/db/schema.rb#L442

However, this value of 0 (https://github.com/rism-ch/muscat/blob/develop/lib/marc_source.rb) is not mapped in https://github.com/rism-ch/muscat/blob/develop/config/marc/default/source/template_configuration.yml#L60.  This patch provides a reasonable source default, so they can be edited without crashing Muscat.