### PR TITLE
Generalise fallback to default file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,9 +9,6 @@ gem 'rails', '>= 5.1', '< 5.2'
 # https://github.com/rails/rails/issues/21544
 gem 'mysql2'
 
-# Use sqlite3 for testing db
-gem 'sqlite3'
-
 # Use SCSS for stylesheets
 gem 'sass-rails'#, '~> 4.0.0'
 

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,9 @@ gem 'rails', '>= 5.1', '< 5.2'
 # https://github.com/rails/rails/issues/21544
 gem 'mysql2'
 
+# Use sqlite3 for testing db
+gem 'sqlite3'
+
 # Use SCSS for stylesheets
 gem 'sass-rails'#, '~> 4.0.0'
 

--- a/app/admin/catalogue.rb
+++ b/app/admin/catalogue.rb
@@ -96,7 +96,7 @@ ActiveAdmin.register Catalogue do
         new_marc.reset_to_new
         @catalogue.marc = new_marc
       else
-        new_marc = MarcCatalogue.new(File.read("#{Rails.root}/config/marc/#{RISM::MARC}/catalogue/default.marc"))
+        new_marc = MarcCatalogue.new(File.read(ConfigFilePath.get_marc_editor_profile_path("#{Rails.root}/config/marc/#{RISM::MARC}/catalogue/default.marc")))
         new_marc.load_source false # this will need to be fixed
         @catalogue.marc = new_marc
       end

--- a/app/admin/guidelines.rb
+++ b/app/admin/guidelines.rb
@@ -3,7 +3,7 @@ ActiveAdmin.register_page "guidelines" do
   
   controller do
     def index
-      @guidelines = Guidelines.new("#{Rails.root}/public/help/#{RISM::MARC}/guidelines.yml", session[:locale])
+      @guidelines = Guidelines.new(ConfigFilePath.get_marc_editor_profile_path("#{Rails.root}/public/help/#{RISM::MARC}/guidelines.yml"), session[:locale])
     end
   end
   

--- a/app/admin/holding.rb
+++ b/app/admin/holding.rb
@@ -134,7 +134,7 @@ ActiveAdmin.register Holding do
       @parent_object_id = params[:source_id]
       @parent_object_type = "Source" #hardcoded for now
       
-      new_marc = MarcHolding.new(File.read("#{Rails.root}/config/marc/#{RISM::MARC}/holding/default.marc"))
+      new_marc = MarcHolding.new(File.read(ConfigFilePath.get_marc_editor_profile_path("#{Rails.root}/config/marc/#{RISM::MARC}/holding/default.marc")))
       new_marc.load_source false # this will need to be fixed
       @holding.marc = new_marc
 

--- a/app/admin/institution.rb
+++ b/app/admin/institution.rb
@@ -82,7 +82,7 @@ ActiveAdmin.register Institution do
     def new
       @institution = Institution.new
       
-      new_marc = MarcInstitution.new(File.read("#{Rails.root}/config/marc/#{RISM::MARC}/institution/default.marc"))
+      new_marc = MarcInstitution.new(File.read(ConfigFilePath.get_marc_editor_profile_path("#{Rails.root}/config/marc/#{RISM::MARC}/institution/default.marc")))
       new_marc.load_source false # this will need to be fixed
       @institution.marc = new_marc
 

--- a/app/admin/person.rb
+++ b/app/admin/person.rb
@@ -86,7 +86,7 @@ ActiveAdmin.register Person do
     
     def index
       person = Person.new
-      new_marc = MarcPerson.new(File.read("#{Rails.root}/config/marc/#{RISM::MARC}/person/default.marc"))
+      new_marc = MarcPerson.new(File.read(ConfigFilePath.get_marc_editor_profile_path("#{Rails.root}/config/marc/#{RISM::MARC}/person/default.marc")))
       new_marc.load_source false # this will need to be fixed
       person.marc = new_marc
       @editor_profile = EditorConfiguration.get_default_layout person
@@ -104,7 +104,7 @@ ActiveAdmin.register Person do
     def new
       @person = Person.new
       
-      new_marc = MarcPerson.new(File.read("#{Rails.root}/config/marc/#{RISM::MARC}/person/default.marc"))
+      new_marc = MarcPerson.new(File.read(ConfigFilePath.get_marc_editor_profile_path("#{Rails.root}/config/marc/#{RISM::MARC}/person/default.marc")))
       new_marc.load_source false # this will need to be fixed
       @person.marc = new_marc
       

--- a/app/admin/source.rb
+++ b/app/admin/source.rb
@@ -147,7 +147,7 @@ ActiveAdmin.register Source do
       else 
         
         default_file_name = EditorConfiguration.get_source_default_file(params[:new_record_type])
-        default_file = "#{Rails.root}/config/marc/#{RISM::MARC}/source/" + default_file_name + '.marc'
+        default_file = ConfigFilePath.get_marc_editor_profile_path("#{Rails.root}/config/marc/#{RISM::MARC}/source/#{default_file_name}.marc")
         
         if File.exists?(default_file)
           new_marc = MarcSource.new(File.read(default_file), MarcSource::RECORD_TYPES[params[:new_record_type].to_sym])

--- a/app/admin/work.rb
+++ b/app/admin/work.rb
@@ -91,7 +91,7 @@ ActiveAdmin.register Work do
     def new
       @work = Work.new
       
-      new_marc = MarcWork.new(File.read("#{Rails.root}/config/marc/#{RISM::MARC}/work/default.marc"))
+      new_marc = MarcWork.new(File.read(ConfigFilePath.get_marc_editor_profile_path("#{Rails.root}/config/marc/#{RISM::MARC}/work/default.marc")))
       new_marc.load_source false # this will need to be fixed
       @work.marc = new_marc
       

--- a/app/models/catalogue.rb
+++ b/app/models/catalogue.rb
@@ -124,7 +124,7 @@ class Catalogue < ApplicationRecord
     return if self.marc_source != nil  
     return if self.suppress_scaffold_marc_trigger == true
  
-    new_marc = MarcCatalogue.new(File.read("#{Rails.root}/config/marc/#{RISM::MARC}/catalogue/default.marc"))
+    new_marc = MarcCatalogue.new(File.read(ConfigFilePath.get_marc_editor_profile_path("#{Rails.root}/config/marc/#{RISM::MARC}/catalogue/default.marc")))
     new_marc.load_source false
     
     #new_100 = MarcNode.new("catalogue", "100", "", "1#")

--- a/app/models/config_file_path.rb
+++ b/app/models/config_file_path.rb
@@ -1,0 +1,19 @@
+module ConfigFilePath
+  # https://stackoverflow.com/questions/54485860/how-to-make-a-custom-method-that-can-be-used-anywhere-in-rails-app/54487749#54487749
+
+  # Check if specific file exists, according to application.rb values;
+  # if not, fallback to default, without further checking, as if the
+  # default file is also missing it would require admin intervention.
+  def self.get_marc_editor_profile_path(file)
+    if File.exists? file
+      file
+    elsif file.include? "/#{RISM::MARC}/"
+      file.sub "/#{RISM::MARC}/", "/default/"
+    elsif file.include? "/#{RISM::EDITOR_PROFILE}/"
+      file.sub "/#{RISM::EDITOR_PROFILE}/", "/default/"
+    else
+      file
+    end
+  end
+
+end

--- a/app/models/holding.rb
+++ b/app/models/holding.rb
@@ -89,7 +89,7 @@ class Holding < ApplicationRecord
     return if self.marc_source != nil  
     return if self.suppress_scaffold_marc_trigger == true
  
-    new_marc = MarcCatalogue.new(File.read("#{Rails.root}/config/marc/#{RISM::MARC}/holding/default.marc"))
+    new_marc = MarcCatalogue.new(File.read(ConfigFilePath.get_marc_editor_profile_path("#{Rails.root}/config/marc/#{RISM::MARC}/holding/default.marc")))
     new_marc.load_source true
     
     node = MarcNode.new("holding", "852", "", "##")

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -136,7 +136,7 @@ class Institution < ApplicationRecord
     return if self.marc_source != nil  
     return if self.suppress_scaffold_marc_trigger == true
   
-    new_marc = MarcInstitution.new(File.read("#{Rails.root}/config/marc/#{RISM::MARC}/institution/default.marc"))
+    new_marc = MarcInstitution.new(File.read(ConfigFilePath.get_marc_editor_profile_path("#{Rails.root}/config/marc/#{RISM::MARC}/institution/default.marc")))
     new_marc.load_source true
     
     new_100 = MarcNode.new("institution", "110", "", "1#")

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -145,7 +145,7 @@ class Person < ApplicationRecord
     return if self.marc_source != nil  
     return if self.suppress_scaffold_marc_trigger == true
   
-    new_marc = MarcPerson.new(File.read("#{Rails.root}/config/marc/#{RISM::MARC}/person/default.marc"))
+    new_marc = MarcPerson.new(File.read(ConfigFilePath.get_marc_editor_profile_path("#{Rails.root}/config/marc/#{RISM::MARC}/person/default.marc")))
     new_marc.load_source true
     
     new_100 = MarcNode.new("person", "100", "", "1#")

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -116,7 +116,7 @@ class Work < ApplicationRecord
     return if self.marc_source != nil  
     return if self.suppress_scaffold_marc_trigger == true
   
-    new_marc = MarcWork.new(File.read("#{Rails.root}/config/marc/#{RISM::MARC}/work/default.marc"))
+    new_marc = MarcWork.new(File.read(ConfigFilePath.get_marc_editor_profile_path("#{Rails.root}/config/marc/#{RISM::MARC}/work/default.marc")))
     new_marc.load_source true
     
     new_100 = MarcNode.new("work", "100", "", "1#")

--- a/housekeeping/correct/11_fix_catalogue_with_nil_marc.rb
+++ b/housekeeping/correct/11_fix_catalogue_with_nil_marc.rb
@@ -4,7 +4,7 @@ catalogue_with_nil_marc = Catalogue.where(:marc => nil)
 
 pb = ProgressBar.new(catalogue_with_nil_marc.size)
 catalogue_with_nil_marc.each do |record|
-  new_marc = MarcCatalogue.new(File.read("#{Rails.root}/config/marc/#{RISM::MARC}/catalogue/default.marc"))
+  new_marc = MarcCatalogue.new(File.read(ConfigFilePath.get_marc_editor_profile_path("#{Rails.root}/config/marc/#{RISM::MARC}/catalogue/default.marc")))
   new_marc.load_source false # this will need to be fixed
   new_240 = MarcNode.new(Catalogue, "240", "", "10")
   ip = new_marc.get_insert_position("240")

--- a/housekeeping/correct/41_migrate_conv.rb
+++ b/housekeeping/correct/41_migrate_conv.rb
@@ -18,7 +18,7 @@ source_list.each do |fsrc, holdings|
   first_source = Source.find(fsrc)
   
   new_source = Source.new
-  marc = MarcSource.new(File.read("#{Rails.root}/config/marc/#{RISM::MARC}/source/000_collection.marc"), MarcSource::RECORD_TYPES[:collection])
+  marc = MarcSource.new(File.read(ConfigFilePath.get_marc_editor_profile_path("#{Rails.root}/config/marc/#{RISM::MARC}/source/000_collection.marc"), MarcSource::RECORD_TYPES[:collection]))
   
   marc.first_occurance("852").destroy_yourself
   marc.first_occurance("700").destroy_yourself

--- a/housekeeping/doc/generate_doc.rb
+++ b/housekeeping/doc/generate_doc.rb
@@ -11,7 +11,7 @@ if ARGV.length >= 3
 end
 
 # arg 1 is input yml file, arg 2 output filename
-guidelines = Guidelines.new("#{Rails.root}/public/help/#{RISM::MARC}/#{ARGV[0]}", lang)
+guidelines = Guidelines.new(ConfigFilePath.get_marc_editor_profile_path("#{Rails.root}/public/help/#{RISM::MARC}/#{ARGV[0]}"), lang)
 outfile = File.open( ARGV[1] , "w") 
 outfile.write guidelines.output
 outfile.close

--- a/housekeeping/upgrade_3.6_a1/001_split_holding_records.rb
+++ b/housekeeping/upgrade_3.6_a1/001_split_holding_records.rb
@@ -10,7 +10,7 @@ def create_holdings(source, marc)
     
     # Make a nice new holding record
     holding = Holding.new
-    new_marc = MarcHolding.new(File.read("#{Rails.root}/config/marc/#{RISM::MARC}/holding/default.marc"))
+    new_marc = MarcHolding.new(File.read(ConfigFilePath.get_marc_editor_profile_path("#{Rails.root}/config/marc/#{RISM::MARC}/holding/default.marc")))
     new_marc.load_source false
     
     # Kill old 852s

--- a/housekeeping/upgrade_ch/05_convert_ms_to_pr.rb
+++ b/housekeeping/upgrade_ch/05_convert_ms_to_pr.rb
@@ -284,7 +284,7 @@ def create_holding(row, source, marc, replace = nil, old_siglum = nil, only_grou
 
     if !replace
         holding = Holding.new
-        new_marc = MarcHolding.new(File.read("#{Rails.root}/config/marc/#{RISM::MARC}/holding/default.marc"))
+        new_marc = MarcHolding.new(File.read(ConfigFilePath.get_marc_editor_profile_path("#{Rails.root}/config/marc/#{RISM::MARC}/holding/default.marc")))
         new_marc.load_source false
     else
 

--- a/lib/editor_configuration.rb
+++ b/lib/editor_configuration.rb
@@ -1,4 +1,4 @@
-# encoding: UTF-8
+# encoding: utf-8
 # The editor configurations define how each marc_item will be printed/edited/shown. It builds uo the old EditorProfile
 # and retains the full functionality.
 # An editor configuration is comprised of a set of layout rules: i.e. which tags show and in which order. It enables to define labels in the same way.
@@ -419,11 +419,11 @@ class EditorConfiguration
   def self.get_help_fname(name, model = "Source")
     model = (model == "Source") ? "" : "#{model.downcase}_"
     # translated version?
-    fname = "/help/#{RISM::MARC}/#{model}#{name}_#{I18n.locale.to_s}.html"
+    fname = ConfigFilePath.get_marc_editor_profile_path("/help/#{RISM::MARC}/#{model}#{name}_#{I18n.locale.to_s}.html")
     #ap fname
     return fname if File.exist?("#{Rails.root}/public#{fname}")
     # english?
-    fname = "/help/#{RISM::MARC}/#{model}#{name}_en.html"
+    fname = ConfigFilePath.get_marc_editor_profile_path("/help/#{RISM::MARC}/#{model}#{name}_en.html")
     return fname if File.exist?("#{Rails.root}/public#{fname}")
     # nope...
     return ""
@@ -439,28 +439,19 @@ class EditorConfiguration
       @squeezed_profiles = Array.new
       
       # Load local configurations
-      file = "#{Rails.root}/config/editor_profiles/#{RISM::EDITOR_PROFILE}/profiles.yml"
-      if File.exists?(file)
-        configurations = YAML::load(IO.read(file))
-        configurations.each do |conf|
-          @squeezed_profiles << EditorConfiguration.new(conf)
-        end      
-      else
-        # if it does not exist, load default
-        file = "#{Rails.root}/config/editor_profiles/default/profiles.yml"
-        configurations = YAML::load(IO.read(file))
-        configurations.each do |conf|
-          @squeezed_profiles << EditorConfiguration.new(conf)
-        end
+      configurations = YAML::load(IO.read(ConfigFilePath.get_marc_editor_profile_path("#{Rails.root}/config/editor_profiles/#{RISM::EDITOR_PROFILE}/profiles.yml")))
+      configurations.each do |conf|
+        @squeezed_profiles << EditorConfiguration.new(conf)
       end
-  
     end
+
     @squeezed_profiles
   end
     
   def self.get_profile_templates(model)
     templates = {}
-    Dir.glob("#{Rails.root}/config/marc/#{RISM::MARC}/#{model}/*").sort.each do |f|
+    dir = ConfigFilePath.get_marc_editor_profile_path("#{Rails.root}/config/marc/#{RISM::MARC}/#{model}/")
+    Dir.glob("#{dir}/*").sort.each do |f|
         file_dir = File.basename(f,'.marc')
         file_label = file_dir.sub(/[^_]*_/,"")
         templates[file_dir] = file_label
@@ -469,19 +460,13 @@ class EditorConfiguration
   end
   
   def self.get_source_templates
-    file = "#{Rails.root}/config/marc/#{RISM::MARC}/source/template_configuration.yml"
-    return {} if !File.exists?(file)
-    
-    conf = YAML::load(IO.read(file))
+    conf = YAML::load(IO.read(ConfigFilePath.get_marc_editor_profile_path("#{Rails.root}/config/marc/#{RISM::MARC}/source/template_configuration.yml")))
     return {} if !conf.has_key? "display"
     conf["display"]
   end
   
   def self.get_source_default_file(record_type)
-    file = "#{Rails.root}/config/marc/#{RISM::MARC}/source/template_configuration.yml"
-    return nil if !File.exists?(file)
-    
-    conf = YAML::load(IO.read(file))
+    conf = YAML::load(IO.read(ConfigFilePath.get_marc_editor_profile_path("#{Rails.root}/config/marc/#{RISM::MARC}/source/template_configuration.yml")))
     return nil if !conf.has_key? "default_mapping"
     conf["default_mapping"][record_type.to_s]
   end

--- a/lib/editor_validation.rb
+++ b/lib/editor_validation.rb
@@ -12,11 +12,9 @@ class EditorValidation
     settings = Settings.new(Hash.new())
     
     profile_name = RISM::EDITOR_PROFILE != "" ? RISM::EDITOR_PROFILE : "default"
-
     file = "#{Rails.root}/config/editor_profiles/#{profile_name}/configurations/#{config}.yml"
-    if File.exists?(file)
-      settings.squeeze(Settings.new(IO.read(file)))
-    end
+    settings.squeeze(Settings.new(IO.read(ConfigFilePath.get_marc_editor_profile_path(file))))
+
     return settings
   end
     

--- a/lib/guidelines.rb
+++ b/lib/guidelines.rb
@@ -84,7 +84,7 @@ class Guidelines
   end
   
   def cat helpfile
-    text = IO.read("#{Rails.root}/public/help/#{RISM::MARC}/#{helpfile}_#{@lang}.html") rescue "HELP WILL FOLLOW"
+    text = IO.read(ConfigFilePath.get_marc_editor_profile_path("#{Rails.root}/public/help/#{RISM::MARC}/#{helpfile}_#{@lang}.html")) rescue "HELP WILL FOLLOW"
     @output += text
   end
 end

--- a/lib/marc.rb
+++ b/lib/marc.rb
@@ -223,7 +223,7 @@ class Marc
 	def superimpose_template(template_name = "default.marc")
 		load_source unless @loaded
 		
-    template = self.class.new(File.read("#{Rails.root}/config/marc/#{RISM::MARC}/#{@model}/#{template_name}"))
+    template = self.class.new(File.read(ConfigFilePath.get_marc_editor_profile_path("#{Rails.root}/config/marc/#{RISM::MARC}/#{@model}/#{template_name}")))
     template.load_source false
 		
 		template.all_tags.each do |tag|

--- a/lib/template.rb
+++ b/lib/template.rb
@@ -30,7 +30,7 @@ module Template
   def create_holding
     marc.by_tags("852").each do |t|
       holding = Holding.new
-      new_marc = MarcHolding.new(File.read("#{Rails.root}/config/marc/#{RISM::MARC}/holding/default.marc"))
+      new_marc = MarcHolding.new(File.read(ConfigFilePath.get_marc_editor_profile_path("#{Rails.root}/config/marc/#{RISM::MARC}/holding/default.marc")))
       new_marc.load_source false
       new_marc.each_by_tag("852") {|t2| t2.destroy_yourself}
       new_852 = t.deep_copy


### PR DESCRIPTION
There are uses RISM::MARC and RISM::EDITOR_CONFIGURATION all over Muscat, and if a value other than default is defined, the application fails in unsuspected places.

This patch creates a generic function so it falls back to default if a specific file does not exist. I have been using for a while in two different Muscat test instances, one having the default values and another having created a custom value.