### PR TITLE
Generalise the retrieval of id when saving Marc records

### DIFF
--- a/lib/marc_controller_actions.rb
+++ b/lib/marc_controller_actions.rb
@@ -33,11 +33,11 @@ module MarcControllerActions
       # @item is used in the Marc Editor
       @item = nil
       if new_marc.get_id != "__TEMP__" 
-        # To get the ID for holdings
-        if params[:controller] == "admin/holdings"
-          @item = model.find(params[:id])
-        else
+        if params[:controller] == "admin/sources"
           @item = model.find(new_marc.get_marc_source_id)
+        else
+          # To get the ID for any other Marc record
+          @item = model.find(params[:id])
         end
       end
 


### PR DESCRIPTION
When saving a Person Marc record, or any other authority record, a popup
error appears (Error saving page!  Please try again.  error Not Found).  It
is caused because the Marc controler only considers holdings and source
records.  This patch allows saving any authority record.