### PR TITLE
Allow edit other bibliographic records from Blacklight

### DIFF
--- a/app/views/catalog/_previous_next_doc.html.erb
+++ b/app/views/catalog/_previous_next_doc.html.erb
@@ -16,7 +16,11 @@
 
       <%=link_to t('blacklight.search.start_over'), start_over_path(current_search_session.try(:query_params) || {}), id: 'startOverLink', class: 'btn' %>
 
-      <%=link_to t('active_admin.edit'), "/admin/sources/#{@document.id.split(" ")[1]}/edit", class: 'btn' %>
+      <% if @document.id.start_with? "Sources" %>
+          <%=link_to t('active_admin.edit'), "/admin/sources/#{@document.id.split(" ")[1]}/edit", class: 'btn' %>
+      <% else %>
+          <%=link_to t('active_admin.edit'), "/admin/catalogues/#{@document.id.split(" ")[1]}/edit", class: 'btn' %>
+      <% end %>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
If bibliographic records other than Sources, like Catalogues, are made
accessible through the Blacklight interface, allow them to be edited like
sources, and link them to the right record type.