### PR TITLE
Require default EDITOR_PROFILE to be set as "default"

### DIFF
--- a/config/sample_application.rb
+++ b/config/sample_application.rb
@@ -14,7 +14,7 @@ module RISM
   # The MARC letters (used in the new_from.rhtml and in the manuscript_controller for the templates) 
   MARC = "default"
   # Select the configuration for the editor profiles to load
-  EDITOR_PROFILE = ""
+  EDITOR_PROFILE = "default"
   # Url redirection for the deprecated Page controller (to be set only if the installation was previously in Muscat 2 with page)
   LEGACY_PAGES_URL = '/'
   # Root redirect, can be changed to something else than BL


### PR DESCRIPTION
Most configuration values in config/application.rb (as copied from
config/sample_application.rb) have an explicit "default" value, except
for EDITOR_PROFILE, that may have an empty string. This complicates
the logic when this variable is used in Muscat, as it has to be
compared to empty string and then set to "default" before using it.