### PR TITLE
Make EditorValidation use get_marc_editor_profile_path

### DIFF
--- a/lib/editor_validation.rb
+++ b/lib/editor_validation.rb
@@ -11,12 +11,9 @@ class EditorValidation
   def squeeze(config)
     settings = Settings.new(Hash.new())
     
-    profile_name = RISM::EDITOR_PROFILE != "" ? RISM::EDITOR_PROFILE : "default"
+    file = ConfigFilePath.get_marc_editor_profile_path("#{Rails.root}/config/editor_profiles/#{RISM::EDITOR_PROFILE}/profiles.yml")
+    settings.squeeze(Settings.new(IO.read(file)))
 
-    file = "#{Rails.root}/config/editor_profiles/#{profile_name}/configurations/#{config}.yml"
-    if File.exists?(file)
-      settings.squeeze(Settings.new(IO.read(file)))
-    end
     return settings
   end
     
@@ -115,11 +112,8 @@ class EditorValidation
       # load global configurations
       @squeezed_profiles = Array.new
     
-      profile_name = RISM::EDITOR_PROFILE != "" ? RISM::EDITOR_PROFILE : "default"
-    
       # Load local configurations
-      file = "#{Rails.root}/config/editor_profiles/#{profile_name}/profiles.yml"
-
+      file = ConfigFilePath.get_marc_editor_profile_path("#{Rails.root}/config/editor_profiles/#{RISM::EDITOR_PROFILE}/profiles.yml")
       configurations = YAML::load(IO.read(file))
       configurations.each do |conf|
         next if !conf[:validation]


### PR DESCRIPTION
EditorValidation config files should use default if specific ones do not
exist, even if EDITOR_PROFILE is set to some value other than default.