### PR TITLE
Read editor specific config files that really exist

### DIFF
--- a/lib/editor_configuration.rb
+++ b/lib/editor_configuration.rb
@@ -39,18 +39,17 @@ class EditorConfiguration
 
     settings = Settings.new(Hash.new())
     
+    configs.each do |config|
+      default_conf = "#{Rails.root}/config/editor_profiles/default/configurations/#{config}.yml"
+      if File.exists?(default_conf)
+        settings.squeeze(Settings.new(IO.read(default_conf)))
+      end
+    end
     if RISM::EDITOR_PROFILE != ""
       configs.each do |config|
         file = "#{Rails.root}/config/editor_profiles/#{RISM::EDITOR_PROFILE}/configurations/#{config}.yml"
         if File.exists?(file)
           settings.squeeze(Settings.new(IO.read(file)))
-        end
-      end
-    else
-      configs.each do |config|
-        default_conf = "#{Rails.root}/config/editor_profiles/default/configurations/#{config}.yml"
-        if File.exists?(default_conf)
-          settings.squeeze(Settings.new(IO.read(default_conf)))
         end
       end
     end

--- a/lib/editor_configuration.rb
+++ b/lib/editor_configuration.rb
@@ -45,7 +45,7 @@ class EditorConfiguration
         settings.squeeze(Settings.new(IO.read(default_conf)))
       end
     end
-    if RISM::EDITOR_PROFILE != ""
+    if RISM::EDITOR_PROFILE != "default"
       configs.each do |config|
         file = "#{Rails.root}/config/editor_profiles/#{RISM::EDITOR_PROFILE}/configurations/#{config}.yml"
         if File.exists?(file)

--- a/lib/editor_validation.rb
+++ b/lib/editor_validation.rb
@@ -115,10 +115,8 @@ class EditorValidation
       # load global configurations
       @squeezed_profiles = Array.new
     
-      profile_name = RISM::EDITOR_PROFILE != "" ? RISM::EDITOR_PROFILE : "default"
-    
       # Load local configurations
-      file = "#{Rails.root}/config/editor_profiles/#{profile_name}/profiles.yml"
+      file = ConfigFilePath.get_marc_editor_profile_path("#{Rails.root}/config/editor_profiles/#{RISM::EDITOR_PROFILE}/profiles.yml")
 
       configurations = YAML::load(IO.read(file))
       configurations.each do |conf|


### PR DESCRIPTION
Creating a specific RISM::EDITOR_PROFILE profile should allow reusing
default config files, and creating only the ones that are different.  This
is what the comments in the squeeze method say, but the code didn't.  Change
it to honor this behaviour.