### PR TITLE
Avoid TypeError: superclass mismatch for class Command error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -150,6 +150,10 @@ gem "recaptcha"
 # To render markdown
 gem 'redcarpet'
 
+# Avoid TypeError: superclass mismatch for class Command
+# See https://github.com/erikhuda/thor/issues/721
+gem 'thor', '~> 0.20.3'
+
 group :test do
   gem "rspec"
   gem 'rspec-rails', '~> 3.5'


### PR DESCRIPTION
Using newer Thor versions (at least 1.0.x) create a name conflict of the
Command class (see https://github.com/erikhuda/thor/issues/721).  This is a
temporary workaround until a better solution is found.