### PR TITLE
Polish translation added to polish-branch

### DIFF
--- a/config/editor_profiles/default/configurations/CatalogueLabels.yml
+++ b/config/editor_profiles/default/configurations/CatalogueLabels.yml
@@ -6,48 +6,56 @@ doc_abbreviations:
     de: "Abkürzungen"
     en: Abbreviations
     es: Abreviaturas
+    pl: Skróty
 doc_aid: 
   label: 
     it: Aiuto
     de: Arbeitshilfen
     en: Aide
     es: Asistencia
+    pl: Asystent
 doc_cataloguing_collections: 
   label: 
     it: Catalogazione di raccolte e volumi compositi
     de: Erfassung von Sammlungen
     en: Cataloging collection and convoluta
     es: "Catalogación de colecciones y volúmenes compuestos"
+    pl: Katalogowanie kolekcji i klocka introligatorskiego
 doc_edit_functions: 
   label: 
     it: funzioni di base
     de: "Grundätzliche Funktionen"
     en: Basic functions
     es: "Funciones básicas"
+    pl: Podstawowe funkcje
 doc_introduction: 
   label: 
     it: introduzione
     de: Einleitung
     en: Introduction
     es: "Introducción"
+    pl: Wprowadzenie
 doc_masks: 
   label: 
     it: Formulari di catalogazione
     de: Masken
     en: Cataloging forms
     es: "Formularios de catalogación"
+    pl: Formularze katalogowania
 doc_tag_index: 
   label: 
     it: Indice dei codici MARC
     de: MARC Tag Index
     en: MARC tag index
     es: "Índice de etiquetas MARC"
+    pl: Indeks znaczników MARC
 doc_templates: 
   label: 
     it: Template
     de: Templates
     en: Templates
     es: Plantillas
+    pl: Szablony
 "000": 
   label: 
     it: Leader
@@ -55,6 +63,7 @@ doc_templates:
     de: Leader
     en: Leader
     es: "Líder"
+    pl: Leader
 "001": 
   label: 
     it: Numero documento RISM
@@ -62,6 +71,7 @@ doc_templates:
     de: RISM Dokumentnummer
     en: RISM ID No.
     es: "Número de ID de RISM"
+    pl: RISM ID
 "003": 
   label: 
     it: Identificatore del numero di controllo
@@ -69,6 +79,7 @@ doc_templates:
     de: Kontrollnummer-Bezeichnung
     en: Control number identifier
     es: "Identificador de número de control"
+    pl: Identyfikator numeru kontrolnego
 "005": 
   label: 
     it: Data e ora dell'ultima transazione
@@ -76,6 +87,7 @@ doc_templates:
     de: Datum und Zeit der letzten Transaktion
     en: Date and time of last transaction
     es: "Fecha y hora de la última transacción" 
+    pl: Data i godzina ostatniej operacji
 "020": 
   label: 
     it: ISBN
@@ -83,6 +95,7 @@ doc_templates:
     de: ISBN
     en: ISBN
     es: ISBN
+    pl: ISBN
   fields: 
     a: 
       label: 
@@ -91,6 +104,7 @@ doc_templates:
         de: ISBN
         en: ISBN
         es: ISBN
+        pl: ISBN
 
 "022": 
   label: 
@@ -99,6 +113,7 @@ doc_templates:
     de: ISSN
     en: ISSN
     es: ISSN
+    pl: ISSN
   fields: 
     a: 
       label: 
@@ -107,6 +122,7 @@ doc_templates:
         de: ISSN
         en: ISSN
         es: ISSN
+        pl: ISSN
 
 "024": 
   label: 
@@ -115,6 +131,7 @@ doc_templates:
     de: ISMN
     en: ISMN
     es: ISMN
+    pl: ISMN
   fields: 
     a: 
       label: 
@@ -123,6 +140,7 @@ doc_templates:
         de: ISMN
         en: ISMN
         es: ISMN
+        pl: ISMN
 
 "041": 
   label: 
@@ -131,6 +149,7 @@ doc_templates:
     de: Sprache
     en: Language Code
     es: "Código de idioma"
+    pl: Kod języka
   fields: 
     a: 
       label: 
@@ -139,6 +158,7 @@ doc_templates:
         de: Sprach-Code
         en: Language Code
         es: "Código de idioma"
+        pl: Kod języka
 "044": 
   label: 
     it: Paese
@@ -146,6 +166,7 @@ doc_templates:
     de: Land
     en: Country of publication
     es: "País de publicación"
+    pl: Kraj publikacji
   fields: 
     a: 
       label: 
@@ -154,6 +175,7 @@ doc_templates:
         de: Land
         en: Country of publication
         es: "País de publicación"
+        pl: Kraj publikacji
 
 "100": 
   label: 
@@ -162,6 +184,7 @@ doc_templates:
     de: Autor
     en: Author
     es: Autor
+    pl: Autor
   accepts: 
   - "710"
   fields: 
@@ -172,6 +195,7 @@ doc_templates:
         de: Autor
         en: Author
         es: Autor
+        pl: Autor
     d: 
       label: 
         it: Data di nascita e di morte
@@ -179,6 +203,7 @@ doc_templates:
         de: Geburts- und Todesdaten
         en: Life dates
         es: Fechas de nacimiento y muerte
+        pl: Daty urodzenia i śmierci
 "210": 
   label: 
     it: Abbreviazione
@@ -186,6 +211,7 @@ doc_templates:
     de: Kürzel
     en: Short title
     es: "Título breve"
+    pl: Skrócony tytuł
   fields: 
     a: 
       label: 
@@ -194,6 +220,7 @@ doc_templates:
         de: Kürzel
         en: Short title
         es: "Título breve"
+        pl: Skrócony tytuł
 "240": 
   label: 
     it: Titolo 
@@ -201,6 +228,7 @@ doc_templates:
     de: Titel
     en: Title
     es: "Título"
+    pl: Tytuł
   fields: 
     a: 
       label: 
@@ -209,6 +237,7 @@ doc_templates:
         de: Titel
         en: Title
         es: "Título"
+        pl: Tytuł
     g: 
       label: 
         it: Tipo
@@ -216,6 +245,7 @@ doc_templates:
         de: Art/Inhalt
         en: Category
         es: "Categoría"
+        pl: Kategoria
     h: 
       label: 
         it: Tipo di pubblicazione
@@ -223,6 +253,7 @@ doc_templates:
         de: Ausgabeform
         en: Type of publication
         es: "Tipo de publicación"
+        pl: Rodzaj publikacji
 "250": 
   label: 
     it: Edizione
@@ -230,6 +261,7 @@ doc_templates:
     de: Ausgabe
     en: Edition statement
     es: "Declaración de edición"
+    pl: Wydanie
   fields: 
     a: 
       label: 
@@ -238,6 +270,7 @@ doc_templates:
         de: Ausgabe
         en: Edition statement
         es: "Declaración de edición"
+        pl: Wydanie
       comment: "NEW IN 2018"
 "260": 
   label: 
@@ -246,6 +279,7 @@ doc_templates:
     de: Imprint
     en: Imprint
     es: Datos editoriales
+    pl: Stopka wydawnicza
   fields: 
     a: 
       label: 
@@ -254,6 +288,7 @@ doc_templates:
         de: Verlagsort
         en: Place of publication
         es: Lugar de publicación
+        pl: Miejsce publikacji
     b: 
       label: 
         it: Editore
@@ -261,6 +296,7 @@ doc_templates:
         de: Verlag
         en: Publisher
         es: Editor
+        pl: Wydawca
     c: 
       label: 
         it: Anno
@@ -268,6 +304,7 @@ doc_templates:
         de: Jahr
         en: Year
         es: Año
+        pl: Rok
 "264": 
   label: 
     it: Produzione
@@ -275,6 +312,7 @@ doc_templates:
     de: Verlauf
     en: Production
     es: "Producción"
+    pl: Produkcja
   fields: 
     c: 
       label: 
@@ -283,6 +321,7 @@ doc_templates:
         de: Verlauf
         en: Production
         es: Producción
+        pl: Produkcja
 "700": 
   label: 
     it: Nome addizionale di persona
@@ -290,6 +329,7 @@ doc_templates:
     de: Sonstige Person
     en: Additional personal name
     es: Nombre personal adicional
+    pl: Dodatkowa osoba
   fields: 
     a: 
       label: 
@@ -297,6 +337,7 @@ doc_templates:
         fr: Personne
         de: Person
         en: Person
+        pl: Osoba
     "4": 
       label: 
         it: Funzione
@@ -305,6 +346,7 @@ doc_templates:
         en: Function
         pt: "Função"
         es: Persona
+        pl: Funkcja
 "710": 
   label: 
     it: Nome di ente
@@ -312,6 +354,7 @@ doc_templates:
     de: Nebeneintragung Körperschaften
     en: Additional institution
     es: "Institución adicional"
+    pl: Dodatkowa instytucja
   fields: 
     a: 
       label: 
@@ -320,6 +363,7 @@ doc_templates:
         de: Körperschaftsname
         en: Institution
         es: "Institución"
+        pl: Instytucja
     b: 
       label: 
         it: Ente subordinato
@@ -327,6 +371,7 @@ doc_templates:
         de: Untergeordnete Körperschaft
         en: Department
         es: Departamento
+        pl: Wydział
     g: 
       label: 
         it: Qualificazione d'attribuzione
@@ -334,12 +379,14 @@ doc_templates:
         de: Zuschreibungsvermerk
         en: Attribution qualifier
         es: "Calificador de atribución"
+        pl: Kwalifikator atrybucji
       edit_label: 
         it: Attribuzione
         fr: Attribution
         de: Zuschreibung
         en: Attribution
         es: Atribución
+        pl: Atrybucja
 
     "4": 
       label: 
@@ -348,6 +395,7 @@ doc_templates:
         de: Funktionsbezeichnung
         en: Function
         es: Función
+        pl: Funkcja
     "8": 
       label: 
         it: Gruppo di materiale
@@ -355,6 +403,7 @@ doc_templates:
         de: Set
         en: Set
         es: "Grupo de materiales"
+        pl: Zbiór
 "730": 
   label:
     it: Titolo uniforme alternativo
@@ -362,6 +411,7 @@ doc_templates:
     de: Zusätzlicher Titel
     en: Additional title
     es: Título adicional
+    pl: Dodatkowy tytuł
   fields:
     a: 
       label: 
@@ -370,6 +420,7 @@ doc_templates:
         de: Zusätzlicher Titel
         en: Additional title
         es: Título adicional
+        pl: Dodatkowy tytuł
 "760": 
   label: 
     it: Fa parte di
@@ -377,6 +428,7 @@ doc_templates:
     de: In
     en: Item part of
     es: "Ítem integrante de"
+    pl: Jest częścią…
   fields: 
     g: 
       label: 
@@ -385,6 +437,7 @@ doc_templates:
         de: Jahrgang, Seite
         en: Volume, year, page
         es: "Volumen, año, página"
+        pl: Wolumen, rok, strona
     t: 
       label: 
         it: Titolo del periodico o della miscellanea
@@ -392,6 +445,7 @@ doc_templates:
         de: "In: "
         en: "Title of periodical, book, or series"
         es: "Título del periódico, libro o serie"
+        pl: Tytuł czasopisma, książki lub serii
 "780": 
   label: 
     it: Titolo precedente
@@ -399,6 +453,7 @@ doc_templates:
     de: Früherer Eintrag
     en: Preceding entry
     es: Entrada anterior
+    pl: Poprzedzający wpis
   fields: 
     t: 
       label: 
@@ -407,6 +462,7 @@ doc_templates:
         de: Früherer Eintrag
         en: Preceding entry
         es: Entrada anterior
+        pl: Poprzedzający wpis
 "785": 
   label: 
     it: Titolo successivo
@@ -414,6 +470,7 @@ doc_templates:
     de: Folgeeintrag
     en: Succeeding entry
     es: Entrada siguiente
+    pl: Kolejny wpis
   fields: 
     t: 
       label: 
@@ -422,6 +479,7 @@ doc_templates:
         de: Folgeeintrag
         en: Succeeding entry
         es: Entrada siguiente
+        pl: Kolejny wpis
 main: 
   label: 
     it: Campi principali
@@ -429,6 +487,7 @@ main:
     de: Haupteintragungen
     en: Main entry fields
     es: Campos principales
+    pl: Główne pola edycji
 codes: 
   label: 
     it: Numeri e codici
@@ -436,6 +495,7 @@ codes:
     de: Nummern und Codes
     en: Numbers and code fields
     es: "Números y códigos"
+    pl: Pola liczb i kodów
 control: 
   label: 
     fr: "Champs de contrôle"
@@ -443,6 +503,7 @@ control:
     it: Campi di controllo
     en: Control Fields
     es: Campos de control
+    pl: Pola kontrolne
 notes: 
   label: 
     it: Note
@@ -450,6 +511,7 @@ notes:
     de: Fussnoten
     en: Note fields
     es: Notas
+    pl: Pola uwag
 other: 
   label: 
     it: Varia
@@ -457,6 +519,7 @@ other:
     de: Verschiedenes
     en: Miscellaneous
     es: Varios
+    pl: Pozostałe
 administration: 
   label: 
     it: Amministrazione
@@ -464,6 +527,7 @@ administration:
     de: Administration
     en: Administration
     es: Administración
+    pl: Administracja
 ed: 
   label: 
     it: Edizione
@@ -471,6 +535,7 @@ ed:
     de: Edition
     en: Edition
     es: Edición
+    pl: Edycja
 H: 
   label: 
     it: Curatore
@@ -478,6 +543,7 @@ H:
     de: Herausgeber
     en: Editor
     es: Editor
+    pl: Edytor
 added_series: 
   label: 
     it: Note secondarie sul titolo sovraordinato
@@ -485,6 +551,7 @@ added_series:
     de: Nebeneintragungen Gesamttitel
     en: Series added entry fields
     es: "Entradas adicionales de la serie"
+    pl: Dodatkowe wpisy tytułów
 administration: 
   label: 
     it: Amministrazione
@@ -492,6 +559,7 @@ administration:
     de: Administration
     en: Administration
     es: Administración
+    pl: Administracja
 arr: 
   label: 
     it: Arrangiatore
@@ -499,6 +567,7 @@ arr:
     de: Bearbeiter
     en: Arranger
     es: Arreglador
+    pl: Aranżer
 art: 
   label: 
     it: Scenografo
@@ -506,6 +575,7 @@ art:
     de: "Bühnenbildner"
     en: Artist
     es: Artista
+    pl: Artysta
 asn: 
   label: 
     it: Altro nome
@@ -513,6 +583,7 @@ asn:
     de: Behandelte Person
     en: Associated name
     es: Nombre asociado
+    pl: Powiązana osoba
 aut: 
   label: 
     it: "Autore addizionale"
@@ -520,6 +591,7 @@ aut:
     de: "Zusätzlicher Autor"
     en: "Additional author"
     es: "Autor adicional"
+    pl: Dodatkowy autor
 bibliographical_reference: 
   label: 
     it: Bibliografia
@@ -527,6 +599,7 @@ bibliographical_reference:
     de: Literatur
     en: References
     es: Referencias
+    pl: Odniesienia
 bnd: 
   label: 
     it: Rilegatore
@@ -534,6 +607,7 @@ bnd:
     de: Buchbinder
     en: Binder
     es: Encuadernador
+    pl: Introligator
 bsl: 
   label: 
     it: Libraio musicale
@@ -541,6 +615,7 @@ bsl:
     de: "Musikalienhändler"
     en: Bookseller
     es: Librero
+    pl: Księgarz
 ccp: 
   label: 
     it: Autore della fonte letteraria
@@ -548,6 +623,7 @@ ccp:
     de: Autor der Textvorlage
     en: Conceptor
     es: Autor de la idea
+    pl: Autor koncepcji
 chr: 
   label: 
     it: Coreografo
@@ -555,6 +631,7 @@ chr:
     de: Choreograph
     en: Choreographer
     es: Coreógrafo
+    pl: Choreograf
 clb: 
   label: 
     it: Autore secondario
@@ -562,6 +639,7 @@ clb:
     de: Mitverfasser
     en: Collaborator
     es: Colaborador
+    pl: Współtwórca
 cmp: 
   label: 
     it: Compositore / Compositore secondario
@@ -569,6 +647,7 @@ cmp:
     de: Komponist / Mitkomponist
     en: Composer
     es: Compositor / Co-compositor
+    pl: Kompozytor
 cnd: 
   label: 
     it: Direttore d'orchestra
@@ -576,6 +655,7 @@ cnd:
     de: Dirigent
     en: Conductor
     es: Director musical
+    pl: Dyrygent
 cns: 
   label: 
     it: Censore
@@ -583,6 +663,7 @@ cns:
     de: Zensor
     en: Censor
     es: Censor
+    pl: Cenzor
 codes: 
   label: 
     it: Numeri e codici
@@ -590,6 +671,7 @@ codes:
     de: Nummern und Codes
     en: Numbers and code fields
     es: "Números y códigos"
+    pl: Pola liczb i kodów
 com: 
   label: 
     it: Compilatore
@@ -597,6 +679,7 @@ com:
     de: Kompilator
     en: Compiler
     es: Compilador
+    pl: Kompilator
 content: 
   label: 
     it: Descrizione del contenuto
@@ -604,6 +687,7 @@ content:
     de: Inhaltsangaben
     en: Content description
     es: "Descripción del contenido"
+    pl: Opis źródła
 control: 
   label: 
     fr: "Champs de contrôle"
@@ -611,6 +695,7 @@ control:
     it: Campi di controllo
     en: Control Fields
     es: Campos de control
+    pl: Pola kontrolne
 cst: 
   label: 
     it: Costumista
@@ -618,6 +703,7 @@ cst:
     de: "Kostümbildner"
     en: Costume designer
     es: Vestuarista
+    pl: Projektant kostiumów
 date: 
   label: 
     it: Date
@@ -625,6 +711,7 @@ date:
     de: Daten
     en: Dates
     es: Fechas
+    pl: Daty
 description: 
   label: 
     it: Campi per la descrizione fisica
@@ -632,6 +719,7 @@ description:
     de: "Felder für die physische Beschreibung"
     en: Physical description, etc. fields
     es: "Campos para la descripción Material"
+    pl: Opis fizyczny itp. pola
 diplomatic_title: 
   label: 
     it: Titolo diplomatico
@@ -639,6 +727,7 @@ diplomatic_title:
     de: Diplomatischer Titel
     en: Diplomatic title
     es: "Título diplomático"
+    pl: Tytuł dyplomatyczny
 dnc: 
   label: 
     it: Ballerino
@@ -646,6 +735,7 @@ dnc:
     de: "Tänzer"
     en: Dancer
     es: "Bailarín(a)"
+    pl: Tancerz
 dnr: 
   label: 
     it: Donatore
@@ -653,6 +743,7 @@ dnr:
     de: Donator
     en: Donor
     es: Donante
+    pl: Donator
 dte: 
   label: 
     it: Dedicatario
@@ -660,6 +751,7 @@ dte:
     de: "Widmungsträger"
     en: Dedicatee
     es: Dedicatario
+    pl: Adresat dedykacji
 dub: 
   label: 
     it: Dubbio
@@ -667,6 +759,7 @@ dub:
     de: Zweifelhaft
     en: Dubious
     es: Dudoso
+    pl: Wątpliwe
 edition: 
   label: 
     it: Campi per i dati editoriali
@@ -674,6 +767,7 @@ edition:
     de: Ausgabe- und Impressumsfelder
     en: Edition, imprint, etc. fields
     es: "Campos para los datos editoriales"
+    pl: Edycja, stopka wydawnicza itp. pola
 edt: 
   label: 
     it: Curatore
@@ -681,6 +775,7 @@ edt:
     de: Herausgeber
     en: Editor
     es: "Editor (curador)/Editorial"
+    pl: Edytor
 egr: 
   label: 
     it: Incisore
@@ -688,6 +783,7 @@ egr:
     de: Stecher
     en: Engraver
     es: Grabador
+    pl: Rytownik
 fmo: 
   label: 
     it: Proprietario precedente
@@ -695,6 +791,7 @@ fmo:
     de: Vorbesitzer
     en: Former owner
     es: Propietario anterior
+    pl: Poprzedni właściciel
 holding: 
   label: 
     it: Informazioni sul fondo
@@ -702,6 +799,7 @@ holding:
     de: Bestandsdaten
     en: Holdings, location, etc. fields
     es: "Campos de los ejemplares y su ubicación"
+    pl: Pola egzemplarza, lokalizacji itp.
 ill: 
   label: 
     it: Disegnatore
@@ -709,6 +807,7 @@ ill:
     de: Illustrator
     en: Illustrator
     es: Ilustrador
+    pl: Ilustrator
 incipit: 
   label: 
     it: Incipit
@@ -716,6 +815,7 @@ incipit:
     de: Incipits
     en: Incipits
     es: Íncipits
+    pl: Incipity
 itr: 
   label: 
     it: Strumentista
@@ -723,6 +823,7 @@ itr:
     de: Instrumentalist
     en: Instrumentalist
     es: Instrumentista
+    pl: Instrumentalista
 lbt: 
   label: 
     it: Librettista
@@ -730,6 +831,7 @@ lbt:
     de: Librettist
     en: Librettist
     es: Libretista
+    pl: Autor libretta
 library: 
   label: 
     it: Biblioteca
@@ -737,6 +839,7 @@ library:
     de: Besitzerangaben
     en: Library information
     es: "Información del repositorio"
+    pl: Informacje o bibliotece
 linkage: 
   label: 
     it: Collegamento
@@ -744,6 +847,7 @@ linkage:
     de: Verlinkung
     en: Linkage
     es: Vínculos
+    pl: Powiązanie
 linking: 
   label: 
     it: Note su collegamenti
@@ -751,6 +855,7 @@ linking:
     de: "Verknüpfungseintragungen"
     en: Linking entry fields
     es: "Campos de entrada de vínculos"
+    pl: Łączenie pól wpisów
 ltg: 
   label: 
     it: Litografo
@@ -758,6 +863,7 @@ ltg:
     de: Lithograph
     en: Lithograph
     es: Litógrafo
+    pl: Litograf
 lyr: 
   label: 
     it: Poeta
@@ -765,6 +871,7 @@ lyr:
     de: Textdichter
     en: Lyricist
     es: Letrista
+    pl: Autor słów
 main: 
   label: 
     it: Campi principali
@@ -772,6 +879,7 @@ main:
     de: Haupteintragungen
     en: Main entry fields
     es: Campos principales
+    pl: Główne pola edycji
 notes: 
   label: 
     it: Note
@@ -779,6 +887,7 @@ notes:
     de: Fussnoten
     en: Note fields
     es: Notas
+    pl: Pola uwag
 other: 
   label: 
     it: Varia
@@ -786,6 +895,7 @@ other:
     de: Verschiedenes
     en: Miscellaneous
     es: Varios
+    pl: Pozostałe
 oth: 
   label: 
     it: Altra funzione
@@ -793,6 +903,7 @@ oth:
     de: Sonstige Funktion
     en: Other function
     es: "Otra función"
+    pl: Inna funkcja
 otm: 
   label: 
     it: Organizzatore
@@ -800,6 +911,7 @@ otm:
     de: Veranstalter
     en: Event organizer
     es: "Organizador del evento"
+    pl: Organizator wydarzenia
 pat: 
   label: 
     it: Committente
@@ -807,6 +919,7 @@ pat:
     de: "Mäzen/Auftraggeber"
     en: Patron
     es: Comitente
+    pl: Sponsor
 pbl: 
   label: 
     it: Editore
@@ -814,6 +927,7 @@ pbl:
     de: Verleger
     en: Publisher
     es: "Editor (publicador)/Editorial (publicadora)"
+    pl: Wydawca
 performance: 
   label: 
     it: Rappresentazioni
@@ -821,6 +935,7 @@ performance:
     de: "Aufführungen"
     en: Performances
     es: Interpretaciones
+    pl: Wykonania
 physical_description: 
   label: 
     it: Descrizione fisica
@@ -828,6 +943,7 @@ physical_description:
     de: Physische Beschreibung
     en: Physical description
     es: "Descripción física"
+    pl: Opis fizyczny
 ppm: 
   label: 
     it: Fabbricante di carta
@@ -835,6 +951,7 @@ ppm:
     de: Papierhersteller
     en: Paper maker
     es: "Fabricante de papel"
+    pl: Producent papieru
 prd: 
   label: 
     it: Personale alla produzione
@@ -842,6 +959,7 @@ prd:
     de: Produktionspersonal
     en: Production personnel
     es: "Personal de producción"
+    pl: Personel produkcyjny
 prf: 
   label: 
     it: Interprete
@@ -849,6 +967,7 @@ prf:
     de: Interpret
     en: Performer
     es: "Intérprete"
+    pl: Wykonawca
 provenance: 
   label: 
     it: Provenienza
@@ -856,6 +975,7 @@ provenance:
     de: Provenienz
     en: Provenance
     es: Procedencia
+    pl: Pochodzenie
 prt: 
   label: 
     it: Stampatore
@@ -863,6 +983,7 @@ prt:
     de: Drucker
     en: Printer
     es: Impresor
+    pl: Drukarnia
 scr: 
   label: 
     it: Copista
@@ -870,6 +991,7 @@ scr:
     de: Schreiber
     en: Scribe
     es: Copista
+    pl: Kopista
 series: 
   label: 
     it: Informazioni sul titolo sovraordinato
@@ -877,6 +999,7 @@ series:
     de: Gesamttitelangaben
     en: Series statement fields
     es: "Información de serie"
+    pl: Pola uwag do serii
 show_admin: 
   label: 
     it: Amministrazione
@@ -884,6 +1007,7 @@ show_admin:
     de: Administration
     en: Administration
     es: Administración
+    pl: Administracja
 show_content: 
   label: 
     it: Contenuto
@@ -891,6 +1015,7 @@ show_content:
     de: Inhalt
     en: Content
     es: Contenido
+    pl: Zawartość
 show_details: 
   label: 
     it: Descrizione fisica
@@ -898,6 +1023,7 @@ show_details:
     de: Physische Beschreibung
     en: Source details
     es: "Detalles de la fuente"
+    pl: Dane źródła
 show_distribution: 
   label: 
     it: Organico
@@ -905,6 +1031,7 @@ show_distribution:
     de: Besetzung
     en: Distribution
     es: "Distribución"
+    pl: Dystrybucja
 show_information: 
   label: 
     it: Note
@@ -912,6 +1039,7 @@ show_information:
     de: Anmerkungen
     en: Further information
     es: "Más información"
+    pl: Dalsze informacje
 show_library: 
   label: 
     it: Biblioteca
@@ -919,6 +1047,7 @@ show_library:
     de: Besitzerangaben
     en: Library information
     es: "Información del repositorio"
+    pl: Informacje o bibliotece
 show_links: 
   label: 
     it: Titoli connessi
@@ -926,6 +1055,7 @@ show_links:
     de: Verlinkungen
     en: Related Titles
     es: "Títulos relacionados"
+    pl: Powiązane tytuły
 show_references: 
   label: 
     it: Bibliografia
@@ -933,6 +1063,7 @@ show_references:
     de: Literatur
     en: References
     es: "Bibliografía"
+    pl: Odniesienia
 show_resources: 
   label: 
     it: Collegamenti
@@ -940,6 +1071,7 @@ show_resources:
     de: Links
     en: Related resources
     es: Recursos relacionados
+    pl: Powiązane zasoby
 show_summary: 
   label: 
     it: Riassunto
@@ -947,6 +1079,7 @@ show_summary:
     de: Zusammenfassung
     en: Summary
     es: Resumen
+    pl: Podsumowanie
 show_terms: 
   label: 
     it: Descrittori
@@ -954,6 +1087,7 @@ show_terms:
     de: Deskriptoren
     en: Index terms
     es: "Términos de indexación"
+    pl: Pojęcia indeksowane
 subject: 
   label: 
     it: Note sul titolo uniforme
@@ -961,6 +1095,7 @@ subject:
     de: Schlagworteintragungen
     en: Subject access fields
     es: "Campos de los puntos de acceso"
+    pl: Pola haseł tematycznych
 title: 
   label: 
     it: Titolo e campi correlati
@@ -968,6 +1103,7 @@ title:
     de: Titel- und damit verbundene Felder
     en: Title and title-related fields
     es: "Título y campos relacionados"
+    pl: Tytuł i pola związane z tytułem
 trl: 
   label: 
     it: Traduttore
@@ -975,6 +1111,7 @@ trl:
     de: "Übersetzer"
     en: Translator
     es: Traductor
+    pl: Tłumacz
 voc: 
   label: 
     it: Cantante
@@ -982,6 +1119,7 @@ voc:
     de: "Sänger"
     en: Vocalist
     es: Cantante
+    pl: Wokalista
 01_codes_artistic: 
   label: 
     it: Autore
@@ -989,6 +1127,7 @@ voc:
     de: Verfasser
     en: Artistic production
     es: Producción artística
+    pl: Autor produkcji artystycznej
 02_codes_performing: 
   label: 
     it: Partecipanti
@@ -996,6 +1135,7 @@ voc:
     de: Mitwirkende
     en: Performance
     es: Interpretación
+    pl: Wykonanie
 03_codes_technical: 
   label: 
     it: Produttore
@@ -1003,6 +1143,7 @@ voc:
     de: Hersteller
     en: Technical production
     es: "Producción técnica"
+    pl: Produkcja techniczna
 04_codes_other: 
   label: 
     it: Altri
@@ -1010,6 +1151,7 @@ voc:
     de: Weitere
     en: Other
     es: Otro
+    pl: Pozostałe
 "300": 
   label: 
     it: Materiale
@@ -1017,6 +1159,7 @@ voc:
     de: Material
     en: Physical Description
     es: "Descripción física"
+    pl: Opis fizyczny
   fields: 
     a: 
       label: 
@@ -1025,6 +1168,7 @@ voc:
         de: Umfang
         en: Extent
         es: "Extensión"
+        pl: Zakres
 "337": 
   label: 
     it: Mezzo fisico
@@ -1032,6 +1176,7 @@ voc:
     de: Physisches Medium 
     en: Media type
     es: "Tipo de medio físico"
+    pl: Rodzaj nośnika
   fields: 
     a: 
       label: 
@@ -1040,6 +1185,7 @@ voc:
         de: Physisches Medium 
         en: Media type
         es: "Tipo de medio físico"
+        pl: Rodzaj nośnika
 "500": 
   label: 
     it: Osservazioni
@@ -1047,6 +1193,7 @@ voc:
     de: Bemerkungen
     en: General note
     es: Nota general
+    pl: Uwaga ogólna
   fields: 
     a: 
       label: 
@@ -1055,6 +1202,7 @@ voc:
         de: Bemerkungen
         en: General note
         es: Nota general
+        pl: Uwaga ogólna
       edit_label: 
       en: ""
 "502": 
@@ -1064,6 +1212,7 @@ voc:
     de: Hinweis zur Dissertation
     en: Dissertation note
     es: "Nota de disertación"
+    pl: Uwaga do dysertacji
   fields: 
     a: 
       label: 
@@ -1072,6 +1221,7 @@ voc:
         de: Hinweis zur Dissertation
         en: Dissertation note
         es: "Nota de disertación"
+        pl: Uwaga do dysertacji
       comment: "NEW IN 2018"
 "520": 
   label: 
@@ -1080,6 +1230,7 @@ voc:
     de: Bestandsangabe
     en: Contents note
     es: "Nota sobre el contenido"
+    pl: Uwaga do zawartości
   fields: 
     a: 
       label: 
@@ -1088,6 +1239,7 @@ voc:
         de: Bestandsangabe
         en: Contents note
         es: "Nota sobre el contenido"
+        pl: Uwaga do zawartości
       edit_label: 
         en: ""
 "599": 
@@ -1097,6 +1249,7 @@ voc:
     de: Interne Fussnoten
     en: Internal note
     es: Nota interna
+    pl: Uwaga wewnętrzna
   fields: 
     a: 
       label: 
@@ -1105,6 +1258,7 @@ voc:
         de: Interne Fussnoten
         en: Internal note
         es: Nota interna
+        pl: Uwaga wewnętrzna
       edit_label: 
         en: ""
 "650": 
@@ -1114,6 +1268,7 @@ voc:
     de: Schlagworteintragung
     en: Subject heading
     es: Descriptor
+    pl: Słowo kluczowe
   fields: 
     v: 
       label: 
@@ -1122,6 +1277,7 @@ voc:
         de: Unterteilung nach der Form
         en: Form subdivision
         es: "Subdivisión de forma"
+        pl: Dalszy podział formularza
     a: 
       label: 
         it: Parola chiave
@@ -1129,6 +1285,7 @@ voc:
         fr: Sujet
         en: Subject heading
         es: Decriptor
+        pl: Słowo kluczowe
     x: 
       label: 
         it: Suddivisione generale
@@ -1136,6 +1293,7 @@ voc:
         de: Allgemeine Unterteilung
         en: Subheading General subdivision
         es: "Subdivisión general"
+        pl: Ogólny dalszy podział podnagłówków
     y: 
       label: 
         it: Suddivisione cronologica
@@ -1143,6 +1301,7 @@ voc:
         de: Chronologische Unterteilung
         en: Chronological subdivision
         es: "Subdivisión cronológica"
+        pl: Dalszy podział chronologiczny
     z: 
       label: 
         it: Suddivisione geografica
@@ -1150,6 +1309,7 @@ voc:
         de: Geographische Unterteilung
         en: Geographic subdivision
         es: "Subdivisión geográfica"
+        pl: Dalszy podział geograficzny
 "651": 
   label: 
     it: Luogo
@@ -1157,6 +1317,7 @@ voc:
     de: "Ort"
     en: Related place
     es: Lugar relacionado
+    pl: Powiązane miejsce
   fields: 
     a: 
       label: 
@@ -1165,6 +1326,7 @@ voc:
         de: "Ort"
         en: Place
         es: Lugar
+        pl: Miejsce
       edit_label: 
         en: ""
 "856": 
@@ -1174,6 +1336,7 @@ voc:
     de: Elektronische Lokalisierung und Zugriff
     en: External resource
     es: Recurso externo
+    pl: Zasób zewnętrzny
   fields: 
     z: 
       label: 
@@ -1182,6 +1345,7 @@ voc:
         de: "Für das Publikum bestimmte Fussnote"
         en: Note about external resource
         es: Nota sobre recurso externo
+        pl: Uwaga o zasobie zewnętrznym
     u: 
       label: 
         it: Risorsa esterna URL
@@ -1189,6 +1353,7 @@ voc:
         de: Uniform Resource Identifier URL
         en: External resource URL
         es: URL del recurso externo
+        pl: URL zasobu zewnętrznego
 # Marc Language codes
 cat: 
   label: 
@@ -1197,6 +1362,7 @@ cat:
     de: Katalanisch
     en: Catalan 
     es: Catalán
+    pl: Kataloński
 cze: 
   label: 
     it: Ceco
@@ -1204,6 +1370,7 @@ cze:
     de: Tschechisch
     en: Czech
     es: Checo
+    pl: Czeski
 dan: 
   label: 
     it: Danese
@@ -1211,6 +1378,7 @@ dan:
     de: Dänisch
     en: Danish
     es: "Danés"
+    pl: Duński
 dut: 
   label: 
     it: Olandese
@@ -1218,6 +1386,7 @@ dut:
     de: Niederländisch
     en: Dutch
     es: "Holandés"
+    pl: Holenderski
 eng: 
   label: 
     it: Inglese
@@ -1225,6 +1394,7 @@ eng:
     de: Englisch
     en: English
     es: "Inglés"
+    pl: Angielski
 fre: 
   label: 
     it: Francese
@@ -1232,6 +1402,7 @@ fre:
     de: Französisch
     en: French
     es: "Francés"
+    pl: Francuski
 ger: 
   label: 
     it: Tedesco
@@ -1239,6 +1410,7 @@ ger:
     de: Deutsch
     en: German
     es: "Alemán"
+    pl: Niemiecki
 grc: 
   label: 
     it: Greco, antico (fino al 1453)
@@ -1246,6 +1418,7 @@ grc:
     de: Altgriechisch (bis 1453)
     en: Greek, Ancient (to 1453)
     es: Griego, Antiguo (hasta 1453)
+    pl: Grecki, historyczny (do 1453 r.)
 gre:  
   label: 
     it: Greco, moderno (1453-)
@@ -1253,6 +1426,7 @@ gre:
     de: Neugriechisch (1453-)
     en: Greek, Modern (1453-)
     es: Griego, Moderno (1453-)
+    pl: Grecki, współczesny (1453-)
 gsw: 
   label: 
     it: Svizzero tedesco 
@@ -1260,6 +1434,7 @@ gsw:
     de: Schweizerdeutsch
     en: Swiss German
     es: "Suizo alemán"
+    pl: Niemiecki szwajcarski
 heb: 
   label: 
     it: Ebreo
@@ -1267,6 +1442,7 @@ heb:
     de: Hebräisch
     en: Hebrew
     es: "Hebreo"
+    pl: Hebrajski
 hrv: 
   label: 
     it: Croato
@@ -1274,6 +1450,7 @@ hrv:
     de: Kroatisch
     en: Croatian
     es: "Croata"
+    pl: Chorwacki
 hun: 
   label: 
     it: Ungherese
@@ -1281,6 +1458,7 @@ hun:
     de: Ungarisch
     en: Hungarian
     es: "Húngaro"
+    pl: Węgierski
 ita: 
   label: 
     it: Italiano
@@ -1288,6 +1466,7 @@ ita:
     de: Italienisch
     en: Italian
     es: "Italiano"
+    pl: Włoski
 jpn: 
   label: 
     it: Giapponese
@@ -1295,6 +1474,7 @@ jpn:
     de: Japanisch
     en: Japanese
     es: "Japonés"
+    pl: Japoński
 kor: 
   label: 
     it: Coreano
@@ -1302,6 +1482,7 @@ kor:
     de: Koreanisch
     en: Korean
     es: "Coreano"
+    pl: Koreański
 lat: 
   label: 
     it: Latino
@@ -1309,6 +1490,7 @@ lat:
     de: Lateinisch
     en: Latin
     es: "Latín"
+    pl: Łaciński
 pol: 
   label: 
     it: Polacco
@@ -1316,6 +1498,7 @@ pol:
     de: Polnisch
     en: Polish
     es: Polaco
+    pl: Polski
 por: 
   label: 
     it: Portoghese
@@ -1323,6 +1506,7 @@ por:
     de: Portugisisch
     en: Portuguese
     es: "Portugués"
+    pl: Portugalski
 rus: 
   label: 
     it: Russo
@@ -1330,6 +1514,7 @@ rus:
     de: Russisch
     en: Russian
     es: Ruso
+    pl: Rosyjski
 slo: 
   label: 
     it: Slovacco
@@ -1337,6 +1522,7 @@ slo:
     de: Slowakisch
     en: Slovak
     es: Eslovaco
+    pl: Słowacki
 slv: 
   label: 
     it: Sloveno
@@ -1344,6 +1530,7 @@ slv:
     de: Slowenisch
     en: Slovenian
     es: Eslovenio
+    pl: Słoweński
 spa: 
   label: 
     it: Spagnolo
@@ -1351,6 +1538,7 @@ spa:
     de: Spanisch
     en: Spanish
     es: "Español"
+    pl: Hiszpański
 srp: 
   label: 
     it: Serbo
@@ -1358,6 +1546,7 @@ srp:
     de: Serbisch
     en: Serbian
     es: Serbio
+    pl: Serbski
 swe: 
   label: 
     it: Svedese
@@ -1365,6 +1554,7 @@ swe:
     de: Schwedisch
     en: Swedish
     es: Sueco
+    pl: Szwedzki
 zho:
   label:
     it: Cinese
@@ -1372,6 +1562,7 @@ zho:
     de: Chinesisch
     en: Chinese
     es: Chino
+    pl: Chiński
 zxx: 
   label: 
     it: Nessun contesto linguistico
@@ -1379,6 +1570,7 @@ zxx:
     de: ohne Sprache
     en: No linguistic content
     es: "Sin contenido lingüístico"
+    pl: Brak zawartości językowej
 #Country Codes
 "XC-DZ":
   label:
@@ -1387,6 +1579,7 @@ zxx:
     de: "Algeria"
     en: "Algeria"
     es: "Argelia"
+    pl: Algieria
 "XA-AD":
   label:
     it: "ANDORRA"
@@ -1394,6 +1587,7 @@ zxx:
     de: "Andorra"
     en: "Andorra"
     es: "ANDORRA"
+    pl: Andora
 "XD-AR":
   label:
     it: "Argentina"
@@ -1401,6 +1595,7 @@ zxx:
     de: "Argentina"
     en: "Argentina"
     es: "Argentina"
+    pl: Argentyna
 "XB-AM":
   label:
     it: "Armenia"
@@ -1408,6 +1603,7 @@ zxx:
     de: "Armenia"
     en: "Armenia"
     es: "Armenia"
+    pl: Armenia
 "XE-AU":
   label:
     it: "Australia"
@@ -1415,6 +1611,7 @@ zxx:
     de: "Australia"
     en: "Australia"
     es: "Australia"
+    pl: Australia
 "XA-AT":
   label:
     it: "Austria"
@@ -1422,6 +1619,7 @@ zxx:
     de: "Austria"
     en: "Austria"
     es: "Austria"
+    pl: Austria
 "XA-BE":
   label:
     it: "Belgio"
@@ -1429,6 +1627,7 @@ zxx:
     de: "Belgium"
     en: "Belgium"
     es: "Bélgica"
+    pl: Belgia
 "XC-BJ":
   label:
     it: "Benin"
@@ -1436,6 +1635,7 @@ zxx:
     de: "Benin"
     en: "Benin"
     es: "Benín"
+    pl: Benin
 "XD-BR":
   label:
     it: "Brasile"
@@ -1443,6 +1643,7 @@ zxx:
     de: "Brazil"
     en: "Brazil"
     es: "Brasil"
+    pl: Brazylia
 "XA-BG":
   label:
     it: "Bulgaria"
@@ -1450,6 +1651,7 @@ zxx:
     de: "Bulgaria"
     en: "Bulgaria"
     es: "Bulgaria"
+    pl: Bułgaria
 "XB-KH":
   label:
     it: "Cambogia"
@@ -1457,6 +1659,7 @@ zxx:
     de: "Cambodia"
     en: "Cambodia"
     es: "Camboya"
+    pl: Kambodża
 "XD-CA":
   label:
     it: "Canada"
@@ -1464,6 +1667,7 @@ zxx:
     de: "Canada"
     en: "Canada"
     es: "Canadá"
+    pl: Kanada
 "XD-CL":
   label:
     it: "Chile"
@@ -1471,6 +1675,7 @@ zxx:
     de: "Chile"
     en: "Chile"
     es: "Chile"
+    pl: Chile
 "XB-CN":
   label:
     it: "Cina"
@@ -1478,6 +1683,7 @@ zxx:
     de: "China"
     en: "China"
     es: "China"
+    pl: Chiny
 "XD-CO":
   label:
     it: "Colombia"
@@ -1485,6 +1691,7 @@ zxx:
     de: "Colombia"
     en: "Colombia"
     es: "Colombia"
+    pl: Kolumbia
 "XA-HR":
   label:
     it: "Croazia"
@@ -1492,6 +1699,7 @@ zxx:
     de: "Croatia"
     en: "Croatia"
     es: "Croacia"
+    pl: Chorwacja
 
 "XD-CU":
   label:
@@ -1500,6 +1708,7 @@ zxx:
     de: "Cuba"
     en: "Cuba"
     es: "Cuba"
+    pl: Kuba
 "XA-CZ":
   label:
     it: "Repubblica ceca"
@@ -1507,6 +1716,7 @@ zxx:
     de: "Czech Republic"
     en: "Czech Republic"
     es: "República Checa"
+    pl: Czechy
 "XA-DK":
   label:
     it: "Danimarca"
@@ -1514,6 +1724,7 @@ zxx:
     de: "Denmark"
     en: "Denmark"
     es: "Dinamarca"
+    pl: Dania
 "XC-EG":
   label:
     it: "Egitto"
@@ -1521,6 +1732,7 @@ zxx:
     de: "Egypt"
     en: "Egypt"
     es: "Egipto"
+    pl: Egipt
 "XA-EE":
   label:
     it: "Estonia"
@@ -1528,6 +1740,7 @@ zxx:
     de: "Estonia"
     en: "Estonia"
     es: "Estonia"
+    pl: Estonia
 "XA-FI":
   label:
     it: "Finlandia"
@@ -1535,6 +1748,7 @@ zxx:
     de: "Finland"
     en: "Finland"
     es: "Finlandia"
+    pl: Finlandia
 "XA-FR":
   label:
     it: "Francia"
@@ -1542,6 +1756,7 @@ zxx:
     de: "France"
     en: "France"
     es: "Francia"
+    pl: Francja
 "XA-DE":
   label:
     it: "Germania"
@@ -1549,6 +1764,7 @@ zxx:
     de: "Germany"
     en: "Germany"
     es: "Alemania"
+    pl: Niemcy
 "XA-GR":
   label:
     it: "Grecia"
@@ -1556,6 +1772,7 @@ zxx:
     de: "Greece"
     en: "Greece"
     es: "Grecia"
+    pl: Grecja
 "XA-VA":
   label:
     it: "Santa Sede"
@@ -1563,6 +1780,7 @@ zxx:
     de: "Holy See"
     en: "Holy See"
     es: "Santa Sede"
+    pl: Watykan
 "XD-HN":
   label:
     it: "Honduras"
@@ -1570,6 +1788,7 @@ zxx:
     de: "Honduras"
     en: "Honduras"
     es: "Honduras"
+    pl: Honduras
 "XA-HU":
   label:
     it: "Ungheria"
@@ -1577,6 +1796,7 @@ zxx:
     de: "Hungary"
     en: "Hungary"
     es: "Hungría"
+    pl: Węgry
 "XA-IS":
   label:
     it: "Islanda"
@@ -1584,6 +1804,7 @@ zxx:
     de: "Iceland"
     en: "Iceland"
     es: "Islandia"
+    pl: Islandia
 "XB-IN":
   label:
     it: "India"
@@ -1591,6 +1812,7 @@ zxx:
     de: "India"
     en: "India"
     es: "India"
+    pl: Indie
 "XB-IR":
   label:
     it: "Iran, Repubblica Islamica dell'"
@@ -1598,6 +1820,7 @@ zxx:
     de: "Iran, Islamic Republic of"
     en: "Iran, Islamic Republic of"
     es: "Irán, República Islámica de"
+    pl: Iran, Republika Islamska
 "XA-IE":
   label:
     it: "Irlanda"
@@ -1605,6 +1828,7 @@ zxx:
     de: "Ireland"
     en: "Ireland"
     es: "Irlanda"
+    pl: Irlandia
 "XB-IL":
   label:
     it: "Israele"
@@ -1612,6 +1836,7 @@ zxx:
     de: "Israel"
     en: "Israel"
     es: "Israel"
+    pl: Izrael
 "XA-IT":
   label:
     it: "Italia"
@@ -1619,6 +1844,7 @@ zxx:
     de: "Italy"
     en: "Italy"
     es: "Italia"
+    pl: Włochy
 "XB-JP":
   label:
     it: "Giappone"
@@ -1626,6 +1852,7 @@ zxx:
     de: "Japan"
     en: "Japan"
     es: "Japón"
+    pl: Japonia
 "XB-KR":
   label:
     it: "Corea, Repubblica di"
@@ -1633,6 +1860,7 @@ zxx:
     de: "Korea, Republic of"
     en: "Korea, Republic of"
     es: "Corea, República de"
+    pl: Korea, Republika
 "XA-LV":
   label:
     it: "Lettonia"
@@ -1640,6 +1868,7 @@ zxx:
     de: "Latvia"
     en: "Latvia"
     es: "Letonia"
+    pl: Łotwa
 "XA-LT":
   label:
     it: "Lituania"
@@ -1647,6 +1876,7 @@ zxx:
     de: "Lithuania"
     en: "Lithuania"
     es: "Lituania"
+    pl: Litwa
 "XA-LU":
   label:
     it: "Lussemburgo"
@@ -1654,6 +1884,7 @@ zxx:
     de: "Luxembourg"
     en: "Luxembourg"
     es: "Luxemburgo"
+    pl: Luksemburg
 "XA-MT":
   label:
     it: "Malta"
@@ -1661,6 +1892,7 @@ zxx:
     de: "Malta"
     en: "Malta"
     es: "Malta"
+    pl: Malta
 "XD-MX":
   label:
     it: "Messico"
@@ -1668,6 +1900,7 @@ zxx:
     de: "Mexico"
     en: "Mexico"
     es: "México"
+    pl: Meksyk
 "XA-ME":
   label:
     it: "Montenegro"
@@ -1675,6 +1908,7 @@ zxx:
     de: "Montenegro"
     en: "Montenegro"
     es: "Montenegro"
+    pl: Czarnogóra
 "XA-NL":
   label:
     it: "Paesi Bassi"
@@ -1682,6 +1916,7 @@ zxx:
     de: "Netherlands"
     en: "Netherlands"
     es: "Países Bajos"
+    pl: Niderlandy
 "XE-NZ":
   label:
     it: "Nuova Zelanda"
@@ -1689,6 +1924,7 @@ zxx:
     de: "New Zealand"
     en: "New Zealand"
     es: "Nueva Zelanda"
+    pl: Nowa Zelandia
 "XA-NO":
   label:
     it: "Norvegia"
@@ -1696,6 +1932,7 @@ zxx:
     de: "Norway"
     en: "Norway"
     es: "Noruega"
+    pl: Norwegia
 "XD-PY":
   label:
     it: "Paraguay"
@@ -1703,6 +1940,7 @@ zxx:
     de: "Paraguay"
     en: "Paraguay"
     es: "Paraguay"
+    pl: Paragwaj
 "XA-PL":
   label:
     it: "Polonia"
@@ -1710,6 +1948,7 @@ zxx:
     de: "Poland"
     en: "Poland"
     es: "Polonia"
+    pl: Polska
 "XA-PT":
   label:
     it: "Portogallo"
@@ -1717,6 +1956,7 @@ zxx:
     de: "Portugal"
     en: "Portugal"
     es: "Portugal"
+    pl: Portugalia
 "XD-PR":
   label:
     it: "Puerto Rico"
@@ -1724,6 +1964,7 @@ zxx:
     de: "Puerto Rico"
     en: "Puerto Rico"
     es: "Puerto Rico"
+    pl: Portoryko
 "XA-RO":
   label:
     it: "Romania"
@@ -1731,6 +1972,7 @@ zxx:
     de: "Romania"
     en: "Romania"
     es: "Rumania"
+    pl: Rumunia
 "XA-RU":
   label:
     it: "Federazione Russa"
@@ -1738,6 +1980,7 @@ zxx:
     de: "Russian Federation"
     en: "Russian Federation"
     es: "Federación Rusa"
+    pl: Federacja Rosyjska
 "XA-RS":
   label:
     it: "Serbia"
@@ -1745,6 +1988,7 @@ zxx:
     de: "Serbia"
     en: "Serbia"
     es: "Serbia"
+    pl: Serbia
 "XA-SK":
   label:
     it: "Slovacchia"
@@ -1752,6 +1996,7 @@ zxx:
     de: "Slovakia"
     en: "Slovakia"
     es: "Eslovaquia"
+    pl: Słowacja
 "XA-SI":
   label:
     it: "Slovenia"
@@ -1759,6 +2004,7 @@ zxx:
     de: "Slovenia"
     en: "Slovenia"
     es: "Eslovenia"
+    pl: Słowenia
 "XC-ZA":
   label:
     it: "Sudafrica"
@@ -1766,6 +2012,7 @@ zxx:
     de: "South Africa"
     en: "South Africa"
     es: "Sudáfrica"
+    pl: Republika Południowej Afryki
 "XA-ES":
   label:
     it: "Spagna"
@@ -1773,6 +2020,7 @@ zxx:
     de: "Spain"
     en: "Spain"
     es: "España"
+    pl: Hiszpania
 "XA-SE":
   label:
     it: "Svezia"
@@ -1780,6 +2028,7 @@ zxx:
     de: "Sweden"
     en: "Sweden"
     es: "Suecia"
+    pl: Szwecja
 "XA-CH-VD":
   label:
     it: "Svizzera: Vaud"
@@ -1787,6 +2036,7 @@ zxx:
     de: "Switzerland: Vaud"
     en: "Switzerland: Vaud"
     es: "Suiza: cantón de Vaud"
+    pl: Szwajcaria: kanton Vaud
 "XA-CH":
   label:
     it: "Svizzera"
@@ -1794,6 +2044,7 @@ zxx:
     de: "Switzerland"
     en: "Switzerland"
     es: "Suiza"
+    pl: Szwajcaria
 "XB-SY":
   label:
     it: "Repubblica Araba Siriana"
@@ -1801,6 +2052,7 @@ zxx:
     de: "Syrian Arab Republic"
     en: "Syrian Arab Republic"
     es: "República Árabe Siria"
+    pl: Syryjska Republika Arabska
 "XB-TW":
   label:
     it: "Taiwan (provincia della Ciina)"
@@ -1808,6 +2060,7 @@ zxx:
     de: "Taiwan (Province of China)"
     en: "Taiwan (Province of China)"
     es: "Taiwán (Provincia de China)"
+    pl: Tajwan (prowincja Chin)
 "XD-TT":
   label:
     it: "Trinidad e Tobago"
@@ -1815,6 +2068,7 @@ zxx:
     de: "Trinidad and Tobago"
     en: "Trinidad and Tobago"
     es: "Trinidad y Tobago"
+    pl: Trynidad i Tobago
 "XB-TR":
   label:
     it: "Turchia"
@@ -1822,6 +2076,7 @@ zxx:
     de: "Turkey"
     en: "Turkey"
     es: "Turquía"
+    pl: Turcja
 "XA-UA":
   label:
     it: "Ucraina"
@@ -1829,6 +2084,7 @@ zxx:
     de: "Ukraine"
     en: "Ukraine"
     es: "Ucrania"
+    pl: Ukraina
 "XA-GB":
   label:
     it: "Regno Unito"
@@ -1836,6 +2092,7 @@ zxx:
     de: "United Kingdom"
     en: "United Kingdom"
     es: "Reino Unido"
+    pl: Zjednoczone Królestwo
 "XD-US":
   label:
     it: "Stati Uniti d'America"
@@ -1843,6 +2100,7 @@ zxx:
     de: "United States of America"
     en: "United States of America"
     es: "Estados Unidos de América"
+    pl: Stany Zjednoczone AP
 "XD-UY":
   label:
     it: "Uruguay"
@@ -1850,6 +2108,7 @@ zxx:
     de: "Uruguay"
     en: "Uruguay"
     es: "Uruguay"
+    pl: Urugwaj
 "XD-VE":
   label:
     it: "Venezuela, Repubblica Bolivariana del"
@@ -1857,6 +2116,7 @@ zxx:
     de: "Venezuela, Bolivarian Republic of"
     en: "Venezuela, Bolivarian Republic of"
     es: "Venezuela, República Bolivariana de"
+    pl: Wenezuela, Republika Boliwariańska
 "XD-EC":
   label:
     it: "Ecuador"
@@ -1864,3 +2124,4 @@ zxx:
     de: "Ecuador"
     en: "Ecuador"
     es: "Ecuador"
+    pl: Ekwador

--- a/config/editor_profiles/default/configurations/HoldingBasicLabels.yml
+++ b/config/editor_profiles/default/configurations/HoldingBasicLabels.yml
@@ -6,18 +6,21 @@ doc_introduction:
     en: Introduction
     it: Introduzione
     es: "Introducción"
+    pl: Wprowadzenie
 doc_masks: 
   label: 
     de: Katalogisierung von Musikquellen
     en: Cataloging musical sources
     it: Catalogazione delle fonti musicali
     es: "Catalogación de fuentes musicales"
+    pl: Katalogowanie źródeł muzycznych
 doc_tag_index: 
   label: 
     de: MARC Tag Index
     en: Index of MARC fields
     it: Indice dei campi MARC
     es: "Índice de campos MARC"
+    pl: Indeks pól MARC
 
 ################
 
@@ -27,48 +30,56 @@ doc_abbreviations:
     en: "Abbreviations and terminology"
     it: "Abbreviazioni e terminologia"
     es: "Abreviaturas y terminología"
+    pl: Skróty i pojęcia
 doc_abbr_dates: 
   label: 
     de: "Datierung"
     en: "Dates"
     it: "Date"
     es: "Fechas"
+    pl: Daty
 doc_abbr_general: 
   label: 
     de: "Allgemeine Abkürzungen und Begriffe"
     en: "General abbreviations and terms"
     it: "Abbreviazioni generali e terminologia"
     es: "Abreviaturas y términos generales"
+    pl: Ogólne skróty i pojęcia
 doc_abbr_keys: 
   label: 
     de: "Tonarten"
     en: "Keys"
     it: "Tasti"
     es: "Tonalidades"
+    pl: Tonacje
 doc_abbr_lang: 
   label: 
     de: "Sprachcodes"
     en: "Language codes"
     it: "Codice lingua"
     es: "Códigos de idioma"
+    pl: Kody języków
 doc_abbr_modes:
   label: 
     de: "Kirchentonarten"
     en: "Ecclesiastical modes"
     it: "Modi ecclesiastici"
     es: "Modos eclesiásticos"
+    pl: Skale kościelne
 doc_abbr_voices_instr: 
   label: 
     de: "Stimmen- und Instrumentenbezeichnungen"
     en: "Terms for voices and instruments"
     it: "Terminologia per voci e strumenti"
     es: "Terminología para voces e instrumentos"
+    pl: Określenia głosów i instrumentów
 doc_abbr_voices_instr2: 
   label: 
     de: "Stimmen- und Instrumentenbezeichnungen tabellarisch"
     en: "RISM instrument abbreviations"
     it: "Abbreviazioni RISM per gli strumenti"
     pt: "Abreviaturas de instrumentos de RISM"
+    pl: Skróty instrumentów wg RISM
 
 ###############
 
@@ -77,36 +88,42 @@ doc_aid:
     de: Arbeitshilfen
     en: Aids
     it: Aiuti
+    pl: Pomoce
 doc_aid_liturgical_feasts: 
   label: 
     de: "Liturgische Feste"
     en: "Liturgical festivals"
     it: "Feste liturgiche"
     es: "Festividades litúrgicas"
+    pl: Święta liturgiczne
 doc_aid_locations: 
   label: 
     de: "Fundorte auf Quellen"
     en: "Locations on the source"
     it: "Luogo sulla fonte"
     es: "Ubicaciones en la fuente"
+    pl: Lokalizacje w źródle
 doc_aid_texts_sacred_works: 
   label: 
     de: "Standardtexte Sakralwerke"
     en: "Standard texts of sacred works"
     it: "Testo standard dei brani musicali sacri"
     es: "Textos estándar de obras sacras"
+    pl: Standardowe teksty utworów sakralnych
 doc_aid_titles_keywords: 
   label: 
     de: "Einordnungstitel - Schlagworte"
     en: "Standardized titles - Subject headings"
     it: "Titolo standard - intestazione del soggetto"
     es: "Títulos uniformes – Descriptores"
+    pl: Znormalizowane tytuły – słowa kluczowe
 doc_aid_transposing_instruments: 
   label: 
     de: "Hilfe zur Transponierung von Instrumenten"
     en: "Help for transposing instruments"
     it: "Aiuto agli strumenti traspositori"
     es: Ayuda para instrumentos transpositores
+    pl: Pomoc przy transpozycji instrumentów
 
 ################
 
@@ -116,24 +133,28 @@ doc_cataloguing:
     en: General cataloging guidelines
     it: Regole di catalogazione generali
     es: "Lineamientos generales para la catalogación"
+    pl: Ogólne wskazówki do katalogowania
 doc_cat_collections: 
   label: 
     de: Erfassung von Sammlungen
     en: Cataloging collection and convoluta
     it: Catalogazione delle collezioni e dei volumi compositi
     es: "Catalogación de colecciones y volúmenes compuestos"
+    pl: Katalogowanie kolekcji i klocka introligatorskiego
 doc_cat_templates: 
   label: 
     de: Templates
     en: Templates
     it: Template
     es: Plantillas
+    pl: Szablony
 doc_cat_authorities: 
   label: 
     de: Normdaten
     en: Authorities
     it: Autorità
     es: Autoridades
+    pl: Hasła wzorcowe
 
 ################
 
@@ -143,23 +164,27 @@ doc_editor:
     en: Using Muscat
     it: Guida all'editor
     es: Uso de Muscat
+    pl: Korzystanie z Muscatu
 doc_edit_functions: 
   label: 
     de: "Grundsätzliche Funktionen"
     en: Basic functions
     it: Funzioni base
     es: "Funciones básicas"
+    pl: Podstawowe funkcje
 doc_edit_workflow: 
   label: 
     de: "Workflow"
     en: Workflow
     it: Workflow
+    pl: Przepływ pracy
 doc_edit_searching:
   label:
     de: "Suche"
     en: "Searching"
     it: "Ricerca"
     es: "Búsqueda"
+    pl: Wyszukiwanie
 
 
    
@@ -171,131 +196,153 @@ doc_library:
     en: Library information
     it: Informazioni sulla biblioteca
     es: "Información del repositorio"
+    pl: Informacje o bibliotece
 doc_provenance: 
   label: 
     de: Provenienz
     en: Provenance
     it: Provenienza
     es: Procedencia
+    pl: Pochodzenie
 doc_linkage: 
   label: 
     de: Verlinkung
     en: Linkage
     it: Collegamenti
     es: "Vínculos"
+    pl: Powiązanie
 doc_diplomatic_title: 
   label: 
     de: Diplomatischer Titel
     en: Diplomatic title
     it: Titolo diplomatico
     es: "Título diplomático"
+    pl: Tytuł dyplomatyczny
 doc_physical_description: 
   label: 
     de: Materialbeschreibung
     en: Material description
     it: Descrizione del materiale
     es: "Descripción del material"
+    pl: Opis materiału
 doc_content: 
   label: 
     de: Inhalt
     en: Content
     it: Contenuto
     es: Contenido
+    pl: Zawartość
 doc_incipit: 
   label: 
     de: Incipits
     en: Incipits
     it: Incipit
     es: "Íncipits"
+    pl: Incipity
 doc_bibliographical_reference: 
   label: 
     de: Literatur
     en: References
     it: Riferimenti
     es: Referencias
+    pl: Odniesienia
 doc_added_entries: 
   label: 
     de: Nebeneintragungen
     en: Added entry name
     it: Nome di entità aggiunto
+    pl: Dodana nazwa wpisu
 doc_performance: 
   label: 
     de: "Aufführungen"
     en: Performances
     it: Esecuzioni
     es: "Interpretaciones"
+    pl: Wykonania
 doc_date: 
   label: 
     de: Daten
     en: Dates
     it: Date
     es: Fechas
+    pl: Daty
 doc_administration: 
   label: 
     de: Administration
     en: Administration
     it: Amministrazione
     es: "Administración"
+    pl: Administracja
 doc_personal_names:
   label:
     de: "Personen"
     en: "Personal names"
     it: "Nomi di persona"
     es: "Nombres personales"
+    pl: Osoby
 doc_images:
   label:
     de: "Bilder"
     en: "Images"
     it: "Immagini"
     es: "Imágenes"
+    pl: Obrazy
 doc_institutions:
   label:
     de: "Körperschaften"
     en: "Institutions"
     it: "Istituzioni"
     es: "Instituciones"
+    pl: Instytucje
 doc_title:
   label:
     de: "Titel und Inhaltsangaben"
     en: "Title and content description"
     it: "Titolo e descrizione del contenuto"
     es: "Título y descripción del contenido"
+    pl: Tytuł i opis źródła
 doc_people:
   label:
     de: "Personen und Körperschaften"
     en: "People and institutions"
     it: "Persone ed istituzioni"
     es: "Personas e instituciones"
+    pl: Osoby i instytucje
 doc_main_entry_fields:
   label:
     de: "Haupteintragungen"
     en: "Main entry fields"
     it: "Campi principali"
     es: "Campos principales"
+    pl: Główne pola edycji
 doc_numbers:
   label:
     de: "Nummern und Codes"
     en: "Numbers and code fields"
     it: "Campi numerici e codici"
     es: "Números y campos de código"
+    pl: Pola liczb i kodów
 doc_name_variants:
   label:
     de: "Namensvarianten"
     en: "Name variants"
     it: "Varianti del nome"
     es: Variantes del nombre
+    pl: Alternatywne nazwy osoby
 doc_relations:
   label:
     de: "Beziehungen"
     en: "Relations"
     it: "Relazioni"
     es: "Relaciones"
+    pl: Relacje
 doc_references:
   label:
     de: "Literatur und Bemerkungen"
     en: "References"
     it: "Riferimenti"
     es: "Referencias"
+    pl: Odniesienia
 
 ################
 
@@ -305,24 +352,28 @@ doc_references:
     fr: Auteur
     de: Verfasser
     en: Artistic production
+    pl: Autor produkcji artystycznej
 02_codes_performing: 
   label: 
     it: Partecipanti
     fr: Exécuteurs
     de: Mitwirkende
     en: Performance
+    pl: Wykonanie
 03_codes_technical: 
   label: 
     it: Produttore
     fr: "Création"
     de: Hersteller
     en: Technical production  
+    pl: Produkcja techniczna
 04_codes_other: 
   label: 
     it: Altri
     fr: Autre
     de: Weitere
     en: Other 
+    pl: Pozostałe
 
 ################
 
@@ -333,6 +384,7 @@ doc_references:
     de: Leader
     en: Leader
     es: "Líder"
+    pl: Leader
 "001": 
   label: 
     it: Numero documento RISM
@@ -340,6 +392,7 @@ doc_references:
     de: RISM Dokumentnummer
     en: RISM ID No.
     es: "Número de ID de RISM"
+    pl: RISM ID
 "035": 
   label: 
     it: Num. locale
@@ -347,6 +400,7 @@ doc_references:
     de: Lokale Nummer
     en: Local Number
     es: "Número local"
+    pl: Numer kontrolny
   fields: 
     a: 
       label: 
@@ -354,6 +408,7 @@ doc_references:
         fr: No. local
         de: Lokale Nummer
         en: Local ID no.
+        pl: Numer kontrolny
       edit_label:
         en: ""
 "300": 
@@ -363,6 +418,7 @@ doc_references:
     de: Material
     en: Physical description
     es: "Descripción física"
+    pl: Opis fizyczny
   fields: 
     a: 
       label: 
@@ -371,6 +427,7 @@ doc_references:
         de: Quellenart, Umfang
         en: Format, extent
         es: "Formato, extensión"
+        pl: Rodzaj źródła, objętość
     b: 
       label: 
         it: Altri dettagli sul materiale
@@ -378,6 +435,7 @@ doc_references:
         de: Zusätzliche Materialbeschreibung
         en: Other physical details
         es: "Otros detalles físicos"
+        pl: Pozostałe dane fizyczne
     c: 
       label: 
         it: Dimensioni
@@ -385,6 +443,7 @@ doc_references:
         de: Format
         en: Dimensions
         es: Dimensiones
+        pl: Wymiary
     "8": 
       label: 
         it: Gruppo di materiale
@@ -392,6 +451,7 @@ doc_references:
         de: Set
         en: Set
         es: Set
+        pl: Zbiór
 "500": 
   label: 
     it: Osservazioni
@@ -399,6 +459,7 @@ doc_references:
     de: Bemerkungen
     en: General note
     es: Nota general
+    pl: Uwaga ogólna
   fields: 
     a: 
       label: 
@@ -407,6 +468,7 @@ doc_references:
         de: Bemerkungen
         en: General note
         es: Nota general
+        pl: Uwaga ogólna
       edit_label: 
         en: ""
     "8": 
@@ -416,6 +478,7 @@ doc_references:
         de: Set
         en: Set
         es: Set
+        pl: Zbiór
 "506": 
   label: 
     it: Restrizioni all'accesso
@@ -423,6 +486,7 @@ doc_references:
     de: "Zugangsbeschränkungen"
     en: Access restrictions
     es: Restricciones de acceso
+    pl: Ograniczenia dostępu
   fields: 
     a: 
       label: 
@@ -431,6 +495,7 @@ doc_references:
         de: "Zugangsbeschränkungen"
         en: Access restriction
         es: Restricciones de acceso
+        pl: Ograniczenia dostępu
       edit_label: 
         en: ""
 "518": 
@@ -440,6 +505,7 @@ doc_references:
     de: "Bemerkungen zu den Aufführungen"
     en: Note on performance
     es: "Nota sobre ocasión de interpretación"
+    pl: Uwaga o wykonaniu
   fields: 
     a: 
       label: 
@@ -448,6 +514,7 @@ doc_references:
         de: "Bemerkungen zu den Aufführungen"
         es: "Nota sobre ocasión de interpretación"
         en: Performer note
+        pl: Uwaga o wykonaniu
       edit_label: 
         en: ""
 "541": 
@@ -457,6 +524,7 @@ doc_references:
     de: Unmittelbare Beschaffungsquelle
     en: Source of acquisition
     es: "Fuente de adquisición"
+    pl: Źródło nabycia
   fields: 
     a: 
       label: 
@@ -465,6 +533,7 @@ doc_references:
         de: Beschaffungsquelle
         en: Source of acquisition note
         es: "Nota sobre la fuente de adquisición"
+        pl: Uwaga o źródle nabycia
     c: 
       label: 
         it: Metodo d'acquisto
@@ -472,6 +541,7 @@ doc_references:
         de: Beschaffungsart
         en: Method of acquisition
         es: "Método de adquisición"
+        pl: Sposób nabycia
     d: 
       label: 
         it: Data d'acquisto
@@ -479,6 +549,7 @@ doc_references:
         de: Beschaffungsdatum
         en: Date of acquisition
         es: "Fecha de adquisición"
+        pl: Data nabycia
     e: 
       label: 
         it: Numero di acquisizione
@@ -486,6 +557,7 @@ doc_references:
         de: Akzessionsnumer
         en: Accession number
         es: "Número de adquisición"
+        pl: Numer akcesji
 "561": 
   label: 
     it: Provenienza
@@ -493,6 +565,7 @@ doc_references:
     de: Provenienzvermerke
     en: Provenance note
     es: Nota de procedencia
+    pl: Uwaga o pochodzeniu
   fields: 
     a: 
       label: 
@@ -501,6 +574,7 @@ doc_references:
         de: Provenienzvermerke
         en: Provenance notes
         es: Notas de procedencia
+        pl: Uwaga o pochodzeniu
       edit_label: 
         en: ""
 "563": 
@@ -510,6 +584,7 @@ doc_references:
     de: Einband note
     en: Binding note
     es: "Nota de encuadernación"
+    pl: Uwaga o oprawie
   fields: 
     a: 
       label: 
@@ -517,6 +592,7 @@ doc_references:
         fr: Reliure note
         de: Einband note
         en: Binding note
+        pl: Uwaga o oprawie
       edit_label: 
         en: ""
 "591": 
@@ -526,6 +602,7 @@ doc_references:
     de: Weitere Signatur
     en: Other shelfmark
     es: Otra signatura
+    pl: Inna sygnatura
   fields: 
     a: 
       label: 
@@ -534,6 +611,7 @@ doc_references:
         de: Weitere Signatur
         en: Other shelfmark
         es: Otra signatura
+        pl: Inna sygnatura
 "592": 
   label: 
     it: Filigrana
@@ -541,6 +619,7 @@ doc_references:
     de: Wasserzeichen
     en: Watermark description
     es: "Descripción de la marca de agua"
+    pl: Opis znaku wodnego
   fields: 
     a: 
       label: 
@@ -549,6 +628,7 @@ doc_references:
         de: Wasserzeichen
         en: Watermark description
         es: "Descripción de la marca de agua"
+        pl: Opis znaku wodnego
     "8": 
       label: 
         it: Gruppo di materiale
@@ -556,6 +636,7 @@ doc_references:
         de: Set
         en: Set
         es: Set
+        pl: Zbiór
 "593": 
   label: 
     it: Categoria di fonte
@@ -563,6 +644,7 @@ doc_references:
     de: Quellentyp
     en: Source type
     es: Tipo de fuente
+    pl: Rodzaj źródła
   fields: 
     a: 
       label: 
@@ -571,6 +653,7 @@ doc_references:
         de: Typ
         en: Type
         es: Tipo
+        pl: Rodzaj
 "599": 
   label: 
     it: Commenti interni
@@ -578,6 +661,7 @@ doc_references:
     de: Interne Fussnoten
     en: Local notes field
     es: Campo de notas locales
+    pl: Pole uwag wewnętrznych
   fields: 
     a: 
       label: 
@@ -586,6 +670,7 @@ doc_references:
         de: Interne Fussnoten
         en: Local notes field
         es: Campo de notas locales
+        pl: Pole uwag wewnętrznych
       edit_label: 
         en: ""
 "651": 
@@ -595,6 +680,7 @@ doc_references:
     de: "Aufführungsort"
     en: Location of performance
     es: "Lugar de interpretación"
+    pl: Lokalizacja wykonania
   fields: 
     a: 
       label: 
@@ -603,6 +689,7 @@ doc_references:
         de: "Aufführungsort"
         en: Location of performance
         es: "Lugar de interpretación"
+        pl: Lokalizacja wykonania
       edit_label: 
         en: ""
 "691": 
@@ -612,6 +699,7 @@ doc_references:
     de: Literaturverweis
     en: Bibliographic reference
     es: "Referencia bibliográfica"
+    pl: Odniesienie bibliograficzne
   fields: 
     a: 
       label: 
@@ -620,6 +708,7 @@ doc_references:
         de: Literatur
         en: Bibliographic reference
         es: "Referencia Bibliográfica"
+        pl: Odniesienie bibliograficzne
     n: 
       label: 
         it: Numero/pagina
@@ -627,6 +716,7 @@ doc_references:
         de: Fundstelle
         en: Number/page
         es: "Número/página"
+        pl: Numer / strona
 "700": 
   label: 
     it: Nomi di persone aggiuntivi
@@ -634,6 +724,7 @@ doc_references:
     de: Nebeneintragung Personen
     en: Additional personal name
     es: Nombre personal adicional
+    pl: Dodatkowa osoba
   fields: 
     a: 
       label: 
@@ -642,6 +733,7 @@ doc_references:
         de: Personenname
         en: Name
         es: Nombre
+        pl: Imię i nazwisko
     d: 
       label: 
         it: Date di nascita e di morte
@@ -649,6 +741,7 @@ doc_references:
         de: Geburts- und Todesdaten
         en: Life dates
         es: Fechas de nacimiento y muerte
+        pl: Daty urodzenia i śmierci
     j: 
       label: 
         it: Qualificazione d'attribuzione
@@ -656,12 +749,14 @@ doc_references:
         de: Zuschreibungsvermerk
         en: Attribution qualifier
         es: "Calificador de atribución"
+        pl: Kwalifikator atrybucji
       edit_label: 
         it: Attribuzione
         fr: Attribution
         de: Zuschreibung
         en: Attribution
         es: "Atribución"
+        pl: Atrybucja
     "4": 
       label: 
         it: Funzione
@@ -669,6 +764,7 @@ doc_references:
         de: Funktionsbezeichnung
         en: Function
         es: "Función"
+        pl: Funkcja
     "8": 
       label: 
         it: Gruppo di materiale
@@ -676,6 +772,7 @@ doc_references:
         de: Set
         en: Set
         es: Set
+        pl: Zbiór
 "710": 
   label: 
     it: Nome di ente
@@ -683,6 +780,7 @@ doc_references:
     de: Nebeneintragung Körperschaften
     en: Additional institution
     es: "Institución adicional"
+    pl: Dodatkowa instytucja
   fields: 
     a: 
       label: 
@@ -691,6 +789,7 @@ doc_references:
         de: Körperschaftsname
         en: Institution
         es: "Institución"
+        pl: Instytucja
     b: 
       label: 
         it: Ente subordinato
@@ -698,6 +797,7 @@ doc_references:
         de: Untergeordnete Körperschaft
         en: Department
         es: Departamento
+        pl: Wydział
     g: 
       label: 
         it: Qualificazione d'attribuzione
@@ -705,12 +805,14 @@ doc_references:
         de: Zuschreibungsvermerk
         en: Attribution qualifier
         es: "Calificador de atribución"
+        pl: Kwalifikator atrybucji
       edit_label: 
         it: Attribuzione
         fr: Attribution
         de: Zuschreibung
         en: Attribution
         es: "Atribución"
+        pl: Atrybucja
 
     "4": 
       label: 
@@ -719,6 +821,7 @@ doc_references:
         de: Funktionsbezeichnung
         en: Function
         es: "Función"
+        pl: Funkcja
     "8": 
       label: 
         it: Gruppo di materiale
@@ -726,6 +829,7 @@ doc_references:
         de: Set
         en: Set
         es: Set
+        pl: Zbiór
 "852": 
   label: 
     it: Sigla della biblioteca
@@ -733,6 +837,7 @@ doc_references:
     de: Bibliothekssigel
     en: Library siglum
     es: Sigla del repositorio
+    pl: Siglum
   fields: 
     a: 
       label: 
@@ -741,6 +846,7 @@ doc_references:
         de: Bibliothekssigel
         en: Library siglum
         es: Sigla del repositorio
+        pl: Siglum
     b: 
       label: 
         it: Dipartimento
@@ -748,6 +854,7 @@ doc_references:
         de: Abteilung
         en: Department
         es: Departamento
+        pl: Wydział
     c: 
       label: 
         it: Segnatura
@@ -755,6 +862,7 @@ doc_references:
         de: Signatur
         en: Shelfmark
         es: Signatura
+        pl: Sygnatura
     d: 
       label: 
         it: Segnatura vecchia (olim)
@@ -762,6 +870,7 @@ doc_references:
         de: Alte Signatur (olim)
         en: Shelfmark (olim)
         es: Signatura antigua (olim)
+        pl: Sygnatura (wcześniejsza)
     e: 
       label: 
         it: Biblioteca
@@ -769,6 +878,7 @@ doc_references:
         de: Bibliothek
         en: Library
         es: "Repositorio"
+        pl: Biblioteka
     q: 
       label: 
         it: Materiale conservato
@@ -776,6 +886,7 @@ doc_references:
         de: Erhaltenes Material
         en: Material held
         es: Material conservado
+        pl: Posiadany materiał
     u: 
       label: 
         it: URI
@@ -783,6 +894,7 @@ doc_references:
         de: URI
         en: URI
         es: URI
+        pl: URI
     z: 
       label: 
         it: Nome del fondo
@@ -790,6 +902,7 @@ doc_references:
         de: Bestandsname
         en: Provenance
         es: Procedencia
+        pl: Pochodzenie
 "856": 
   label: 
     it: Localizzazione e accesso elettronico
@@ -797,6 +910,7 @@ doc_references:
     de: Elektronische Lokalisierung und Zugriff
     en: External resource URI
     es: URI de recurso externo
+    pl: URI zasobu zewnętrznego
   fields: 
     z: 
       label: 
@@ -805,6 +919,7 @@ doc_references:
         de: "Für das Publikum bestimmte Fussnote"
         en: Note about external resource
         es: Nota sobre recurso externo
+        pl: Uwaga o zasobie zewnętrznym
     u: 
       label: 
         it: Risorsa esterna
@@ -812,6 +927,7 @@ doc_references:
         de: Uniform Resource Identifier
         en: External resource
         es: Recurso externo
+        pl: Zasób zewnętrzny
     x: 
       label: 
         it: Tipo di collegamento
@@ -819,6 +935,7 @@ doc_references:
         de: Linktyp
         en: Link type
         es: Tipo de enlace
+        pl: Typ odsyłacza
 "963": 
   label: 
     it: Non-migrated bound with value from 563 
@@ -826,6 +943,7 @@ doc_references:
     de: Non-migrated bound with value from 563
     en: Non-migrated bound with value from 563
     es: Non-migrated bound with value from 563
+    pl: Non-migrated bound with value from 563 
   fields: 
     u: 
       label: 
@@ -834,6 +952,7 @@ doc_references:
         de: Temp val
         en: Temp val
         es: Temp val
+        pl: Temp val
 "973": 
   label: 
     it: Rilegato con
@@ -841,6 +960,7 @@ doc_references:
     de: Eingesprungen
     en: Bound with
     es: Encuadernado con
+    pl: Współoprawne z
   fields: 
     u: 
       label: 
@@ -849,6 +969,7 @@ doc_references:
         de: Eingesprungen
         en: Bound with
         es: Encuadernado con
+        pl: Współoprawne z
       comment: "NEW IN 2018!"
 ################
 
@@ -859,6 +980,7 @@ show_admin:
     de: Administration
     en: Administration
     es: "Administración"
+    pl: Administracja
 show_content: 
   label: 
     it: Contenuto
@@ -866,6 +988,7 @@ show_content:
     de: Inhalt
     en: Content
     es: Contenido
+    pl: Zawartość
 show_distribution: 
   label: 
     it: Organico
@@ -873,6 +996,7 @@ show_distribution:
     de: Besetzung
     en: Distribution
     es: "Distribución"
+    pl: Dystrybucja
 show_information: 
   label: 
     it: Note
@@ -880,6 +1004,7 @@ show_information:
     de: Anmerkungen
     en: Further information
     es: "Información suplementaria"
+    pl: Dalsze informacje
 show_library: 
   label: 
     it: Biblioteca
@@ -887,6 +1012,7 @@ show_library:
     de: Besitzerangaben
     en: Library information
     es: "Información del repositorio"
+    pl: Informacje o bibliotece
 show_links: 
   label: 
     it: Titoli connessi
@@ -894,6 +1020,7 @@ show_links:
     de: Verlinkungen
     en: Related Titles
     es: "Títulos relacionados"
+    pl: Powiązane tytuły
 show_material: 
   label: 
     it: Descrizione del materiale
@@ -901,6 +1028,7 @@ show_material:
     de: Materialbeschreibung
     en: Material description
     es: "Descripción material"   
+    pl: Opis materiału
 show_references: 
   label: 
     it: Bibliografia
@@ -908,6 +1036,7 @@ show_references:
     de: Literatur
     en: References
     es: "Referencias"
+    pl: Odniesienia
 show_resources: 
   label: 
     it: Collegamenti
@@ -915,6 +1044,7 @@ show_resources:
     de: Links
     en: Related resources
     es: Recursos relacionados
+    pl: Powiązane zasoby
 show_summary: 
   label: 
     it: Riassunto
@@ -922,6 +1052,7 @@ show_summary:
     de: Zusammenfassung
     en: Summary
     es: Resumen
+    pl: Podsumowanie
 show_terms: 
   label: 
     it: Descrittori
@@ -929,6 +1060,7 @@ show_terms:
     de: Deskriptoren
     en: Index terms
     es: "Términos de indexación"
+    pl: Pojęcia indeksowane
         
 ################
         
@@ -939,6 +1071,7 @@ edit_administration:
     de: Administration
     en: Administration
     es: Administración
+    pl: Administracja
 edit_library: 
   label: 
     it: Biblioteca e relazione
@@ -946,6 +1079,7 @@ edit_library:
     de: Besitzerangaben und Verlinkung
     en: Library information and relations
     es: "Información del repositorio y sus relaciones"
+    pl: Informacje i relacje bibliotekarskie
 edit_material: 
   label: 
     it: Descrizione del materiale
@@ -953,6 +1087,7 @@ edit_material:
     de: Materialbeschreibung
     en: Material description
     es: "Descripción del material" 
+    pl: Opis materiału
 edit_names: 
   label: 
     it: Persone e istituzione
@@ -960,6 +1095,7 @@ edit_names:
     de: Personen und Körperschaften
     en: People and institutions
     es: Personas e instituciones
+    pl: Osoby i instytucje
 edit_references: 
   label: 
     it: Bibliografia e note
@@ -967,6 +1103,7 @@ edit_references:
     de: Literatur und Fussnoten
     en: References and notes
     es: Referencias y notas
+    pl: Odniesienia i uwagi
 
 unmatched: 
   label: 
@@ -975,6 +1112,7 @@ unmatched:
     de: Unbekannte Felder
     en: Unknown fields
     es: Campos desconocidos
+    pl: Pola nieznane
 
 ################
 
@@ -985,6 +1123,7 @@ arr:
     de: Bearbeiter
     en: Arranger
     es: Arreglador
+    pl: Aranżer
 art: 
   label: 
     it: Scenografo
@@ -992,6 +1131,7 @@ art:
     de: "Bühnenbildner"
     en: Artist
     es: Puestista
+    pl: Artysta
 asn: 
   label: 
     it: Altro nome
@@ -999,6 +1139,7 @@ asn:
     de: Weiterer Name
     en: Other
     es: Otro nombre
+    pl: Pozostałe
 aut: 
   label: 
     it: Autore
@@ -1006,6 +1147,7 @@ aut:
     de: Autor
     en: Author
     es: Autor
+    pl: Autor
 bnd: 
   label: 
     it: Rilegatore
@@ -1013,6 +1155,7 @@ bnd:
     de: Buchbinder
     en: Binder
     es: Encuadernador
+    pl: Introligator
 bsl: 
   label: 
     it: Libraio musicale
@@ -1020,6 +1163,7 @@ bsl:
     de: "Musikalienhändler"
     en: Bookseller
     es: Librero
+    pl: Księgarz
 ccp: 
   label: 
     it: Autore della fonte letteraria
@@ -1027,6 +1171,7 @@ ccp:
     de: Autor der Textvorlage
     en: Conceptor
     es: "Autor del concepto"
+    pl: Autor koncepcji
 chr: 
   label: 
     it: Coreografo
@@ -1034,6 +1179,7 @@ chr:
     de: Choreograph
     en: Choreographer
     es: "Coreógrafo"
+    pl: Choreograf
 clb: 
   label: 
     it: Autore secondario
@@ -1041,6 +1187,7 @@ clb:
     de: Mitverfasser
     en: Contributer
     es: Colaborador
+    pl: Kontrybutor
 cmp: 
   label: 
     it: Rimando ad altro compositore
@@ -1048,6 +1195,7 @@ cmp:
     de: Komponistenquerverweis
     en: Composer cross-reference
     es: Referencia cruzada de compositor
+    pl: Odniesienie do innego kompozytora
 cnd: 
   label: 
     it: Direttore d'orchestra
@@ -1055,6 +1203,7 @@ cnd:
     de: Dirigent
     en: Conductor
     es: Director musical
+    pl: Dyrygent
 cns: 
   label: 
     it: Censore
@@ -1062,6 +1211,7 @@ cns:
     de: Zensor
     en: Censor
     es: Censor
+    pl: Cenzor
 com: 
   label: 
     it: Compilatore
@@ -1069,6 +1219,7 @@ com:
     de: Kompilator
     en: Compiler
     es: Compilador
+    pl: Kompilator
 cst: 
   label: 
     it: Costumista
@@ -1076,6 +1227,7 @@ cst:
     de: "Kostümbildner"
     en: Costume designer
     es: Vestuarista
+    pl: Projektant kostiumów
 ctb: 
   label: 
     it: Compositore secondario
@@ -1083,6 +1235,7 @@ ctb:
     de: Mitkomponist
     en: Co-composer
     es: Co-compositor
+    pl: Współkompozytor
 dnc: 
   label: 
     it: Ballerino
@@ -1090,6 +1243,7 @@ dnc:
     de: "Tänzer"
     en: Dancer
     es: "Bailarín(a)"
+    pl: Tancerz
 dnr: 
   label: 
     it: Donatore
@@ -1097,6 +1251,7 @@ dnr:
     de: Donator
     en: Donor
     es: Donante
+    pl: Donator
 dpt: 
   label: 
     it: Depositante
@@ -1104,6 +1259,7 @@ dpt:
     de: Depositor
     en: Depositor
     es: Depositante
+    pl: Deponent
 dsr: 
   label: 
     it: Progettista
@@ -1111,6 +1267,7 @@ dsr:
     de: Designer
     en: Designer
     es: "Diseñador"
+    pl: Projektant
 dte: 
   label: 
     it: Dedicatario
@@ -1118,6 +1275,7 @@ dte:
     de: "Widmungsträger"
     en: Dedicatee
     es: "Dedicatario(a)"
+    pl: Adresat dedykacji
 asn: 
   label: 
     it: Nome associato
@@ -1126,6 +1284,7 @@ asn:
     en: Associated name
     es: Nombre asociado
     pt: Nome associado
+    pl: Niepewne
 edt: 
   label: 
     it: Curatore
@@ -1133,6 +1292,7 @@ edt:
     de: Herausgeber
     en: Editor
     es: Incierto
+    pl: Edytor
 egr: 
   label: 
     it: Incisore
@@ -1140,6 +1300,7 @@ egr:
     de: Stecher
     en: Engraver
     es: Editor
+    pl: Rytownik
 evp:
   label: 
     it: "Luogo dell’evento"
@@ -1147,6 +1308,7 @@ evp:
     de: Veranstaltungsort
     en: Event place
     es: Lugar del evento
+    pl: Miejsce wydarzenia
 fmo: 
   label: 
     it: Proprietario precedente
@@ -1154,6 +1316,7 @@ fmo:
     de: Vorbesitzer
     en: Former owner
     es: Propietario anterior
+    pl: Poprzedni właściciel
 ill: 
   label: 
     it: Disegnatore
@@ -1161,6 +1324,7 @@ ill:
     de: Illustrator
     en: Illustrator
     es: Ilustrador
+    pl: Ilustrator
 itr: 
   label: 
     it: Strumentista
@@ -1168,6 +1332,7 @@ itr:
     de: Instrumentalist
     en: Instrumentalist
     es: Instrumentista
+    pl: Instrumentalista
 lbt: 
   label: 
     it: Librettista
@@ -1175,6 +1340,7 @@ lbt:
     de: Librettist
     en: Librettist
     es: Libretista
+    pl: Autor libretta
 ltg: 
   label: 
     it: Litografo
@@ -1182,6 +1348,7 @@ ltg:
     de: Lithograph
     en: Lithographer
     es: "Litógrafo"
+    pl: Litograf
 lyr: 
   label: 
     it: Poeta
@@ -1189,6 +1356,7 @@ lyr:
     de: Textdichter
     en: Text author
     es: Autor del texto
+    pl: Autor tekstu
 oth: 
   label: 
     it: Altra funzione
@@ -1196,6 +1364,7 @@ oth:
     de: Sonstige Funktion
     en: Other
     es: "Otra función"
+    pl: Pozostałe
 otm: 
   label: 
     it: Organizzatore
@@ -1203,6 +1372,7 @@ otm:
     de: Veranstalter
     en: Event organizer
     es: Organizador de evento
+    pl: Organizator wydarzenia
 pat: 
   label: 
     it: Committente
@@ -1210,6 +1380,7 @@ pat:
     de: "Mäzen/Auftraggeber"
     en: Patron
     es: Comitente
+    pl: Sponsor
 pbl: 
   label: 
     it: Editore
@@ -1217,6 +1388,7 @@ pbl:
     de: Verleger
     en: Publisher
     es: Editor
+    pl: Wydawca
 ppm: 
   label: 
     it: Fabbricante di carta
@@ -1224,6 +1396,7 @@ ppm:
     de: Papierhersteller
     en: Papermaker
     es: Fabricante de papel
+    pl: Producent papieru
 prd: 
   label: 
     it: Personale alla produzione
@@ -1231,6 +1404,7 @@ prd:
     de: Produktionspersonal
     en: Production personnel
     es: "Personal de producción"
+    pl: Personel produkcyjny
 prf: 
   label: 
     it: Interprete
@@ -1238,6 +1412,7 @@ prf:
     de: Interpret
     en: Performer
     es: "Intérprete"
+    pl: Wykonawca
 prt: 
   label: 
     it: Stampatore
@@ -1245,6 +1420,7 @@ prt:
     de: Drucker
     en: Printer
     es: Impresor
+    pl: Drukarnia
 pub: 
   label: 
     it: Editore
@@ -1252,6 +1428,7 @@ pub:
     de: Verleger
     en: Publisher
     es: Editor
+    pl: Wydawca
 scr: 
   label: 
     it: Copista
@@ -1259,6 +1436,7 @@ scr:
     de: Schreiber
     en: Copyist
     es: Copista
+    pl: Kopista
 trl: 
   label: 
     it: Traduttore
@@ -1266,6 +1444,7 @@ trl:
     de: "Übersetzer"
     en: Translator
     es: Traductor
+    pl: Tłumacz
 voc: 
   label: 
     it: Cantante
@@ -1273,6 +1452,7 @@ voc:
     de: "Sänger"
     en: Vocalist
     es: Cantante
+    pl: Wokalista
 #Attribution qualifier for 100/700$j
 "Verified":
   label:
@@ -1281,6 +1461,7 @@ voc:
     de: Gesichert
     en: Verified
     es: Verificada
+    pl: Zweryfikowane
 "Ascertained":   
   label:
     it: Accertato
@@ -1288,6 +1469,7 @@ voc:
     de: Ermittelt
     en: Ascertained
     es: Certificada
+    pl: Stwierdzone
 "Alleged":   
   label:
     it: Presunto
@@ -1295,6 +1477,7 @@ voc:
     de: Angeblich
     en: Alleged
     es: Supuesta
+    pl: Domniemane
 "Doubtful":   
   label:
     it: Dubbio
@@ -1302,6 +1485,7 @@ voc:
     de: Zweifelhaft
     en: Doubtful
     es: Dudosa
+    pl: Wątpliwe
 "Misattributed":   
   label:
     it: Attribuito erroneamente
@@ -1309,6 +1493,7 @@ voc:
     de: Fälschlich
     en: Misattributed
     es: Mal atribuida
+    pl: Błędnie przypisane
 "Conjectural":   
   label:
     it: Congetturale
@@ -1316,6 +1501,7 @@ voc:
     de: Mutmaßlich
     en: Conjectural
     es: Conjetural
+    pl: Spekulatywne
 #Physical medium (340 $a) - currently not used by the partial
 Autography:
   label:
@@ -1324,6 +1510,7 @@ Autography:
     de: "Autographie"
     en: "Autography"
     es: "Autógrafo"
+    pl: Autografia
 "Computer printout":
   label:
     it: "Stampata da computer"
@@ -1331,6 +1518,7 @@ Autography:
     de: "Computerausdruck"
     en: "Computer printout"
     es: "Impreso de computadora"
+    pl: Wydruk komputerowy
 Engraving:
   label:
     it: "Incisione"
@@ -1338,6 +1526,7 @@ Engraving:
     de: "Stich"
     en: "Engraving"
     es: "Grabado"
+    pl: Sztych
 Facsimile:
   label:
     it: "Facsimile"
@@ -1345,6 +1534,7 @@ Facsimile:
     de: "Faksimile"
     en: "Facsimile"
     es: "Facsímil"
+    pl: Faksymile
 Lithography:
   label:
     it: "Litografia"
@@ -1352,6 +1542,7 @@ Lithography:
     de: "Lithographie"
     en: "Lithography"
     es: "Litografía"
+    pl: Litografia
 "Photoreproductive process":
   label:
     it: "Cianografia"
@@ -1359,6 +1550,7 @@ Lithography:
     de: "Blaupause"
     en: "Photoreproductive process (bluprint)"
     es: "Proceso fotoreproductivo"
+    pl: Proces optyczny (światłokopia)
 Reproduction:
   label:
     it: "Riproduzione"
@@ -1366,6 +1558,7 @@ Reproduction:
     de: "Reproduktion"
     en: "Reproduction"
     es: "Reproducción"
+    pl: Reprodukcja
 Transparency:
   label:
     it: "Trasparente"
@@ -1373,6 +1566,7 @@ Transparency:
     de: "Transparentfolie"
     en: "Transparency"
     es: "Transparencia"
+    pl: Przezrocze
 Typescript:
   label:
     it: "Dattiloscritto"
@@ -1380,6 +1574,7 @@ Typescript:
     de: "Typescript"
     en: "Typescript"
     es: "Escrito mecanografiado"
+    pl: Maszynopis
 Typography:
   label:
     it: "Stampa tipografica"
@@ -1387,6 +1582,7 @@ Typography:
     de: "Typendruck"
     en: "Typography"
     es: "Tipografía"
+    pl: Typografia
 IIIF: 
   label: 
     it: "Manifesto IIIF"
@@ -1394,6 +1590,7 @@ IIIF:
     de: "IIIF manifest"
     en: "IIIF manifest"
     es: "Manifiesto IIIF"
+    pl: Manifest IIIF
 Digitalization: 
   label: 
     it: "Fonte digitalizzata"
@@ -1401,6 +1598,7 @@ Digitalization:
     de: "Notendigitalisat"
     en: "Digitized music"
     es: "Música digitalizada"
+    pl: Cyfrowa reprodukcja źródła
 Other: 
   label: 
     it: "Altro"
@@ -1408,3 +1606,4 @@ Other:
     de: "Sonstiges"
     en: "Other"
     es: "Otro"
+    pl: Pozostałe

--- a/config/editor_profiles/default/configurations/InstitutionLabels.yml
+++ b/config/editor_profiles/default/configurations/InstitutionLabels.yml
@@ -6,48 +6,56 @@ doc_abbreviations:
     de: "Abkürzungen"
     en: Abbreviations
     es: Abreviaturas
+    pl: Skróty
 doc_aid:
   label:
     it: Aiuti
     de: Arbeitshilfen
     en: Aide
     es: Asistencia
+    pl: Asystent
 doc_cataloguing_collections:
   label:
     it: Catalogazione di raccolte e volumi compositi
     de: Erfassung von Sammlungen
     en: Cataloging collection and convoluta
     es: "Catalogación de colecciones y volúmenes compuestos"
+    pl: Katalogowanie kolekcji i klocka introligatorskiego
 doc_edit_functions:
   label:
     it: Funzioni base
     de: "Grundsätzliche Funktionen"
     en: Basic functions
     es: "Funciones básicas"
+    pl: Podstawowe funkcje
 doc_introduction:
   label:
     it: Introduzione
     de: Einleitung
     en: Introduction
     es: "Introducción"
+    pl: Wprowadzenie
 doc_masks:
   label:
     it: Formulari di catalogazione
     de: Masken
     en: Cataloging forms
     es: "Formularios de catalogación"
+    pl: Formularze katalogowania
 doc_tag_index:
   label:
     it: indice dei campi MARC
     de: MARC Tag Index
     en: MARC tag index
     es: "Índice de etiquetas MARC"
+    pl: Indeks znaczników MARC
 doc_templates:
   label:
     it: Template
     de: Templates
     en: Templates
     es: Plantillas
+    pl: Szablony
 "000":
   label:
     it: Leader
@@ -55,6 +63,7 @@ doc_templates:
     de: Leader
     en: Leader
     es: "Líder"
+    pl: Leader
 "001":
   label:
     it: Numero documento RISM
@@ -62,6 +71,7 @@ doc_templates:
     de: RISM Dokumentnummer
     en: RISM ID no.
     es: "Número de ID de RISM"
+    pl: RISM ID
 "003":
   label:
     it: Identificatore del numero di controllo
@@ -69,6 +79,7 @@ doc_templates:
     de: Kontrollnummer-Bezeichnung
     en: Control number identifier
     es: "Identificador de número de control"
+    pl: Identyfikator numeru kontrolnego
 "005":
   label:
     it: Data e ora dell'ultima transazione
@@ -76,6 +87,7 @@ doc_templates:
     de: Datum und Zeit der letzten Transaktion
     en: Date and time of last transaction
     es: "Fecha y hora de la última transacción"
+    pl: Data i godzina ostatniej operacji
 "008":
   label:
     it: Data di creazione
@@ -83,6 +95,7 @@ doc_templates:
     de: Datum der Erstellung
     en: Date of creation
     es: "Fecha de creación"
+    pl: Data utworzenia
 "024":
   label:
     it: "Riferimento autorità"
@@ -90,6 +103,7 @@ doc_templates:
     de: Normdatenverweise
     en: Authority Reference
     es: Referencia de autoridad
+    pl: Odniesienie do bazy haseł wzorcowych
   fields:
     a:
       label:
@@ -98,6 +112,7 @@ doc_templates:
         de: Normdatenverweise
         en: Authority Reference
         es: Referencia de autoridad
+        pl: Odniesienie do bazy haseł wzorcowych
     "2":
       label:
         it: "Agenzia autorità"
@@ -105,6 +120,7 @@ doc_templates:
         de: Normdatenagentur
         en: Authority Agency
         es: Agencia de autoridad
+        pl: Baza haseł wzorcowych
 "034":
   label:
     it: Posizione
@@ -112,6 +128,7 @@ doc_templates:
     de: Position
     en: Location
     es: Ubicación
+    pl: Lokalizacja
   fields:
     d:
       label:
@@ -120,6 +137,7 @@ doc_templates:
         de: Längengrad 
         en: Longitude
         es: Longitud
+        pl: Długość geograficzna
     f:
       label:
         it: Latitudine
@@ -127,6 +145,7 @@ doc_templates:
         de: Breitengrad 
         en: Latitude
         es: Latitud
+        pl: Szerokość geograficzna
 "040":
   label:
     it: Fonte della catalogazione
@@ -134,6 +153,7 @@ doc_templates:
     de: Katalogisierungsquelle
     en: Cataloguing agency
     es: "Agencia de catalogación"
+    pl: Jednostka katalogująca
   fields:
     a:
       label:
@@ -142,6 +162,7 @@ doc_templates:
         de: Original-Katalogisierungsstelle
         en: Original cataloguing agency
         es: "Agencia de catalogación original"
+        pl: Jednostka katalogująca pierwotny rekord
     b:
       label:
         it: Lingua della catalogazione
@@ -149,6 +170,7 @@ doc_templates:
         de: Katalogisierungssprache
         en: Language of cataloguing
         es: "Idioma de la catalogación"
+        pl: Język katalogowania
     c:
       label:
         it: Agenzia della trascrizione
@@ -156,6 +178,7 @@ doc_templates:
         de: "Übertragende Katalogisierungsstelle"
         en: Transcribing agency
         es: "Agencia de la transcripción"
+        pl: Jednostka transkrybująca
     d:
       label:
         it: Agenzia della modifica
@@ -163,6 +186,7 @@ doc_templates:
         de: Modifizierende Katalogisierungsstelle
         en: Modifying agency
         es: "Agencia de la modificación"
+        pl: Jednostka modyfikująca
 
 
 "043":
@@ -172,6 +196,7 @@ doc_templates:
     de: Länder-Code
     en: Country code
     es: "Código de país"
+    pl: Kod kraju
   fields:
     c:
       label:
@@ -180,6 +205,7 @@ doc_templates:
         de: Länder-Code  
         en: Country code
         es: "Código de país"
+        pl: Kod kraju
 "110":
   label:
     it: Nome di ente
@@ -187,6 +213,7 @@ doc_templates:
     de: "Körperschaftsname"
     en: Institution
     es: "Institución"
+    pl: Instytucja
   accepts: 
   - "710"
   fields:
@@ -197,6 +224,7 @@ doc_templates:
         de: "Körperschaftsname"
         en: Institution
         es: "Institución"
+        pl: Instytucja
     b:
       label:
         it: Ente subordinato
@@ -204,6 +232,7 @@ doc_templates:
         de: "Untergeordnete Körperschaft"
         en: Subordinate unit
         es: Unidad subordinada
+        pl: Jednostka podporządkowana
     c:
       label:
         it: Luogo
@@ -211,6 +240,7 @@ doc_templates:
         de: Ort
         en: Place
         es: Lugar
+        pl: Miejsce
     g:
       label:
         it: Sigla
@@ -218,6 +248,7 @@ doc_templates:
         de: "Sigel"
         en: Siglum
         es: Sigla
+        pl: Siglum
 "368":
   label:
     it: Tipo di ente
@@ -225,6 +256,7 @@ doc_templates:
     de: Typ der Körperschaft
     en: Type of Institution
     es: "Tipo de institución"
+    pl: Rodzaj instytucji
   fields:
     a:
       label:
@@ -233,6 +265,7 @@ doc_templates:
         de: Typ der Körperschaft
         en: Type of institution
         es: "Tipo de institución"
+        pl: Rodzaj instytucji
 "371":
   label:
     it: Luogo ed indirizzo
@@ -240,6 +273,7 @@ doc_templates:
     de: "Adresse"
     en: Location and Address
     es: "Ubicación y dirección"
+    pl: Lokalizacja i adres
   fields:
     a:
       label:
@@ -248,6 +282,7 @@ doc_templates:
         de: Strasse
         en: Street address
         es: "Calle y número"
+        pl: Ulica, numer, numer lokalu
     e:
       label:
         it: Codice postale
@@ -255,6 +290,7 @@ doc_templates:
         de: Postleitzahl
         en: Postal code
         es: "Código postal"
+        pl: Kod pocztowy
     b:
       label:
         it: "Città"
@@ -262,6 +298,7 @@ doc_templates:
         de: Ort
         en: City
         es: Ciudad
+        pl: Miejscowość
     c:
       label:
         it: Cantone o provincia
@@ -269,6 +306,7 @@ doc_templates:
         de: Bezirk oder Staat
         en: County or province
         es: "País o provincia"
+        pl: Stan, hrabstwo, prowincja...
     d:
       label:
         it: Paese
@@ -276,6 +314,7 @@ doc_templates:
         de: Land
         en: Country
         es: "País"
+        pl: Kraj
     m:
       label:
         it: E-mail
@@ -283,6 +322,7 @@ doc_templates:
         de: E-Mail
         en: E-mail
         es: E-mail
+        pl: E-mail
     u:
       label:
         it: URL
@@ -290,6 +330,7 @@ doc_templates:
         de: URL
         en: URL
         es: URL
+        pl: URL
     z:
       label:
         it: Altri dati sul contatto
@@ -297,6 +338,7 @@ doc_templates:
         de: Bemerkungen
         en: Public Note
         es: "Nota pública"
+        pl: Inne informacje kontaktowe
 "410":
   label:
     it: Altre forme del nome
@@ -304,14 +346,16 @@ doc_templates:
     de: Andere Namensformen
     en: Other form of name
     es: Otra forma del nombre
+    pl: Wariant nazwy instytucji
   fields:
     a:
       label:
-        t: Altre forme del nome
+        it: Altre forme del nome
         fr: Autre forme de nom
         de: Andere Namensformen
         en: Other form of name
         es: Otra forma del nombre
+        pl: Wariant nazwy instytucji
 "510":
   label:
     it: Forma parallela del nome
@@ -319,6 +363,7 @@ doc_templates:
     de: Parallele Namensformen
     en: Parallel form of name
     es: Forma paralela del nombre
+    pl: Współistniejąca forma nazwy
   fields:
     a:
       label:
@@ -327,6 +372,7 @@ doc_templates:
         de: Namensvarianten  
         en: Parallel form of name
         es: Forma paralela del nombre
+        pl: Współistniejąca forma nazwy
 "551":
   label:
     it: Luoghi
@@ -334,6 +380,7 @@ doc_templates:
     de: Orte
     en: Places
     es: Lugares
+    pl: Miejsca
   fields:
     a:
       label:
@@ -342,6 +389,7 @@ doc_templates:
         de: Ort
         en: Place
         es: Lugares
+        pl: Miejsce
 "580":
   label:
     it: Ora in
@@ -349,14 +397,16 @@ doc_templates:
     de: Heute in
     en: Now in
     es: Actualmente en
+    pl: Obecnie w …
   fields:
     x:
       label:
-        t: Ora in
+        it: Ora in
         fr: Maintenant à
         de: Heute in
         en: Now in
         es: Actualmente en
+        pl: Obecnie w …
 "667":
   label:
     it: Nota interna
@@ -364,6 +414,7 @@ doc_templates:
     de: Interne Bemerkungen
     en: Internal Notes
     es: Notas internas
+    pl: Uwagi wewnętrzne
   fields:
     a:
       label:
@@ -372,6 +423,7 @@ doc_templates:
         de: Interne Bemerkungen
         en: Internal notes
         es: Notas internas
+        pl: Uwagi wewnętrzne
 "670":
   label:
     it: Bibliografia
@@ -379,6 +431,7 @@ doc_templates:
     de: Literatur
     en: Literature
     es: Bibliografía
+    pl: Literatura
   fields:
     a:
       label:
@@ -387,6 +440,7 @@ doc_templates:
         de: Literatur
         en: Literature
         es: Bibliografía
+        pl: Literatura
     b:
       label:
         it: Informazione rinvenuta
@@ -394,6 +448,7 @@ doc_templates:
         de: Fundstelle
         en: Information found
         es: Información encontrada
+        pl: Odnaleziona informacja
 "678":
   label:
     it: "Storia dell'ente"
@@ -401,6 +456,7 @@ doc_templates:
     de: Geschichte der Körperschaft
     en: History of institution
     es: "Historia de la institución"
+    pl: Historia instytucji
   fields:
     a:
       label:
@@ -409,6 +465,7 @@ doc_templates:
         de: Geschichte der Körperschaft
         en: History of institution
         es: "Historia de la institución"
+        pl: Historia instytucji
 "680":
   label:
     it: Altre note sulla descrizione
@@ -416,6 +473,7 @@ doc_templates:
     de: Allgemeine Fussnote
     en: General note
     es: Nota general
+    pl: Uwaga ogólna
   fields:
     a:
       label:
@@ -424,6 +482,7 @@ doc_templates:
         de: Allgemeine Fussnote
         en: General note
         es: Nota general
+        pl: Uwaga ogólna
 "700":
   label:
     it: Persona
@@ -431,6 +490,7 @@ doc_templates:
     de: Person
     en: Person
     es: Persona
+    pl: Osoba
   fields:
     a:
       label:
@@ -439,6 +499,7 @@ doc_templates:
         de: Person
         en: Person
         es: Persona
+        pl: Osoba
 
 "710":
   label:
@@ -447,6 +508,7 @@ doc_templates:
     de: in Beziehung stehende Körpschaft
     en: Related institution
     es: "Institución relacionada"
+    pl: Powiązana instytucja
   fields:
     a:
       label:
@@ -455,6 +517,7 @@ doc_templates:
         de: In Beziehung stehende Körperschaft
         en: Related institution
         es: "Institución relacionada"
+        pl: Powiązana instytucja
 
 "856":
   label:
@@ -463,6 +526,7 @@ doc_templates:
     de: Archivführer und andere Publikationen
     en: Online finding aids
     es: Asistencia online encontrada
+    pl: Pomoce do wyszukiwania on-line
   fields:
     u:
       label:
@@ -471,6 +535,7 @@ doc_templates:
         de: Archivführer und andere Publikationen
         en: Online finding aids
         es: Asistencia online encontrada
+        pl: Pomoce do wyszukiwania on-line
     z:
       label:
         it: Nota
@@ -478,6 +543,7 @@ doc_templates:
         de: Bemerkung
         en: Note
         es: Nota
+        pl: Uwaga
 
 
 main:
@@ -487,6 +553,7 @@ main:
     de: Haupteintragungen
     en: Main entry fields
     es: Campos principales
+    pl: Główne pola edycji
 codes:
   label:
     it: Numeri e codici
@@ -494,6 +561,7 @@ codes:
     de: Nummern und Codes
     en: Numbers and code fields
     es: Números y códigos
+    pl: Pola liczb i kodów
 control:
   label:
     fr: "Champs de contrôle"
@@ -501,6 +569,7 @@ control:
     it: Campi di controllo
     en: Control Fields
     es: Campos de control
+    pl: Pola kontrolne
 notes:
   label:
     it: Note
@@ -508,6 +577,7 @@ notes:
     de: Fussnoten
     en: Note fields
     es: Notas
+    pl: Pola uwag
 other:
   label:
     it: Varia
@@ -515,6 +585,7 @@ other:
     de: Verschiedenes
     en: Miscellaneous
     es: Varios
+    pl: Pozostałe
 administration:
   label:
     it: Amministrazione
@@ -522,6 +593,7 @@ administration:
     de: Administration
     en: Administration
     es: Administración
+    pl: Administracja
 sigla:
   label:
     it: Sigla
@@ -529,6 +601,7 @@ sigla:
     de: Sigel
     en: Sigla
     es: Sigla
+    pl: Sigla
 contact:
   label:
     it: Contatto
@@ -536,6 +609,7 @@ contact:
     de: Kontakt
     en: Contact
     es: Contacto
+    pl: Kontakt
 identity:
   label:
     it: "Identità"
@@ -543,6 +617,7 @@ identity:
     de: Identifizierung
     en: Identity
     es: Identidad
+    pl: Tożsamość
 description:
   label:
     it: Descrizione
@@ -550,6 +625,7 @@ description:
     de: Beschreibung
     en: Description
     es: Decripción
+    pl: Opis
 
 
 
@@ -562,6 +638,7 @@ description:
     de: Verfasser
     en: Artistic production
     es: "Producción artística"
+    pl: Autor produkcji artystycznej
 02_codes_performing:
   label:
     it: Partecipanti
@@ -569,6 +646,7 @@ description:
     de: Mitwirkende
     en: Performance
     es: Interpretación
+    pl: Wykonanie
 03_codes_technical:
   label:
     it: Produttore
@@ -576,6 +654,7 @@ description:
     de: Hersteller
     en: Technical production
     es: "Producción técncia"
+    pl: Produkcja techniczna
 04_codes_other:
   label:
     it: Altri
@@ -583,6 +662,7 @@ description:
     de: Weitere
     en: Other
     es: Otro
+    pl: Pozostałe
 ed:
   label:
     it: Edizione
@@ -590,6 +670,7 @@ ed:
     de: Edition
     en: Edition
     es: Edición
+    pl: Edycja
 H:
   label:
     it: Curatore
@@ -597,6 +678,7 @@ H:
     de: Herausgeber
     en: Editor
     es: "Editor (curador)/Editorial"
+    pl: Edytor
 arr:
   label:
     it: Arrangiatore
@@ -604,6 +686,7 @@ arr:
     de: Bearbeiter
     en: Arranger
     es: Arreglador
+    pl: Aranżer
 art:
   label:
     it: Scenografo
@@ -611,6 +694,7 @@ art:
     de: "Bühnenbildner"
     en: Artist
     es: Artista
+    pl: Artysta
 asn:
   label:
     it: Altro nome
@@ -618,6 +702,7 @@ asn:
     de: Weiterer Name
     en: Associated name
     es: Nombre asociado
+    pl: Powiązana osoba
 aut:
   label:
     it: Autore
@@ -625,6 +710,7 @@ aut:
     de: Autor
     en: Author
     es: Autor
+    pl: Autor
 bnd:
   label:
     it: Rilegatore
@@ -632,6 +718,7 @@ bnd:
     de: Buchbinder
     en: Binder
     es: Encuadernador
+    pl: Introligator
 bsl:
   label:
     it: Libraio musicale
@@ -639,6 +726,7 @@ bsl:
     de: "Musikalienhändler"
     en: Bookseller
     es: Librero
+    pl: Księgarz
 ccp:
   label:
     it: Autore della fonte letteraria
@@ -646,6 +734,7 @@ ccp:
     de: Autor der Textvorlage
     en: Conceptor
     es: Autor del concepto
+    pl: Autor koncepcji
 chr:
   label:
     it: Coreografo
@@ -653,6 +742,7 @@ chr:
     de: Choreograph
     en: Choreographer
     es: "Coreógrafo"
+    pl: Choreograf
 clb:
   label:
     it: Autore secondario
@@ -660,6 +750,7 @@ clb:
     de: Mitverfasser
     en: Collaborator
     es: Colaborador
+    pl: Współtwórca
 cmp:
   label:
     it: Compositore/Compositore secondario
@@ -667,6 +758,7 @@ cmp:
     de: Komponist / Mitkomponist
     en: Composer
     es: Compositor
+    pl: Kompozytor
 cnd:
   label:
     it: Direttore d'orchestra
@@ -674,6 +766,7 @@ cnd:
     de: Dirigent
     en: Conductor
     es: Director musical
+    pl: Dyrygent
 cns:
   label:
     it: Censore
@@ -681,6 +774,7 @@ cns:
     de: Zensor
     en: Censor
     es: Censor
+    pl: Cenzor
 com:
   label:
     it: Compilatore
@@ -688,6 +782,7 @@ com:
     de: Kompilator
     en: Compiler
     es: Compilador
+    pl: Kompilator
 cst:
   label:
     it: Costumista
@@ -695,6 +790,7 @@ cst:
     de: "Kostümbildner"
     en: Costume designer
     es: Vestuarista
+    pl: Projektant kostiumów
 dnc:
   label:
     it: Ballerino
@@ -702,6 +798,7 @@ dnc:
     de: "Tänzer"
     en: Dancer
     es: Bailarín(a)
+    pl: Tancerz
 dnr:
   label:
     it: Donatore
@@ -709,6 +806,7 @@ dnr:
     de: Donator
     en: Donor
     es: Donante
+    pl: Donator
 dte:
   label:
     it: Dedicatario
@@ -716,6 +814,7 @@ dte:
     de: "Widmungsträger"
     en: Dedicatee
     es: Dedicatario
+    pl: Adresat dedykacji
 asn: 
   label: 
     it: Nome associato
@@ -724,6 +823,7 @@ asn:
     en: Associated name
     es: Nombre asociado
     pt: Nome associado
+    pl: Powiązana osoba
 edt:
   label:
     it: Curatore
@@ -731,6 +831,7 @@ edt:
     de: Herausgeber
     en: Editor
     es: Editor (curador)
+    pl: Edytor
 egr:
   label:
     it: Incisore
@@ -738,6 +839,7 @@ egr:
     de: Stecher
     en: Engraver
     es: Grabador
+    pl: Rytownik
 fmo:
   label:
     it: Proprietario precedente
@@ -745,6 +847,7 @@ fmo:
     de: Vorbesitzer
     en: Former owner
     es: Propietario anterior
+    pl: Poprzedni właściciel
 ill:
   label:
     it: Disegnatore
@@ -752,6 +855,7 @@ ill:
     de: Illustrator
     en: Illustrator
     es: Ilustrador
+    pl: Ilustrator
 itr:
   label:
     it: Strumentista
@@ -759,6 +863,7 @@ itr:
     de: Instrumentalist
     en: Instrumentalist
     es: Instrumentista
+    pl: Instrumentalista
 lbt:
   label:
     it: Librettista
@@ -766,6 +871,7 @@ lbt:
     de: Librettist
     en: Librettist
     es: Libretista
+    pl: Autor libretta
 ltg:
   label:
     it: Litografo
@@ -773,6 +879,7 @@ ltg:
     de: Lithograph
     en: Lithograph
     es: Litógrafo
+    pl: Litograf
 lyr:
   label:
     it: Poeta
@@ -780,6 +887,7 @@ lyr:
     de: Textdichter
     en: Lyricist
     es: Letrista
+    pl: Autor słów
 otm:
   label:
     it: Organizzatore
@@ -787,6 +895,7 @@ otm:
     de: Veranstalter
     en: Event organizer
     es: "Organizador del evento"
+    pl: Organizator wydarzenia
 pat:
   label:
     it: Committente
@@ -794,6 +903,7 @@ pat:
     de: "Mäzen/Auftraggeber"
     en: Patron
     es: Comitente
+    pl: Sponsor
 pbl:
   label:
     it: Editore
@@ -801,6 +911,7 @@ pbl:
     de: Verleger
     en: Publisher
     es: "Editor (publicador)/Editorial (publicadora)"
+    pl: Wydawca
 ppm:
   label:
     it: Fabbricante di carta
@@ -808,6 +919,7 @@ ppm:
     de: Papierhersteller
     en: Paper maker
     es: "Fabricante de papel"
+    pl: Producent papieru
 prd:
   label:
     it: Personale alla produzione
@@ -815,6 +927,7 @@ prd:
     de: Produktionspersonal
     en: Production personnel
     es: "Personal de producción"
+    pl: Personel produkcyjny
 prf:
   label:
     it: Interprete
@@ -822,6 +935,7 @@ prf:
     de: Interpret
     en: Performer
     es: "Intérprete"
+    pl: Wykonawca
 prt:
   label:
     it: Stampatore
@@ -829,6 +943,7 @@ prt:
     de: Drucker
     en: Printer
     es: Impresor
+    pl: Drukarnia
 scr:
   label:
     it: Copista
@@ -836,6 +951,7 @@ scr:
     de: Schreiber
     en: Scribe
     es: Copista
+    pl: Kopista
 trl:
   label:
     it: Traduttore
@@ -843,6 +959,7 @@ trl:
     de: "Übersetzer"
     en: Translator
     es: Traductor
+    pl: Tłumacz
 voc:
   label:
     it: Cantante
@@ -850,6 +967,7 @@ voc:
     de: "Sänger"
     en: Vocalist
     es: Cantante
+    pl: Wokalista
 #Country Codes
 "XC-DZ":
   label:
@@ -858,6 +976,7 @@ voc:
     de: "Algeria"
     en: "Algeria"
     es: "Argelia"
+    pl: Algieria
 "XD-AR":
   label:
     it: "Argentina"
@@ -865,6 +984,7 @@ voc:
     de: "Argentina"
     en: "Argentina"
     es: "Argentina"
+    pl: Argentyna
 "XB-AM":
   label:
     it: "Armenia"
@@ -872,6 +992,7 @@ voc:
     de: "Armenia"
     en: "Armenia"
     es: "Armenia"
+    pl: Armenia
 "XE-AU":
   label:
     it: "Australia"
@@ -879,6 +1000,7 @@ voc:
     de: "Australia"
     en: "Australia"
     es: "Australia"
+    pl: Australia
 "XA-AT":
   label:
     it: "Austria"
@@ -886,6 +1008,7 @@ voc:
     de: "Austria"
     en: "Austria"
     es: "Austria"
+    pl: Austria
 "XA-AT-2":
   label:
     it: "Austria: Carinzia"
@@ -893,6 +1016,7 @@ voc:
     de: "Austria: Carinthia"
     en: "Austria: Carinthia"
     es: "Austria: Carintia"
+    pl: Austria: Karyntia
 "XA-AT-3":
   label:
     it: "Austria: Austria Inferiore"
@@ -900,6 +1024,7 @@ voc:
     de: "Austria: Lower Austria"
     en: "Austria: Lower Austria"
     es: "Austria: Baja Austria"
+    pl: Austria: Dolna Austria
 "XA-AT-5":
   label:
     it: "Austria: Salisburgo"
@@ -907,6 +1032,7 @@ voc:
     de: "Austria: Salzburg"
     en: "Austria: Salzburg"
     es: "Austria: Salzburgo"
+    pl: Austria: Salzburg
 "XA-AT-6":
   label:
     it: "Austria: Stiria"
@@ -914,6 +1040,7 @@ voc:
     de: "Austria: Styria"
     en: "Austria: Styria"
     es: "Austria: Estiria"
+    pl: Austria: Styria
 "XA-AT-7":
   label:
     it: "Austria: Tirole"
@@ -921,6 +1048,7 @@ voc:
     de: "Austria: Tyrol"
     en: "Austria: Tyrol"
     es: "Austria: Tirol"
+    pl: Austria: Tyrol
 "XA-AT-4":
   label:
     it: "Austria: Austria Superiore"
@@ -928,6 +1056,7 @@ voc:
     de: "Austria: Upper Austria"
     en: "Austria: Upper Austria"
     es: "Austria: Alta Austria"
+    pl: Austria: Górna Austria
 "XA-AT-9":
   label:
     it: "Austria: Vienna"
@@ -935,6 +1064,7 @@ voc:
     de: "Austria: Vienna"
     en: "Austria: Vienna"
     es: "Austria: Viena"
+    pl: Austria: Wiedeń
 "XA-BE":
   label:
     it: "Belgio"
@@ -942,6 +1072,7 @@ voc:
     de: "Belgium"
     en: "Belgium"
     es: "Bélgica"
+    pl: Belgia
 "XC-BJ":
   label:
     it: "Benin"
@@ -949,6 +1080,7 @@ voc:
     de: "Benin"
     en: "Benin"
     es: "Benín"
+    pl: Benin
 "XD-BR":
   label:
     it: "Brasile"
@@ -956,6 +1088,7 @@ voc:
     de: "Brazil"
     en: "Brazil"
     es: "Brasil"
+    pl: Brazylia
 "XA-BG":
   label:
     it: "Bulgaria"
@@ -963,6 +1096,7 @@ voc:
     de: "Bulgaria"
     en: "Bulgaria"
     es: "Bulgaria"
+    pl: Bułgaria
 "XB-KH":
   label:
     it: "Cambogia"
@@ -970,6 +1104,7 @@ voc:
     de: "Cambodia"
     en: "Cambodia"
     es: "Camboya"
+    pl: Kambodża
 "XD-CA":
   label:
     it: "Canada"
@@ -977,6 +1112,7 @@ voc:
     de: "Canada"
     en: "Canada"
     es: "Canadá"
+    pl: Kanada
 "XD-CL":
   label:
     it: "Cile"
@@ -984,6 +1120,7 @@ voc:
     de: "Chile"
     en: "Chile"
     es: "Chile"
+    pl: Chile
 "XB-CN":
   label:
     it: "Cina"
@@ -991,6 +1128,7 @@ voc:
     de: "China"
     en: "China"
     es: "China"
+    pl: Chiny
 "XD-CO":
   label:
     it: "Colombia"
@@ -998,6 +1136,7 @@ voc:
     de: "Colombia"
     en: "Colombia"
     es: "Colombia"
+    pl: Kolumbia
 "XA-HR":
   label:
     it: "Croazia"
@@ -1005,6 +1144,7 @@ voc:
     de: "Croatia"
     en: "Croatia"
     es: "Croacia"
+    pl: Chorwacja
 "XD-CU":
   label:
     it: "Cuba"
@@ -1012,6 +1152,7 @@ voc:
     de: "Cuba"
     en: "Cuba"
     es: "Cuba"
+    pl: Kuba
 "XA-CZ":
   label:
     it: "Repubblica Ceca"
@@ -1019,6 +1160,7 @@ voc:
     de: "Czech Republic"
     en: "Czech Republic"
     es: "República Checa"
+    pl: Czechy
 "XA-DK":
   label:
     it: "Danimarca"
@@ -1026,6 +1168,7 @@ voc:
     de: "Denmark"
     en: "Denmark"
     es: "Dinamarca"
+    pl: Dania
 "XC-EG":
   label:
     it: "Egitto"
@@ -1033,6 +1176,7 @@ voc:
     de: "Egypt"
     en: "Egypt"
     es: "Egipto"
+    pl: Egipt
 "XA-EE":
   label:
     it: "Estonia"
@@ -1040,6 +1184,7 @@ voc:
     de: "Estonia"
     en: "Estonia"
     es: "Estonia"
+    pl: Estonia
 "XA-FI":
   label:
     it: "Finlandia"
@@ -1047,6 +1192,7 @@ voc:
     de: "Finland"
     en: "Finland"
     es: "Finlandia"
+    pl: Finlandia
 "XA-FR":
   label:
     it: "Francia"
@@ -1054,6 +1200,7 @@ voc:
     de: "France"
     en: "France"
     es: "Francia"
+    pl: Francja
 "XA-DE":
   label:
     it: "Germania"
@@ -1061,6 +1208,7 @@ voc:
     de: "Germany"
     en: "Germany"
     es: "Alemania"
+    pl: Niemcy
 "XA-DE-BY":
   label:
     it: "Germania: Baviera"
@@ -1068,6 +1216,7 @@ voc:
     de: "Germany: Bavaria"
     en: "Germany: Bavaria"
     es: "Alemania: Bavaria"
+    pl: Niemcy: Bawaria
 "XA-DE-SN":
   label:
     it: "Germania: Sassonia"
@@ -1075,6 +1224,7 @@ voc:
     de: "Germany: Saxony"
     en: "Germany: Saxony"
     es: "Alemania: Sajonia"
+    pl: Niemcy: Saksonia
 "XA-GR":
   label:
     it: "Grecia"
@@ -1082,6 +1232,7 @@ voc:
     de: "Greece"
     en: "Greece"
     es: "Grecia"
+    pl: Grecja
 "XD-GT":
   label:
     it: "Guatemala"
@@ -1089,6 +1240,7 @@ voc:
     de: "Guatemala"
     en: "Guatemala"
     it: "Guatemala"
+    pl: Gwatemala
 "XA-VA":
   label:
     it: "Santa Sede"
@@ -1096,6 +1248,7 @@ voc:
     de: "Holy See"
     en: "Holy See"
     es: "Santa Sede"
+    pl: Watykan
 "XD-HN":
   label:
     it: "Honduras"
@@ -1103,6 +1256,7 @@ voc:
     de: "Honduras"
     en: "Honduras"
     es: "Honduras"
+    pl: Honduras
 "XA-HU":
   label:
     it: "Ungheria"
@@ -1110,6 +1264,7 @@ voc:
     de: "Hungary"
     en: "Hungary"
     es: "Hungría"
+    pl: Węgry
 "XA-IS":
   label:
     it: "Islanda"
@@ -1117,6 +1272,7 @@ voc:
     de: "Iceland"
     en: "Iceland"
     es: "Islandia"
+    pl: Islandia
 "XB-IN":
   label:
     it: "India"
@@ -1124,6 +1280,7 @@ voc:
     de: "India"
     en: "India"
     es: "India"
+    pl: Indie
 "XB-IR":
   label:
     it: "Iran, Repubblica Islamica dell'"
@@ -1131,6 +1288,7 @@ voc:
     de: "Iran, Islamic Republic of"
     en: "Iran, Islamic Republic of"
     es: "Irán, República Islámica de"
+    pl: Iran, Republika Islamska
 "XA-IE":
   label:
     it: "Irlanda"
@@ -1138,6 +1296,7 @@ voc:
     de: "Ireland"
     en: "Ireland"
     es: "Irlanda"
+    pl: Irlandia
 "XB-IL":
   label:
     it: "Israele"
@@ -1145,6 +1304,7 @@ voc:
     de: "Israel"
     en: "Israel"
     es: "Israel"
+    pl: Izrael
 "XA-IT-32":
   label:
     it: "Italia: Trentino-Alto Adige"
@@ -1152,6 +1312,7 @@ voc:
     de: "Italy: Trentino-Alto Adige"
     en: "Italy: Trentino-Alto Adige"
     es: "Italia: Trentino-Alto Adigio"
+    pl: Włochy: Trentino-Alto Adige
 "XA-IT":
   label:
     it: "Italia"
@@ -1159,6 +1320,7 @@ voc:
     de: "Italy"
     en: "Italy"
     es: "Italia"
+    pl: Włochy
 "XB-JP":
   label:
     it: "Giappone"
@@ -1166,6 +1328,7 @@ voc:
     de: "Japan"
     en: "Japan"
     es: "Japón"
+    pl: Japonia
 "XB-KR":
   label:
     it: "Corea, Repubblica di"
@@ -1173,6 +1336,7 @@ voc:
     de: "Korea, Republic of"
     en: "Korea, Republic of"
     es: "Corea, República de"
+    pl: Korea, Republika
 "XA-LV":
   label:
     it: "Lettonia"
@@ -1180,6 +1344,7 @@ voc:
     de: "Latvia"
     en: "Latvia"
     es: "Letonia"
+    pl: Łotwa
 "XA-LT":
   label:
     it: "Lituania"
@@ -1187,6 +1352,7 @@ voc:
     de: "Lithuania"
     en: "Lithuania"
     es: "Lituania"
+    pl: Litwa
 "XA-LU":
   label:
     it: "Lussemburgo"
@@ -1194,6 +1360,7 @@ voc:
     de: "Luxembourg"
     en: "Luxembourg"
     es: "Luxemburgo"
+    pl: Luksemburg
 "XA-MT":
   label:
     it: "Malta"
@@ -1201,6 +1368,7 @@ voc:
     de: "Malta"
     en: "Malta"
     es: "Malta"
+    pl: Malta
 "XD-MX":
   label:
     it: "Messico"
@@ -1208,6 +1376,7 @@ voc:
     de: "Mexico"
     en: "Mexico"
     es: "México"
+    pl: Meksyk
 "XA-ME":
   label:
     it: "Montenegro"
@@ -1215,6 +1384,7 @@ voc:
     de: "Montenegro"
     en: "Montenegro"
     es: "Montenegro"
+    pl: Czarnogóra
 "XA-NL":
   label:
     it: "Paesi Bassi"
@@ -1222,6 +1392,7 @@ voc:
     de: "Netherlands"
     en: "Netherlands"
     es: "Países Bajos"
+    pl: Niderlandy
 "XE-NZ":
   label:
     it: "Nuova Zelanda"
@@ -1229,6 +1400,7 @@ voc:
     de: "New Zealand"
     en: "New Zealand"
     es: "Nueva Zelanda"
+    pl: Nowa Zelandia
 "XA-NO":
   label:
     it: "Norvegia"
@@ -1236,6 +1408,7 @@ voc:
     de: "Norway"
     en: "Norway"
     es: "Noruega"
+    pl: Norwegia
 "XD-PY":
   label:
     it: "Paraguay"
@@ -1243,6 +1416,7 @@ voc:
     de: "Paraguay"
     en: "Paraguay"
     es: "Paraguay"
+    pl: Paragwaj
 "XA-PL":
   label:
     it: "Polonia"
@@ -1250,6 +1424,7 @@ voc:
     de: "Poland"
     en: "Poland"
     es: "Polonia"
+    pl: Polska
 "XA-PT":
   label:
     it: "Portogallo"
@@ -1257,6 +1432,7 @@ voc:
     de: "Portugal"
     en: "Portugal"
     es: "Portugal"
+    pl: Portugalia
 "XD-PR":
   label:
     it: "Puerto Rico"
@@ -1264,6 +1440,7 @@ voc:
     de: "Puerto Rico"
     en: "Puerto Rico"
     es: "Puerto Rico"
+    pl: Portoryko
 "XA-RO":
   label:
     it: "Romania"
@@ -1271,6 +1448,7 @@ voc:
     de: "Romania"
     en: "Romania"
     es: "Rumania"
+    pl: Rumunia
 "XA-RU":
   label:
     it: "Federazione Russa"
@@ -1278,6 +1456,7 @@ voc:
     de: "Russian Federation"
     en: "Russian Federation"
     es: "Federación Rusa"
+    pl: Federacja Rosyjska
 "XA-RS":
   label:
     it: "Serbia"
@@ -1285,6 +1464,7 @@ voc:
     de: "Serbia"
     en: "Serbia"
     es: "Serbia"
+    pl: Serbia
 "XA-SK":
   label:
     it: "Slovacchia"
@@ -1292,6 +1472,7 @@ voc:
     de: "Slovakia"
     en: "Slovakia"
     es: "Eslovaquia"
+    pl: Słowacja
 "XA-SI":
   label:
     it: "Slovenia"
@@ -1299,6 +1480,7 @@ voc:
     de: "Slovenia"
     en: "Slovenia"
     es: "Eslovenia"
+    pl: Słowenia
 "XC-ZA":
   label:
     it: "Sudafrica"
@@ -1306,6 +1488,7 @@ voc:
     de: "South Africa"
     en: "South Africa"
     es: "Sudáfrica"
+    pl: Republika Południowej Afryki
 "XA-ES":
   label:
     it: "Spagna"
@@ -1313,6 +1496,7 @@ voc:
     de: "Spain"
     en: "Spain"
     es: "España"
+    pl: Hiszpania
 "XA-SE":
   label:
     it: "Svezia"
@@ -1320,6 +1504,7 @@ voc:
     de: "Sweden"
     en: "Sweden"
     es: "Suecia"
+    pl: Szwecja
 "XA-CH-VD":
   label:
     it: "Svizzera: Vaud"
@@ -1327,6 +1512,7 @@ voc:
     de: "Switzerland: Vaud"
     en: "Switzerland: Vaud"
     es: "Suiza: cantón de Vaud"
+    pl: Szwajcaria: kanton Vaud
 "XA-CH":
   label:
     it: "Svizzera"
@@ -1334,6 +1520,7 @@ voc:
     de: "Switzerland"
     en: "Switzerland"
     es: "Suiza"
+    pl: Szwajcaria
 "XB-SY":
   label:
     it: "Repubblica Araba Siriana"
@@ -1341,6 +1528,7 @@ voc:
     de: "Syrian Arab Republic"
     en: "Syrian Arab Republic"
     es: "República Árabe Siria"
+    pl: Syryjska Republika Arabska
 "XD-TT":
   label:
     it: "Trinidad e Tobago"
@@ -1348,6 +1536,7 @@ voc:
     de: "Trinidad and Tobago"
     en: "Trinidad and Tobago"
     es: "Trinidad y Tobago"
+    pl: Trynidad i Tobago
 "XB-TR":
   label:
     it: "Turchia"
@@ -1355,6 +1544,7 @@ voc:
     de: "Turkey"
     en: "Turkey"
     es: "Turquía"
+    pl: Turcja
 "XA-UA":
   label:
     it: "Ucraina"
@@ -1362,6 +1552,7 @@ voc:
     de: "Ukraine"
     en: "Ukraine"
     es: "Ucrania"
+    pl: Ukraina
 "XA-GB":
   label:
     it: "Regno Unito"
@@ -1369,6 +1560,7 @@ voc:
     de: "United Kingdom"
     en: "United Kingdom"
     es: "Reino Unido"
+    pl: Zjednoczone Królestwo
 "XD-US":
   label:
     it: "Stati Uniti d'America"
@@ -1376,6 +1568,7 @@ voc:
     de: "United States of America"
     en: "United States of America"
     es: "Estados Unidos de América"
+    pl: Stany Zjednoczone AP
 "XD-UY":
   label:
     it: "Uruguay"
@@ -1383,6 +1576,7 @@ voc:
     de: "Uruguay"
     en: "Uruguay"
     es: "Uruguay"
+    pl: Urugwaj
 "XD-VE":
   label:
     it: "Venezuela, Repubblica Bolivariana del"
@@ -1390,6 +1584,7 @@ voc:
     de: "Venezuela, Bolivarian Republic of"
     en: "Venezuela, Bolivarian Republic of"
     es: "Venezuela, República Bolivariana de"
+    pl: Wenezuela, Republika Boliwariańska
 "XB-VN":
   label:
     it: "Vietnam"
@@ -1397,6 +1592,7 @@ voc:
     de: "Viet Nam"
     en: "Viet Nam"
     es: "Vietnam"
+    pl: Wietnam
 "XD-EC":
   label:
     it: "Ecuador"
@@ -1404,6 +1600,7 @@ voc:
     de: "Ecuador"
     en: "Ecuador"
     es: "Ecuador"
+    pl: Ekwador
 "Library":
   label:
     it: "Biblioteca"
@@ -1411,6 +1608,7 @@ voc:
     de: "Bibliothek"
     en: "Library"
     es: "Biblioteca"
+    pl: Biblioteka
 "Archive":
   label:
     it: "Archivio"
@@ -1418,6 +1616,7 @@ voc:
     de: "Archiv"
     en: "Archive"
     es: "Archivo"
+    pl: Archiwum
 "Publisher":
   label:
     it: Editore
@@ -1425,6 +1624,7 @@ voc:
     de: Verleger
     en: Publisher
     es: "Editor (Publicador)/Editorial"
+    pl: Wydawca
 "Other":
   label:
     it: Altri
@@ -1432,30 +1632,35 @@ voc:
     de: Weitere
     en: Other
     es: Otro
+    pl: Pozostałe
 "Institution":
   label:
     it: "Ente collettivo"
     fr: "Institution"
     de: "Körperschaft"
     en: "Institution"
+    pl: Instytucja
 "Documentation center":
   label:
     it: "Centro di documentazione"
     fr: "DOCUMENTATION CENTER"
     de: "Dokumentationszentrum"
     en: "Documentation center"
+    pl: Centrum dokumentacji
 "Museum":
   label:
     it: "Museo"
     fr: "MUSEUM"
     de: "Museum"
     en: "Museum"
+    pl: Muzeum
 "Printer":
   label:
     it: "Stampatore"
     fr: "PRINTER"
     de: "Druckerei"
     en: "Printer"
+    pl: Drukarnia
 "Research institute":
   label:
     it: "Istituto di ricerca"
@@ -1463,3 +1668,4 @@ voc:
     de: "Forschungsinstitut"
     en: "Research institute"
     es: "Institución"
+    pl: Instytut badawczy

--- a/config/editor_profiles/default/configurations/PersonLabels.yml
+++ b/config/editor_profiles/default/configurations/PersonLabels.yml
@@ -5,48 +5,56 @@ doc_abbreviations:
     de: "Abkürzungen"
     en: Abbreviations
     es: Abreviaturas
+    pl: Skróty
 doc_aid:
   label:
     it: Aiuti
     de: Arbeitshilfen
     en: Aide
     es: Asistencia
+    pl: Asystent
 doc_cataloguing_collections:
   label:
     it: Catalogazione di raccolte e volumi compositi
     de: Erfassung von Sammlungen
     en: Cataloging collection and convoluta
     es: "Catalogación de colecciones y volúmenes compuestos"
+    pl: Katalogowanie kolekcji i klocka introligatorskiego
 doc_edit_functions:
   label:
     it: Funzioni base
     de: "Grundsätzliche Funktionen"
     en: Basic functions
     es: "Funciones básicas"
+    pl: Podstawowe funkcje
 doc_introduction:
   label:
     it: Introduzione
     de: Einleitung
     en: Introduction
     es: "Introducción"
+    pl: Wprowadzenie
 doc_masks:
   label:
     it: Formulari di catalogazione
     de: Masken
     en: Cataloging forms
     es: "Formularios de catalogación"
+    pl: Formularze katalogowania
 doc_tag_index:
   label:
     it: indice dei campi MARC
     de: MARC Tag Index
     en: MARC tag index
     es: "Índice de etiquetas MARC"
+    pl: Indeks znaczników MARC
 doc_templates:
   label:
     it: Template
     de: Templates
     en: Templates
     es: Plantillas
+    pl: Szablony
 
 ################
 
@@ -56,12 +64,14 @@ doc_editor:
     de: "Editor Hilfe"
     en: Editor help
     es: Ayuda del editor
+    pl: Pomoc do edycji
 doc_edit_workflow: 
   label: 
     it: Workflow
     de: "Workflow"
     en: Workflow
     es: Flujo de trabajo
+    pl: Przepływ pracy
     
 ################
 
@@ -73,6 +83,7 @@ doc_edit_workflow:
     de: Leader
     en: Leader
     es: "Líder"
+    pl: Leader
 "001":
   label:
     it: Numero documento RISM
@@ -80,6 +91,7 @@ doc_edit_workflow:
     de: RISM Dokumentnummer
     en: RISM ID number
     es: "Número de ID de RISM"
+    pl: RISM ID
 "003":
   label:
     it: Identificatore del numero di controllo
@@ -87,6 +99,7 @@ doc_edit_workflow:
     de: Kontrollnummer-Bezeichnung
     en: Control number identifier
     es: "Identificador de número de control"
+    pl: Identyfikator numeru kontrolnego
 "005":
   label:
     it: Data e ora dell'ultima transazione
@@ -94,6 +107,7 @@ doc_edit_workflow:
     de: Datum und Zeit der letzten Transaktion
     en: Date and time of last transaction
     es: "Fecha y hora de la última transacción"
+    pl: Data i godzina ostatniej operacji
 "024":
   label:
     it: "Riferimento autorità"
@@ -101,6 +115,7 @@ doc_edit_workflow:
     de: Normdatenverweise
     en: Other standard identifier
     es: "Otro identificador estándar"
+    pl: Identyfikator innego standardu
   fields:
     a:
       label:
@@ -109,6 +124,7 @@ doc_edit_workflow:
         de: Normdatenverweise
         en: Standard number or code
         es: "Número o código estándar"
+        pl: Standardowy numer lub kod
     "2":
       label:
         it: "Agenzia autorità"
@@ -116,6 +132,7 @@ doc_edit_workflow:
         de: Normdatenagentur
         en: Source of number or code
         es: "Fuente de número o código"
+        pl: Źródło numeru lub kodu
 "040":
   label:
     it: Fonte della catalogazione
@@ -123,6 +140,7 @@ doc_edit_workflow:
     de: Katalogisierungsquelle
     en: Cataloging source
     es: "Fuente de la catalogación"
+    pl: Katalogowanie źródła
   fields:
     a:
       label:
@@ -131,6 +149,7 @@ doc_edit_workflow:
         de: Original-Katalogisierungsstelle
         en: Original cataloging agency
         es: "Agencia de catalogación original"
+        pl: Jednostka katalogująca pierwotny rekord
     b:
       label:
         it: Lingua della catalogazione
@@ -138,6 +157,7 @@ doc_edit_workflow:
         de: Katalogisierungssprache
         en: Language of cataloging
         es: "Idioma de la catalogación"
+        pl: Język katalogowania
     c:
       label:
         it: Agenzia della trascrizione
@@ -145,6 +165,7 @@ doc_edit_workflow:
         de: "Übertragende Katalogisierungsstelle"
         en: Transcribing agency
         es: "Agencia de la transcripción"
+        pl: Jednostka transkrybująca
     d:
       label:
         it: Agenzia della modifica
@@ -152,6 +173,7 @@ doc_edit_workflow:
         de: Modifizierende Katalogisierungsstelle
         en: Modifying agency
         es: "Agencia de la modificación"
+        pl: Jednostka modyfikująca
 "042":
   label:
     it: Codice di autenticazione
@@ -159,6 +181,7 @@ doc_edit_workflow:
     de: Authentication Code
     en: Authentication Code
     es: "Código de autenticación"
+    pl: Kod uwierzytelnienia
   fields:
     a:
       label:
@@ -167,6 +190,7 @@ doc_edit_workflow:
         de: Authentication Code
         en: Authentication Code
         es: "Código de autenticación"
+        pl: Kod uwierzytelnienia
 "043":
   label:
     it: Codice del Paese
@@ -174,6 +198,7 @@ doc_edit_workflow:
     de: Länder-Code
     en: Nationality
     es: Nacionalidad
+    pl: Narodowość
   fields:
     c:
       label:
@@ -182,6 +207,7 @@ doc_edit_workflow:
         de: Länder-Code  
         en: Nationality
         es: Nacionalidad
+        pl: Narodowość
 "100":
   label:
     it: Nome di persona
@@ -189,6 +215,7 @@ doc_edit_workflow:
     de: Ansetzungsform
     en: Heading - Personal name
     es: Nombre personal
+    pl: Nagłówek – Osoba
   accepts: 
   - "700"
   fields:
@@ -199,6 +226,7 @@ doc_edit_workflow:
         de: Name
         en: Heading - personal name
         es: Nombre personal
+        pl: Nagłówek – Osoba
     c:
       label:
         it: Ordine religioso
@@ -206,6 +234,7 @@ doc_edit_workflow:
         de: Orden/Titel
         en: Religious order
         es: "Orden religiosa"
+        pl: Zgromadzenie zakonne
     d:
       label:
         it: Data di nascita e di morte
@@ -213,6 +242,7 @@ doc_edit_workflow:
         de: Geburts- und Todesdaten
         en: Years of birth and death
         es: "Años de nacimiento y muerte"
+        pl: Lata urodzenia i śmierci
     w:
       label:
         it: Status
@@ -220,6 +250,7 @@ doc_edit_workflow:
         de: Status
         en: Status
         es: Estado
+        pl: Status
     y:
       label:
         it: Altre date
@@ -227,6 +258,7 @@ doc_edit_workflow:
         de: Andere Lebensdaten
         en: Other life dates
         es: "Otras fechas de vida"
+        pl: Pozostałe daty urodzenia i śmierci
 "370":
   label:
     it: Luogo associato
@@ -234,6 +266,7 @@ doc_edit_workflow:
     de: Associated Place
     en: Associated Place
     es: Lugar asociado
+    pl: Powiązane miejsce
   fields:
     a:
       label:
@@ -242,6 +275,7 @@ doc_edit_workflow:
         de: Geburtsort  
         en: Place of birth
         es: Lugar de nacimiento
+        pl: Miejsce urodzenia
 "375":
   label:
     it: Genere
@@ -249,6 +283,7 @@ doc_edit_workflow:
     de: Geschlecht
     en: Gender
     es: "Género"
+    pl: Płeć społeczno-kulturowa
   fields:
     a:
       label:
@@ -257,6 +292,7 @@ doc_edit_workflow:
         de: Geschlecht 
         en: Gender
         es: "Género"
+        pl: Płeć społeczno-kulturowa
 "400":
   label:
     it: Varianti del nome
@@ -264,6 +300,7 @@ doc_edit_workflow:
     de: Namensvarianten
     en: Name variant
     es: Variantes del nombre
+    pl: Alternatywna nazwa osoby
   fields:
     a:
       label:
@@ -272,6 +309,7 @@ doc_edit_workflow:
         de: Namensvarianten  
         en: Name variant
         es: Variantes del nombre
+        pl: Alternatywna nazwa osoby
     d:
       label:
         it: Data di nascita e di morte
@@ -279,6 +317,7 @@ doc_edit_workflow:
         de: Geburts- und Todesdaten
         en: Life dates
         es: Fechas de nacimiento y muerte
+        pl: Daty urodzenia i śmierci
     j:
       label:
         it: Descrizione della variante del nome
@@ -286,6 +325,7 @@ doc_edit_workflow:
         de: Art der Namensvariante
         en: Type of name variant
         es: Tipo de variante de nombre
+        pl: Typ alternatywnej nazwy osoby
 "500":
   label:
     it: Persone correlate
@@ -293,6 +333,7 @@ doc_edit_workflow:
     de: Zugehörige Personen
     en: Related personal name
     es: Nombre personal relacionado
+    pl: Powiązana osoba
   fields:
     a:
       label:
@@ -301,6 +342,7 @@ doc_edit_workflow:
         de:  Name
         en:  Related personal name
         es:  Nombre personal relacionado
+        pl: Powiązana osoba
     y:
       label:
         it:  Relazione
@@ -308,6 +350,7 @@ doc_edit_workflow:
         de:  Beziehung
         en:  Type of relationship
         es:  "Tipo de relación"
+        pl: Rodzaj relacji
 
 "510":
   label:
@@ -316,6 +359,7 @@ doc_edit_workflow:
     de: Beziehung Körperschaft 
     en: Associated institution
     es: "Institución asociada"
+    pl: Powiązana instytucja
   fields:
     a:
       label:
@@ -324,6 +368,7 @@ doc_edit_workflow:
         de:  Beziehung Körperschaft
         en:  Associated institution
         es:  "Institución asociada" 
+        pl: Powiązana instytucja
 "550":
   label:
     it: Professione o funzione
@@ -331,6 +376,7 @@ doc_edit_workflow:
     de: Beruf oder Funktion
     en: Profession or function
     es: "Profesión o función"
+    pl: Zawód lub funkcja
   fields:
     a:
       label:
@@ -339,6 +385,7 @@ doc_edit_workflow:
         de: Beruf oder Funktion
         en: Profession or function
         es: "Profesión o función"
+        pl: Zawód lub funkcja
     i:
       label:
         it:  Relazione
@@ -346,6 +393,7 @@ doc_edit_workflow:
         de:  Bedeutung
         en:  Type
         es:  Tipo
+        pl: Rodzaj
 "551":
   label:
     it: Nome geografico
@@ -353,6 +401,7 @@ doc_edit_workflow:
     de: Orte
     en: Geographic name
     es: "Nombre geográfico"
+    pl: Nazwa geograficzna
   fields:
     a:
       label:
@@ -361,6 +410,7 @@ doc_edit_workflow:
         de:  Ort
         en:  Geographic name
         es:  "Nombre geográfico"
+        pl: Nazwa geograficzna
     i:
       label:
         it:  Tipo
@@ -368,6 +418,7 @@ doc_edit_workflow:
         de:  Ort Bedeutung
         en:  Type
         es:  Tipo
+        pl: Rodzaj
 
 "667":
   label:
@@ -376,6 +427,7 @@ doc_edit_workflow:
     de:  Non public note
     en:  Internal note
     es:  Nota interna
+    pl: Uwaga wewnętrzna
   fields:
     a:
       label:
@@ -384,6 +436,7 @@ doc_edit_workflow:
         de:  Non public note
         en:  Internal note
         es:  Nota Interna
+        pl: Uwaga wewnętrzna
 "670":
   label:
     it: Fonte dei dati 
@@ -391,6 +444,7 @@ doc_edit_workflow:
     de: Literaturnachweis
     en: Source data found 
     es: "Fuente de los datos encontrados"
+    pl: Odnalezione źródło danych
   fields:
     a:
       label:
@@ -399,6 +453,7 @@ doc_edit_workflow:
         de: Literaturnachweis
         en: Source data found
         es: "Fuente de los datos encontrados"
+        pl: Odnalezione źródło danych
     b:
       label:
         it: Informazione rinvenuta
@@ -406,6 +461,7 @@ doc_edit_workflow:
         de: Fundstelle
         en: Information found
         es: "Información encontrada"
+        pl: Odnaleziona informacja
 "678":
   label:
     it: Informazioni biografiche addizionali 
@@ -413,6 +469,7 @@ doc_edit_workflow:
     de: Weitere biographische Angaben
     en: Additional biographical information
     es: "Información biográfica adicional"
+    pl: Dodatkowe informacje biograficzne
   fields:
     a:
       label:
@@ -421,6 +478,7 @@ doc_edit_workflow:
         de: Weitere biographische Angaben
         en: Additional biographical information
         es: "Información biográfica adicional"
+        pl: Dodatkowe informacje biograficzne
 "680":
   label:
     it: Osservazioni
@@ -428,6 +486,7 @@ doc_edit_workflow:
     de: Allgemeine Bemerkungen
     en: General note
     es: Nota general
+    pl: Uwaga ogólna
   fields:
     a:
       label:
@@ -436,6 +495,7 @@ doc_edit_workflow:
         de: Externe Bemerkungen
         en: General note
         es: Nota general
+        pl: Uwaga ogólna
 "856":
   label:
     it: Localizzazione e accesso elettronico
@@ -443,6 +503,7 @@ doc_edit_workflow:
     de: Elektronische Lokalisierung und Zugriff
     en: External resource
     es: Recurso externo
+    pl: Zasób zewnętrzny
   fields:
     y:
       label:
@@ -451,6 +512,7 @@ doc_edit_workflow:
         de: "Für das Publikum bestimmte Fussnote"
         en: Note about external resource
         es: Nota sobre el recurso externo
+        pl: Uwaga o zasobie zewnętrznym
     u:
       label:
         it: Risorsa esterna URL
@@ -458,6 +520,7 @@ doc_edit_workflow:
         de: Uniform Resource Identifier
         en: External resource URL
         es: URL del recurso externo
+        pl: URL zasobu zewnętrznego
 main_person:
   label:
     it: Campi principali
@@ -465,6 +528,7 @@ main_person:
     de: Haupteintragungen
     en: Main entry fields
     es: Campos principales
+    pl: Główne pola edycji
 codes:
   label:
     it: Numeri e codici
@@ -472,6 +536,7 @@ codes:
     de: Nummern und Codes
     en: Numbers and code fields
     es: "Números y códigos"
+    pl: Pola liczb i kodów
 control:
   label:
     fr: "Champs de contrôle"
@@ -479,6 +544,7 @@ control:
     it: Campi di controllo
     en: Control fields
     es: Campos de control
+    pl: Pola kontrolne
 notes:
   label:
     it: Note
@@ -486,6 +552,7 @@ notes:
     de: Bemerkungen
     en: Note fields
     es: Campos de notas
+    pl: Pola uwag
 subject:
   label:
     it: Soggetti
@@ -493,6 +560,7 @@ subject:
     de: Schlagworteintragungen
     en: Subject access fields
     es: Campos de los puntos de acceso
+    pl: Pola haseł tematycznych
 places:
   label:
     it: Luoghi
@@ -500,6 +568,7 @@ places:
     de: Länder und Orte
     en: Countries and Places
     es: "Países y lugares"
+    pl: Kraje i miejsca
 other:
   label:
     it: Varia
@@ -507,6 +576,7 @@ other:
     de: Verschiedenes
     en: Miscellaneous
     es: Varios
+    pl: Pozostałe
 references:
   label:
     it: Riferimento
@@ -514,6 +584,7 @@ references:
     de: Literatur und Bemerkungen
     en: References and notes
     es: Referencias y notas
+    pl: Odniesienia i uwagi
 relations:
   label:
     it: Relazione
@@ -521,6 +592,7 @@ relations:
     de: Beziehungen
     en: Relations
     es: Relaciones
+    pl: Relacje
 variants:
   label:
     it: Varianti
@@ -528,6 +600,7 @@ variants:
     de: Namensvarianten
     en: Name Variants
     es: Variantes del nombre
+    pl: Alternatywne nazwy osoby
 administration:
   label:
     it: Amministrazione
@@ -535,6 +608,7 @@ administration:
     de: Administration
     en: Administration
     es: "Administración"
+    pl: Administracja
 male:
   label:
     it: maschio
@@ -542,6 +616,7 @@ male:
     de: männlich
     en: male
     es: masculino
+    pl: mężczyzna
 female:
   label:
     it: femmina
@@ -549,6 +624,7 @@ female:
     de: weiblich
     en: female
     es: femenino
+    pl: kobieta
 unknown:
   label:
     it: sconosciuto
@@ -556,6 +632,7 @@ unknown:
     de: unbekannt
     en: unknown
     es: desconocido
+    pl: płeć nieznana
 
 #########################
 go:
@@ -565,6 +642,7 @@ go:
     de: Geburtsort
     en: Place of birth
     es: Lugar de nacimiento
+    pl: Miejsce urodzenia
 ha:
   label:
     it: Luogo di origine
@@ -572,6 +650,7 @@ ha:
     de: Herkunftsangabe
     en: Place of origin
     es: Lugar de origen
+    pl: Miejsce pochodzenia
 po:
   label:
     it: Luogo postale
@@ -579,6 +658,7 @@ po:
     de: postalischer Ort
     en: postal Place
     es: "Dirección postal"
+    pl: Rejon pocztowy
 so:
   label:
     it: Luogo di morte
@@ -586,6 +666,7 @@ so:
     de: Sterbeort
     en: Place of death
     es: Lugar de fallecimiento
+    pl: Miejsce śmierci
 wl:
   label:
     it: "Paese di attività"
@@ -593,6 +674,7 @@ wl:
     de: Wirkungsland
     en: Country active
     es: "País de actividad"
+    pl: Kraj aktywności artystycznej
 wo:
   label:
     it: "Luogo di attività"
@@ -600,6 +682,7 @@ wo:
     de: Wirkungsort
     en: Place active
     es: "Lugar de actividad"
+    pl: Miejsce aktywności artystycznej
 wr:
   label:
     it: "Regione di attività"
@@ -607,6 +690,7 @@ wr:
     de: Wirkungsregion
     en: Region active
     es: "Región de actividad"
+    pl: Region aktywności artystycznej
 #Country Codes
 "XC-DZ":
   label:
@@ -615,6 +699,7 @@ wr:
     de: "Algeria"
     en: "Algeria"
     es: "Argelia"
+    pl: Algieria
 "XD-AR":
   label:
     it: "Argentina"
@@ -622,6 +707,7 @@ wr:
     de: "Argentina"
     en: "Argentina"
     es: "Argentina"
+    pl: Argentyna
 "XB-AM":
   label:
     it: "Armenia"
@@ -629,6 +715,7 @@ wr:
     de: "Armenia"
     en: "Armenia"
     es: "Armenia"
+    pl: Armenia
 "XE-AU":
   label:
     it: "Australia"
@@ -636,6 +723,7 @@ wr:
     de: "Australia"
     en: "Australia"
     es: "Australia"
+    pl: Australia
 "XA-AT":
   label:
     it: "Austria"
@@ -643,6 +731,7 @@ wr:
     de: "Austria"
     en: "Austria"
     es: "Austria"
+    pl: Austria
 "XA-AT-2":
   label:
     it: "Austria: Carinzia"
@@ -650,6 +739,7 @@ wr:
     de: "Austria: Carinthia"
     en: "Austria: Carinthia"
     es: "Austria: Carintia"
+    pl: Austria: Karyntia
 "XA-AT-3":
   label:
     it: "Austria: Austria Inferiore"
@@ -657,6 +747,7 @@ wr:
     de: "Austria: Lower Austria"
     en: "Austria: Lower Austria"
     es: "Austria: Baja Austria"
+    pl: Austria: Dolna Austria
 "XA-AT-5":
   label:
     it: "Austria: Salisburgo"
@@ -664,6 +755,7 @@ wr:
     de: "Austria: Salzburg"
     en: "Austria: Salzburg"
     es: "Austria: Salzburgo"
+    pl: Austria: Salzburg
 "XA-AT-6":
   label:
     it: "Austria: Stiria"
@@ -671,6 +763,7 @@ wr:
     de: "Austria: Styria"
     en: "Austria: Styria"
     es: "Austria: Estiria"
+    pl: Austria: Styria
 "XA-AT-7":
   label:
     it: "Austria: Tirolo"
@@ -678,6 +771,7 @@ wr:
     de: "Austria: Tyrol"
     en: "Austria: Tyrol"
     es: "Austria: Tirol"
+    pl: Austria: Tyrol
 "XA-AT-4":
   label:
     it: "Austria: Austria Superiore"
@@ -685,6 +779,7 @@ wr:
     de: "Austria: Upper Austria"
     en: "Austria: Upper Austria"
     es: "Austria: Alta Austria"
+    pl: Austria: Górna Austria
 "XA-AT-9":
   label:
     it: "Austria: Vienna"
@@ -692,6 +787,7 @@ wr:
     de: "Austria: Vienna"
     en: "Austria: Vienna"
     es: "Austria: Viena"
+    pl: Austria: Wiedeń
 "XA-BE":
   label:
     it: "Belgio"
@@ -699,6 +795,7 @@ wr:
     de: "Belgium"
     en: "Belgium"
     es: "Bélgica"
+    pl: Belgia
 "XC-BJ":
   label:
     it: "Benin"
@@ -706,6 +803,7 @@ wr:
     de: "Benin"
     en: "Benin"
     es: "Benín"
+    pl: Benin
 "XD-BR":
   label:
     it: "Brasile"
@@ -713,6 +811,7 @@ wr:
     de: "Brazil"
     en: "Brazil"
     es: "Brasil"
+    pl: Brazylia
 "XA-BG":
   label:
     it: "Bulgaria"
@@ -720,6 +819,7 @@ wr:
     de: "Bulgaria"
     en: "Bulgaria"
     es: "Bulgaria"
+    pl: Bułgaria
 "XB-KH":
   label:
     it: "Cambogia"
@@ -727,6 +827,7 @@ wr:
     de: "Cambodia"
     en: "Cambodia"
     es: "Camboya"
+    pl: Kambodża
 "XD-CA":
   label:
     it: "Canada"
@@ -734,6 +835,7 @@ wr:
     de: "Canada"
     en: "Canada"
     es: "Canadá"
+    pl: Kanada
 "XD-CL":
   label:
     it: "Cile"
@@ -741,6 +843,7 @@ wr:
     de: "Chile"
     en: "Chile"
     es: "Chile"
+    pl: Chile
 "XB-CN":
   label:
     it: "Cina"
@@ -748,6 +851,7 @@ wr:
     de: "China"
     en: "China"
     es: "China"
+    pl: Chiny
 "XD-CO":
   label:
     it: "Colombia"
@@ -755,6 +859,7 @@ wr:
     de: "Colombia"
     en: "Colombia"
     es: "Colombia"
+    pl: Kolumbia
 "XA-HR":
   label:
     it: "Croazia"
@@ -762,6 +867,7 @@ wr:
     de: "Croatia"
     en: "Croatia"
     es: "Croacia"
+    pl: Chorwacja
 "XD-CU":
   label:
     it: "Cuba"
@@ -769,6 +875,7 @@ wr:
     de: "Cuba"
     en: "Cuba"
     es: "Cuba"
+    pl: Kuba
 "XA-CZ":
   label:
     it: "Repubblica Ceca"
@@ -776,6 +883,7 @@ wr:
     de: "Czech Republic"
     en: "Czech Republic"
     es: "República Checa"
+    pl: Czechy
 "XA-DK":
   label:
     it: "Danimarca"
@@ -783,6 +891,7 @@ wr:
     de: "Denmark"
     en: "Denmark"
     es: "Dinamarca"
+    pl: Dania
 "XC-EG":
   label:
     it: "Egitto"
@@ -790,6 +899,7 @@ wr:
     de: "Egypt"
     en: "Egypt"
     es: "Egipto"
+    pl: Egipt
 "XA-EE":
   label:
     it: "Estonia"
@@ -797,6 +907,7 @@ wr:
     de: "Estonia"
     en: "Estonia"
     es: "Estonia"
+    pl: Estonia
 "XA-FI":
   label:
     it: "Finlandia"
@@ -804,6 +915,7 @@ wr:
     de: "Finland"
     en: "Finland"
     es: "Finlandia"
+    pl: Finlandia
 "XA-FR":
   label:
     it: "Francia"
@@ -811,6 +923,7 @@ wr:
     de: "France"
     en: "France"
     es: "Francia"
+    pl: Francja
 "XB-GE":
   label:
     it: "Georgia"
@@ -818,6 +931,7 @@ wr:
     de: "Georgia"
     en: "Georgia"
     es: "Georgia"
+    pl: Gruzja
 "XA-DE":
   label:
     it: "Germania"
@@ -825,6 +939,7 @@ wr:
     de: "Germany"
     en: "Germany"
     es: "Alemania"
+    pl: Niemcy
 "XA-DE-BY":
   label:
     it: "Germana: Baviera"
@@ -832,6 +947,7 @@ wr:
     de: "Germany: Bavaria"
     en: "Germany: Bavaria"
     es: "Alemania: Bavaria"
+    pl: Niemcy: Bawaria
 "XA-DE-SN":
   label:
     it: "Germania: Sassonia"
@@ -839,6 +955,7 @@ wr:
     de: "Germany: Saxony"
     en: "Germany: Saxony"
     es: "Alemania: Sajonia"
+    pl: Niemcy: Saksonia
 "XA-GR":
   label:
     it: "Grecia"
@@ -846,6 +963,7 @@ wr:
     de: "Greece"
     en: "Greece"
     es: "Grecia"
+    pl: Grecja
 "XC-GN":
   label:
     it: "GUINEA"
@@ -853,6 +971,7 @@ wr:
     de: "Guinea"
     en: "Guinea"
     es: "Guinea"
+    pl: Gwinea
 "XA-VA":
   label:
     it: "Santa Sede"
@@ -860,6 +979,7 @@ wr:
     de: "Holy See"
     en: "Holy See"
     es: "Santa Sede"
+    pl: Watykan
 "XD-HN":
   label:
     it: "Honduras"
@@ -867,6 +987,7 @@ wr:
     de: "Honduras"
     en: "Honduras"
     es: "Honduras"
+    pl: Honduras
 "XA-HU":
   label:
     it: "Ungheria"
@@ -874,6 +995,7 @@ wr:
     de: "Hungary"
     en: "Hungary"
     es: "Hungría"
+    pl: Węgry
 "XA-IS":
   label:
     it: "Islanda"
@@ -881,6 +1003,7 @@ wr:
     de: "Iceland"
     en: "Iceland"
     es: "Islandia"
+    pl: Islandia
 "XB-IN":
   label:
     it: "India"
@@ -888,6 +1011,7 @@ wr:
     de: "India"
     en: "India"
     es: "India"
+    pl: Indie
 "XB-IR":
   label:
     it: "Iran, Repubblica Islamica dell'"
@@ -895,6 +1019,7 @@ wr:
     de: "Iran, Islamic Republic of"
     en: "Iran, Islamic Republic of"
     es: "Irán, República Islámica de"
+    pl: Iran, Republika Islamska
 "XA-IE":
   label:
     it: "Irlanda"
@@ -902,12 +1027,14 @@ wr:
     de: "Ireland"
     en: "Ireland"
     es: "Irlanda"
+    pl: Irlandia
 "XB-IQ":
   label:
     it: "Iraq"
     fr: "IRAQ"
     de: "Irak"
     en: "Iraq"
+    pl: Irak
 "XB-IL":
   label:
     it: "Israele"
@@ -915,6 +1042,7 @@ wr:
     de: "Israel"
     en: "Israel"
     es: "Israel"
+    pl: Izrael
 "XA-IT-32":
   label:
     it: "Italia: Trentino-Alto Adige"
@@ -922,6 +1050,7 @@ wr:
     de: "Italy: Trentino-Alto Adige"
     en: "Italy: Trentino-Alto Adige"
     es: "Italia: Trentino-Alto Adigio"
+    pl: Włochy: Trentino-Alto Adige
 "XA-IT":
   label:
     it: "Italia"
@@ -929,6 +1058,7 @@ wr:
     de: "Italy"
     en: "Italy"
     es: "Italia"
+    pl: Włochy
 "XB-JP":
   label:
     it: "Giappone"
@@ -936,6 +1066,7 @@ wr:
     de: "Japan"
     en: "Japan"
     es: "Japón"
+    pl: Japonia
 "XB-KR":
   label:
     it: "Corea, Repubblica di"
@@ -943,6 +1074,7 @@ wr:
     de: "Korea, Republic of"
     en: "Korea, Republic of"
     es: "Corea, República de"
+    pl: Korea, Republika
 "XA-LV":
   label:
     it: "Lettonia"
@@ -950,6 +1082,7 @@ wr:
     de: "Latvia"
     en: "Latvia"
     es: "Letonia"
+    pl: Łotwa
 "XA-LT":
   label:
     it: "Lituania"
@@ -957,6 +1090,7 @@ wr:
     de: "Lithuania"
     en: "Lithuania"
     es: "Lituania"
+    pl: Litwa
 "XA-LU":
   label:
     it: "Lussemburgo"
@@ -964,6 +1098,7 @@ wr:
     de: "Luxembourg"
     en: "Luxembourg"
     es: "Luxemburgo"
+    pl: Luksemburg
 "XA-MT":
   label:
     it: "Malta"
@@ -971,6 +1106,7 @@ wr:
     de: "Malta"
     en: "Malta"
     es: "Malta"
+    pl: Malta
 "XD-MX":
   label:
     it: "Messico"
@@ -978,6 +1114,7 @@ wr:
     de: "Mexico"
     en: "Mexico"
     es: "México"
+    pl: Meksyk
 "XA-MD":
   label:
     it: "Moldavia"
@@ -985,6 +1122,7 @@ wr:
     de: "Moldawien"
     en: "Moldavia"
     es: "Moldavia"
+    pl: Mołdawia
 "XA-MC":
   label:
     it: "Monaco"
@@ -992,6 +1130,7 @@ wr:
     de: "Monaco"
     en: "Monaco"
     es: "Mónaco"
+    pl: Monako
 "XA-ME":
   label:
     it: "Montenegro"
@@ -999,6 +1138,7 @@ wr:
     de: "Montenegro"
     en: "Montenegro"
     es: "Montenegro"
+    pl: Czarnogóra
 "XA-NL":
   label:
     it: "Paesi Bassi"
@@ -1006,6 +1146,7 @@ wr:
     de: "Netherlands"
     en: "Netherlands"
     es: "Países Bajos"
+    pl: Niderlandy
 "XE-NZ":
   label:
     it: "Nuova Zelanda"
@@ -1013,6 +1154,7 @@ wr:
     de: "New Zealand"
     en: "New Zealand"
     es: "Nueva Zelanda"
+    pl: Nowa Zelandia
 "XA-NO":
   label:
     it: "Norvegia"
@@ -1020,6 +1162,7 @@ wr:
     de: "Norway"
     en: "Norway"
     es: "Noruega"
+    pl: Norwegia
 "XD-PY":
   label:
     it: "Paraguay"
@@ -1027,6 +1170,7 @@ wr:
     de: "Paraguay"
     en: "Paraguay"
     es: "Paraguay"
+    pl: Paragwaj
 "XD-PE":
   label:
     it: "Perù"
@@ -1034,6 +1178,7 @@ wr:
     de: "Peru"
     en: "Peru"
     es: "Perú"
+    pl: Peru
 "XA-PL":
   label:
     it: "Polonia"
@@ -1041,6 +1186,7 @@ wr:
     de: "Poland"
     en: "Poland"
     es: "Polonia"
+    pl: Polska
 "XA-PT":
   label:
     it: "Portogallo"
@@ -1048,6 +1194,7 @@ wr:
     de: "Portugal"
     en: "Portugal"
     es: "Portugal"
+    pl: Portugalia
 "XD-PR":
   label:
     it: "Puerto Rico"
@@ -1055,6 +1202,7 @@ wr:
     de: "Puerto Rico"
     en: "Puerto Rico"
     es: "Puerto Rico"
+    pl: Portoryko
 "XA-RO":
   label:
     it: "Romania"
@@ -1062,6 +1210,7 @@ wr:
     de: "Romania"
     en: "Romania"
     es: "Rumania"
+    pl: Rumunia
 "XA-RU":
   label:
     it: "Federazione Russa"
@@ -1069,6 +1218,7 @@ wr:
     de: "Russian Federation"
     en: "Russian Federation"
     es: "Federación Rusa"
+    pl: Federacja Rosyjska
 "XA-RS":
   label:
     it: "Serbia"
@@ -1076,6 +1226,7 @@ wr:
     de: "Serbia"
     en: "Serbia"
     es: "Serbia"
+    pl: Serbia
 "XA-SK":
   label:
     it: "Slovacchia"
@@ -1083,6 +1234,7 @@ wr:
     de: "Slovakia"
     en: "Slovakia"
     es: "Eslovaquia"
+    pl: Słowacja
 "XA-SI":
   label:
     it: "Slovenia"
@@ -1090,6 +1242,7 @@ wr:
     de: "Slovenia"
     en: "Slovenia"
     es: "Eslovenia"
+    pl: Słowenia
 "XC-ZA":
   label:
     it: "Sudafrica"
@@ -1097,6 +1250,7 @@ wr:
     de: "South Africa"
     en: "South Africa"
     es: "Sudáfrica"
+    pl: Republika Południowej Afryki
 "XA-ES":
   label:
     it: "Spagna"
@@ -1104,6 +1258,7 @@ wr:
     de: "Spain"
     en: "Spain"
     es: "España"
+    pl: Hiszpania
 "XA-SE":
   label:
     it: "Svezia"
@@ -1111,6 +1266,7 @@ wr:
     de: "Sweden"
     en: "Sweden"
     es: "Suecia"
+    pl: Szwecja
 "XA-CH-VD":
   label:
     it: "Svizzera: Vaud"
@@ -1118,6 +1274,7 @@ wr:
     de: "Switzerland: Vaud"
     en: "Switzerland: Vaud"
     es: "Suiza: cantón de Vaud"
+    pl: Szwajcaria: kanton Vaud
 "XA-CH":
   label:
     it: "Svizzera"
@@ -1125,6 +1282,7 @@ wr:
     de: "Switzerland"
     en: "Switzerland"
     es: "Suiza"
+    pl: Szwajcaria
 "XB-SY":
   label:
     it: "Repubblica Araba Siriana"
@@ -1132,6 +1290,7 @@ wr:
     de: "Syrian Arab Republic"
     en: "Syrian Arab Republic"
     es: "República Árabe Siria"
+    pl: Syryjska Republika Arabska
 "XB-TW":
   label:
     it: "Taiwan (provincia della Cina)"
@@ -1139,6 +1298,7 @@ wr:
     de: "Taiwan (Province of China)"
     en: "Taiwan (Province of China)"
     es: "Taiwán (Provincia de China)"
+    pl: Tajwan (prowincja Chin)
 "XD-TT":
   label:
     it: "Trinidad e Tobago"
@@ -1146,6 +1306,7 @@ wr:
     de: "Trinidad and Tobago"
     en: "Trinidad and Tobago"
     es: "Trinidad y Tobago"
+    pl: Trynidad i Tobago
 "XB-TR":
   label:
     it: "Turchia"
@@ -1153,6 +1314,7 @@ wr:
     de: "Turkey"
     en: "Turkey"
     es: "Turquía"
+    pl: Turcja
 "XA-UA":
   label:
     it: "Ucraina"
@@ -1160,6 +1322,7 @@ wr:
     de: "Ukraine"
     en: "Ukraine"
     es: "Ucrania"
+    pl: Ukraina
 "XA-GB":
   label:
     it: "Regno Unito"
@@ -1167,6 +1330,7 @@ wr:
     de: "United Kingdom"
     en: "United Kingdom"
     es: "Reino Unido"
+    pl: Zjednoczone Królestwo
 "XD-US":
   label:
     it: "Stati Uniti d'America"
@@ -1174,6 +1338,7 @@ wr:
     de: "United States of America"
     en: "United States of America"
     es: "Estados Unidos de América"
+    pl: Stany Zjednoczone AP
 "XD-UY":
   label:
     it: "Uruguay"
@@ -1181,6 +1346,7 @@ wr:
     de: "Uruguay"
     en: "Uruguay"
     es: "Uruguay"
+    pl: Urugwaj
 "XD-VE":
   label:
     it: "Venezuela, Repubblica Bolivariana del"
@@ -1188,6 +1354,7 @@ wr:
     de: "Venezuela, Bolivarian Republic of"
     en: "Venezuela, Bolivarian Republic of"
     es: "Venezuela, República Bolivariana de"
+    pl: Wenezuela, Republika Boliwariańska
 "XB-VN":
   label:
     it: "Vietnam"
@@ -1195,6 +1362,7 @@ wr:
     de: "Vietnam"
     en: "Vietnam"
     es: "Vietnam"
+    pl: Wietnam
 "XD-EC":
   label:
     it: "Ecuador"
@@ -1202,6 +1370,7 @@ wr:
     de: "Ecuador"
     en: "Ecuador"
     es: "Ecuador"
+    pl: Ekwador
 # Relationships
 brother of:
   label:
@@ -1210,6 +1379,7 @@ brother of:
     de: Bruder von
     en: brother of
     es: hermano de
+    pl: Brat …
 child of:
   label:
     it: Figlio/figlia di
@@ -1217,6 +1387,7 @@ child of:
     de: Kind von
     en: child of
     es: "hijo/a de"
+    pl: Potomek …
 mother of:
   label:
     it: Madre di
@@ -1224,6 +1395,7 @@ mother of:
     de: Mutter von
     en: mother of
     es: madre de
+    pl: Matka …
 confused with:
   label:
     it: Confuso/confusa con
@@ -1231,12 +1403,14 @@ confused with:
     de: Verwechselt mit
     en: confused with
     es: "Confundido/a con"
+    pl: Mylon(y/a) z …
 sister of:
   label:
     it: Sorella di
     fr: Soeur de
     de: Schwester von
     en: sister of
+    pl: Siostra …
 married to:
   label:
     it: Sposato/sposata con
@@ -1245,6 +1419,7 @@ married to:
     es: hermana de
     en: married to
     es: "casado/a con"
+    pl: W małżeństwie z …
 father of:
   label:
     it: Padre di
@@ -1252,6 +1427,7 @@ father of:
     de: Vater von
     en: father of
     es: padre de
+    pl: Ojciec …
 related to:
   label:
     it: Parente di
@@ -1259,6 +1435,7 @@ related to:
     de: Verwandt mit
     en: related to
     es: relacionado/a con
+    pl: W pokrewieństwie z …
 other:
   label:
     it: Altro
@@ -1266,6 +1443,7 @@ other:
     de: Weiteres
     en: other
     es: otro
+    pl: Pozostałe
     
 # Name variant codes
 bn:
@@ -1275,6 +1453,7 @@ bn:
     de: Beiname
     en: Nickname
     es: Apodo
+    pl: Przezwisko
 da:
   label:
     it: Pseudonimo
@@ -1282,6 +1461,7 @@ da:
     de: Pseudonym
     en: Pseudonym
     es: "Seudónimo"
+    pl: Pseudonim
 do:
   label:
     it: Nome di religione
@@ -1289,6 +1469,7 @@ do:
     de: Ordensname
     en: Religious name
     es: Nombre religioso
+    pl: Imię z wyznania
 dv:
   label:
     it: Altra forma di ricerca
@@ -1296,6 +1477,7 @@ dv:
     de: andere Suchform
     en: Other variant
     es: Otra variante
+    pl: Inny wariant
 ee:
   label:
     it: Nome da sposato
@@ -1303,6 +1485,7 @@ ee:
     de: Ehename
     en: Married name
     es: Apellido de casada/o
+    pl: Nazwisko po mężu
 ef:
   label:
     it: Nome di famiglia
@@ -1310,6 +1493,7 @@ ef:
     de: Familienname
     en: Name of family
     es: Apellido
+    pl: Nazwa rodziny
 ff:
   label:
     it: Nome di persona
@@ -1317,6 +1501,7 @@ ff:
     de: Personenname
     en: Personal name
     es: Nombre de pila
+    pl: Imię i nazwisko
 gg:
   label:
     it: Nome da nubile/celibe
@@ -1324,6 +1509,7 @@ gg:
     de: Geburtsname
     en: Birth name
     es: Nombre de nacimiento
+    pl: Nazwisko rodowe
 in:
   label:
     it: Iniziali
@@ -1331,6 +1517,7 @@ in:
     de: Initiale
     en: Initials
     es: Iniciales
+    pl: Inicjały
 mo:
   label:
     it: Monogramma
@@ -1338,6 +1525,7 @@ mo:
     de: Monogramm
     en: Monogram
     es: Monograma
+    pl: Monogram
 tn:
   label:
     it: Nome di battesimo
@@ -1345,6 +1533,7 @@ tn:
     de: Taufname
     en: Baptsimal name
     es: Nombre bautismal
+    pl: Imię z chrztu
 ub:
   label:
     it: Traduzione
@@ -1352,6 +1541,7 @@ ub:
     de: Übersetzung
     en: Translation
     es: Traducción
+    pl: Tłumaczenie
 z:
   label:
     it: Ortografia alternativa
@@ -1359,6 +1549,7 @@ z:
     de: Andere Schreibweise
     en: Alternate spelling
     es: Ortografía alternativa
+    pl: Alternatywna pisownia
 xx:
   label:
     it: Sconosciuto
@@ -1366,4 +1557,5 @@ xx:
     de: Unbekannt
     en: Unknown
     es: Desconcido
+    pl: Nieznane
 

--- a/config/editor_profiles/default/configurations/SourceLabels.yml
+++ b/config/editor_profiles/default/configurations/SourceLabels.yml
@@ -1,296 +1,337 @@
---- !map:ActiveSupport::HashWithIndifferentAccess 
+--- !map:ActiveSupport::HashWithIndifferentAccess
 
-doc_introduction: 
-  label: 
+doc_introduction:
+  label:
     de: Einleitung
     en: Introduction
     it: Introduzione
     pt: "Introdução"
     es: "Introducción"
-doc_masks: 
-  label: 
+    pl: Wprowadzenie
+doc_masks:
+  label:
     de: Katalogisierung von Musikquellen
     en: Cataloging musical sources
     it: Catalogazione delle fonti musicali
     pt: "Catalogando fontes musicais"
     es: "Catalogación de fuentes musicales"
-doc_tag_index: 
-  label: 
+    pl: Katalogowanie źródeł muzycznych
+doc_tag_index:
+  label:
     de: MARC Tag Index
     en: Index of MARC fields
     it: Indice dei campi MARC
     pt: "Índice dos campos MARC"
     es: "Índice de campos MARC"
+    pl: Indeks pól MARC
 
 ################
 
-doc_abbreviations: 
-  label: 
+doc_abbreviations:
+  label:
     de: "Abkürzungen und Bezeichnungen"
     en: "Abbreviations and terminology"
     it: "Abbreviazioni e terminologia"
     pt: "Abreviaturas e terminologia"
     es: "Abreviaturas y terminología"
-doc_abbr_dates: 
-  label: 
+    pl: Skróty i pojęcia
+doc_abbr_dates:
+  label:
     de: "Datierung"
     en: "Dates"
     it: "Date"
     pt: Data
     es: "Fechas"
-doc_abbr_general: 
-  label: 
+    pl: Daty
+doc_abbr_general:
+  label:
     de: "Allgemeine Abkürzungen und Begriffe"
     en: "General abbreviations and terms"
     it: "Abbreviazioni generali e terminologia"
     pt: "Abreviaturas e termos gerais"
     es: "Abreviaturas y términos generales"
-doc_abbr_keys: 
-  label: 
+    pl: Ogólne skróty i pojęcia
+doc_abbr_keys:
+  label:
     de: "Tonarten"
     en: "Keys"
     it: "Tonalità"
     es: "Tonalidades"
     pt: Tonalidades
-doc_abbr_lang: 
-  label: 
+    pl: Tonacje
+doc_abbr_lang:
+  label:
     de: "Sprachcodes"
     en: "Language codes"
     it: "Codice lingua"
     pt: "Código de idioma"
     es: "Código de Idioma"
+    pl: Kody języków
 doc_abbr_modes:
-  label: 
+  label:
     de: "Kirchentonarten"
     en: "Ecclesiastical modes"
     it: "Modi ecclesiastici"
     pt: "Modos eclesiáticos"
     es: "Modos eclesiásticos"
-doc_abbr_voices_instr: 
-  label: 
+    pl: Skale kościelne
+doc_abbr_voices_instr:
+  label:
     de: "Stimmen- und Instrumentenbezeichnungen"
     en: "Terms for voices and instruments"
     it: "Terminologia per voci e strumenti"
     pt: Termos para vozes e instrumentos
     it: "Terminología para voces e instrumentos"
-doc_abbr_voices_instr2: 
-  label: 
+    pl: Określenia głosów i instrumentów
+doc_abbr_voices_instr2:
+  label:
     de: "Stimmen- und Instrumentenbezeichnungen tabellarisch"
     en: "RISM instrument abbreviations"
     it: "Abbreviazioni RISM per gli strumenti"
     pt: "Abreviaturas de instrumentos do RISM"
     pt: "Abreviaturas de instrumentos de RISM"
+    pl: Skróty instrumentów wg RISM
 
 ###############
 
-doc_aid: 
-  label: 
+doc_aid:
+  label:
     de: Arbeitshilfen
     en: Aide
     it: Aiuti alla catalogazione
     es: Ayuda
-doc_aid_liturgical_feasts: 
-  label: 
+    pl: Asystent
+doc_aid_liturgical_feasts:
+  label:
     de: "Liturgische Feste"
     en: "Liturgical festivals"
     it: "Feste liturgiche"
     pt: "Festa litúrgica"
     es: "Festividades litúrgicas"
-doc_aid_locations: 
-  label: 
+    pl: Święta liturgiczne
+doc_aid_locations:
+  label:
     de: "Fundorte auf Quellen"
     en: "Locations on the source"
     it: "Luogo sulla fonte"
     es: "Ubicaciones en la fuente"
-doc_aid_texts_sacred_works: 
-  label: 
+    pl: Lokalizacje w źródle
+doc_aid_texts_sacred_works:
+  label:
     de: "Standardtexte Sakralwerke"
     en: "Standard texts of sacred works"
     it: "Testo standard dei brani musicali sacri"
     pt: "Textos padronizados de obras sacras"
     es: "Textos estándar de obras sacras"
-doc_aid_titles_keywords: 
-  label: 
+    pl: Standardowe teksty utworów sakralnych
+doc_aid_titles_keywords:
+  label:
     de: "Schlagworte"
     en: "Subject headings"
     it: "Intestazione del soggetto"
     pt: "Cabeçalhos de assunto"
     es: "Descriptores"
-doc_aid_transposing_instruments: 
-  label: 
+    pl: Słowa kluczowe
+doc_aid_transposing_instruments:
+  label:
     de: "Hilfe zur Transponierung von Instrumenten"
     en: "Help for transposing instruments"
     it: "Aiuto per gli strumenti traspositori"
     pt: Ajuda para instrumentos transpositores
     es: Ayuda para instrumentos transpositores
+    pl: Pomoc przy transpozycji instrumentów
 
 ################
 
-doc_cataloguing: 
-  label: 
+doc_cataloguing:
+  label:
     de: Allgemeine Erfassung Hilfe
     en: General cataloging guidelines
     it: Regole di catalogazione generali
     pt: "Diretrizes gerais para catalogação"
     es: "Lineamientos generales para la catalogación"
-doc_cat_collections: 
-  label: 
+    pl: Ogólne wskazówki do katalogowania
+doc_cat_collections:
+  label:
     de: Erfassung von Sammlungen
     en: Cataloging collections
     it: Catalogazione delle raccolte
     pt: "Catalogação de coletâneas"
     es: "Catalogación de colecciones"
-doc_cat_language: 
-  label: 
+    pl: Katalogowanie kolekcji
+doc_cat_language:
+  label:
     de: Katalogisierungsspache
     en: Cataloging language
-    it: Lingua di catalogazione  
+    it: Lingua di catalogazione
     pt: "Idioma de catalogação"
     es: "Idioma de catalogación"
-doc_cat_templates: 
-  label: 
+    pl: Język katalogowania
+doc_cat_templates:
+  label:
     de: Templates
     en: Templates
     it: Template
     pt: Modelos
     es: Plantillas
-doc_cat_authorities: 
-  label: 
+    pl: Szablony
+doc_cat_authorities:
+  label:
     de: Normdaten
     en: Authorities
     it: Voci di autorità
     pt: "Autoridades"
     es: Autoridades
+    pl: Hasła wzorcowe
 doc_when_new_record:
-  label: 
+  label:
     de: Wann soll einen neuen Eintrag erstellt werden (Musikdrucke)
     en: When to input a new record (printed music)
     it: Quando inserire una nuova scheda (edizioni musicali a stampa)
     pt: "Quando criar um novo registro (música impressa)"
     es: "Cuándo crear un nuevo registro (música impresa)"
-doc_scope_printed_music:  
-  label: 
+    pl: Kiedy wprowadzić nowy rekord (dla druków muzycznych)
+doc_scope_printed_music:
+  label:
     de: Umfang der Dokumentation von Musikdrucke in RISM
     en: Scope of printed music in RISM
     it: Copertura delle edizioni musicali a stampa in RISM
     pt: "Âmbito da música impressa no RISM"
     es: "Cobertura de la música impresa en RISM"
-doc_standardized_titles_printed_music:  
-  label: 
+    pl: Zakres druków muzycznych w RISM
+doc_standardized_titles_printed_music:
+  label:
     de: Einordnungstitel für Musikdrucke
     en: Standardized titles for printed music
     it: Titolo uniforme
     pt: "Títulos uniformes para música impressa"
     es: "Títulos uniformes para música impresa"
+    pl: Znormalizowane tytuły dla druków muzycznych
 
 ################
 
-doc_editor: 
-  label: 
+doc_editor:
+  label:
     de: "Editor Hilfe"
     en: Using Muscat
     it: Guida all'editor
     pt: "Catalogando fontes"
     es: Uso de Muscat
-doc_edit_functions: 
-  label: 
+    pl: Korzystanie z Muscatu
+doc_edit_functions:
+  label:
     de: "Grundsätzliche Funktionen"
     en: Basic functions
     it: Funzioni base
     pt: "Funções básicas"
     es: "Funciones básicas"
-doc_edit_workflow: 
-  label: 
+    pl: Podstawowe funkcje
+doc_edit_workflow:
+  label:
     de: "Workflow"
     en: Workflow
     it: Workflow
+    pl: Przepływ pracy
 doc_edit_searching:
   label:
     de: "Suche"
     en: "Searching"
     it: "Ricerca"
     es: "Búsqueda"
+    pl: Wyszukiwanie
 
 
-   
+
 ################
 
-doc_library: 
-  label: 
+doc_library:
+  label:
     de: Besitzerangaben
     en: Library information
     it: Informazioni sulla biblioteca
     pt: "Informação da instituição"
     es: "Información del repositorio"
-doc_provenance: 
-  label: 
+    pl: Informacje o bibliotece
+doc_provenance:
+  label:
     de: Provenienz
     en: Provenance
     it: Provenienza
     pt: "Proveniência"
     es: Procedencia
-doc_linkage: 
-  label: 
+    pl: Pochodzenie
+doc_linkage:
+  label:
     de: Verlinkung
     en: Linkage
     it: Collegamenti
     es: "Vínculos"
-doc_diplomatic_title: 
-  label: 
+    pl: Powiązanie
+doc_diplomatic_title:
+  label:
     de: Diplomatischer Titel
     en: Diplomatic title
     it: Titolo diplomatico
     es: "Título diplomático"
-doc_physical_description: 
-  label: 
+    pl: Tytuł dyplomatyczny
+doc_physical_description:
+  label:
     de: Materialbeschreibung
     en: Material description
     it: Descrizione del materiale
     pt: "Descrição de material"
     es: "Descripción del material"
-doc_content: 
-  label: 
+    pl: Opis materiału
+doc_content:
+  label:
     de: Inhalt
     en: Content
     it: Contenuto
     es: Contenido
-doc_incipit: 
-  label: 
+    pl: Zawartość
+doc_incipit:
+  label:
     de: Incipits
     en: Incipits
     it: Incipit
     es: "Íncipits"
-doc_bibliographical_reference: 
-  label: 
+    pl: Incipity
+doc_bibliographical_reference:
+  label:
     de: Literatur
     en: References
     it: Riferimenti
     pt: Referências
     es: Referencias
-doc_added_entries: 
-  label: 
+    pl: Odniesienia
+doc_added_entries:
+  label:
     de: Nebeneintragungen
     en: Added entry name
     it: Nomi aggiuntivi
-doc_performance: 
-  label: 
+    pl: Dodana nazwa wpisu
+doc_performance:
+  label:
     de: "Aufführungen"
     en: Performances
     it: Esecuzioni
     es: "Interpretaciones"
-doc_date: 
-  label: 
+    pl: Wykonania
+doc_date:
+  label:
     de: Daten
     en: Dates
     it: Date
     es: Fechas
-doc_administration: 
-  label: 
+    pl: Daty
+doc_administration:
+  label:
     de: Administration
     en: Administration
     it: Amministrazione
     pt: "Administração"
     es: "Administración"
+    pl: Administracja
 doc_personal_names:
   label:
     de: "Personen"
@@ -298,6 +339,7 @@ doc_personal_names:
     it: "Nomi di persona"
     pt: "Nomes de pessoas"
     es: "Nombres personales"
+    pl: Osoby
 doc_images:
   label:
     de: "Bilder"
@@ -305,6 +347,7 @@ doc_images:
     it: "immagini"
     pt: "Imagens"
     es: "Imágenes"
+    pl: Obrazy
 doc_institutions:
   label:
     de: "Körperschaften"
@@ -312,6 +355,7 @@ doc_institutions:
     it: "Enti collettivi"
     pt: "Instituições"
     es: "Instituciones"
+    pl: Instytucje
 doc_title:
   label:
     de: "Titel und Inhaltsangaben"
@@ -319,6 +363,7 @@ doc_title:
     it: "Titolo e descrizione del contenuto"
     pt: "Título e descrição de conteúdo"
     es: "Título y descripción del contenido"
+    pl: Tytuł i opis źródła
 doc_people:
   label:
     de: "Personen und Körperschaften"
@@ -326,6 +371,7 @@ doc_people:
     it: "Persone ed enti colletivi"
     pt: "Pessoas e instituições"
     es: "Personas e instituciones"
+    pl: Osoby i instytucje
 doc_main_entry_fields:
   label:
     de: "Haupteintragungen"
@@ -333,6 +379,7 @@ doc_main_entry_fields:
     it: "Campi principali"
     pt: "Campos de entrada principal"
     es: "Campos principales"
+    pl: Główne pola edycji
 doc_mult_copies:
   label:
     de: "Mehrere Exemplare"
@@ -340,6 +387,7 @@ doc_mult_copies:
     it: "Exemplari multipli"
     pt: "Múltiplos exemplares em uma instituição"
     es: "Múltiples ejemplares en una institución"
+    pl: Wiele kopii
 doc_numbers:
   label:
     de: "Nummern und Codes"
@@ -347,6 +395,7 @@ doc_numbers:
     it: "Campi numerici e codici"
     pt: "Números e campos de código"
     es: "Números y campos de código"
+    pl: Pola liczb i kodów
 doc_name_variants:
   label:
     de: "Namensvarianten"
@@ -354,6 +403,7 @@ doc_name_variants:
     it: "Varianti del nome"
     pt: Variantes de nome
     es: Variantes del nombre
+    pl: Alternatywne nazwy osoby
 doc_relations:
   label:
     de: "Beziehungen"
@@ -361,6 +411,7 @@ doc_relations:
     it: "Relazioni"
     pt: "Relacionamentos"
     es: "Relaciones"
+    pl: Relacje
 doc_references:
   label:
     de: "Literatur und Bemerkungen"
@@ -368,6 +419,7 @@ doc_references:
     it: "Riferimenti"
     pt: "Referências"
     es: "Referencias"
+    pl: Odniesienia
 doc_record_actions:
   label:
     de: "Titel veröffentlichen"
@@ -375,6 +427,7 @@ doc_record_actions:
     it: "Azioni per la scheda"
     pt: "Ações do registro"
     es: "Acciones del registro"
+    pl: Działania na rekordzie
 doc_record_status:
   label:
     de: "RECORD STATUS"
@@ -382,1000 +435,1120 @@ doc_record_status:
     it: "Stato della scheda"
     pt: "Estado do registro"
     es: "Estado del registro"
+    pl: Status rekordu
 ################
 
-01_codes_artistic: 
-  label: 
+01_codes_artistic:
+  label:
     it: Autore
     fr: Auteur
     de: Verfasser
     en: Artistic production
-02_codes_performing: 
-  label: 
+    pl: Autor produkcji artystycznej
+02_codes_performing:
+  label:
     it: Partecipanti
     fr: Exécuteurs
     de: Mitwirkende
     en: Performance
-03_codes_technical: 
-  label: 
+    pl: Wykonanie
+03_codes_technical:
+  label:
     it: Produttore
     fr: "Création"
     de: Hersteller
-    en: Technical production  
-04_codes_other: 
-  label: 
+    en: Technical production
+    pl: Produkcja techniczna
+04_codes_other:
+  label:
     it: Altri
     fr: Autre
     de: Weitere
-    en: Other 
+    en: Other
+    pl: Pozostałe
 
 ################
 
-"000": 
-  label: 
+"000":
+  label:
     it: Leader
     fr: Guide
     de: Leader
     en: Leader
     pt: "Líder"
     es: "Líder"
-"001": 
-  label: 
+    pl: Leader
+"001":
+  label:
     it: Numero documento RISM
     fr: No. RISM
     de: RISM Dokumentnummer
     en: RISM ID No.
     pt: "Número ID RISM"
     es: "Número de ID de RISM"
-"026": 
-  label: 
+    pl: RISM ID
+"026":
+  label:
     it: Impronta
     fr: Indentificateur d'empreintes
-    de: Fingerprint-Erkennung 
+    de: Fingerprint-Erkennung
     en: Fingerprint Identifier
     pt: "Identificador de impressão"
     es: "Identificador tipográfico"
-  fields: 
-    a: 
-      label: 
+    pl: Identyfikator odcisku palca
+  fields:
+    a:
+      label:
         it: Primo/Secondo gruppo
         fr: Premier/deuxième groupe de caractères
         de: Erste und zweite Zeichengruppe
         en: First/second group
         pt: Primeiro/Segundo grupo
         es: Primero/segundo grupo
+        pl: Pierwsza / druga grupa
       comment: "NEW IN 2018"
-    b: 
-      label: 
+    b:
+      label:
         it: Terzo/Quarto gruppo
         fr: Troisième/quatrième groupe de caractères
         de: Dritte und vierte Zeichengruppe
         en: Third/fourth group
         pt: Terceiro/Quarto grupo
         es: Tercero/cuarto grupo
+        pl: Grupa trzecia / czwarta
       comment: "NEW IN 2018"
-    c: 
-      label: 
+    c:
+      label:
         it: Data
         fr: Date
         de: Datum
         en: Date
         pt: Data
         es: Fecha
+        pl: Data
       comment: "NEW IN 2018"
-    d: 
-      label: 
+    d:
+      label:
         it: Numero del volume/parte
         fr: Nombre de volumes ou de pièces
         de: Nummer des Bandes oder Teils
         en: Number of volume/part
         pt: "Número de volume/parte"
         es: "Número de volúmen/parte"
+        pl: Numer wolumenu / części
       comment: "NEW IN 2018"
-    e: 
-      label: 
+    e:
+      label:
         it: Impronta non analizzata
         fr: Empreinte non analysée
         de: Zusammenhängender Fingerprint
         en: Unparsed fingerprint
         pt: "Identificador de impressão não analisado"
         es: "Identificador tipográfico no disgregado"
+        pl: Nieprzeanalizowany odcisk palca
       comment: "NEW IN 2018"
-028: 
-  label: 
+028:
+  label:
     it: Numero della lastra
     fr: "Numéro de plaque"
     de: Plattennummer
     en: Plate Number
     pt: "Número de chapa"
     es: "Número de plancha"
-  fields: 
-    a: 
-      label: 
+    pl: Numer wydawniczy
+  fields:
+    a:
+      label:
         it: Numero della lastra
         fr: "Numéro de plaque"
         de: Plattennummer
         en: Plate number
         pt: "Número de chapa"
         es: "Número de plancha"
-    "8": 
-      label: 
+        pl: Numer wydawniczy
+    "8":
+      label:
         it: Gruppo di materiale
         fr: Documents
         de: Set
         en: Set
         pt: Set
         es: Set
-"031": 
-  label: 
+        pl: Zbiór
+"031":
+  label:
     it: Incipit musicale
     fr: Incipit musical
     de: Musikincipit
     en: Incipit
     pt: Incipit
     es: Íncipit
-  fields: 
-    a: 
-      label: 
+    pl: Incipit
+  fields:
+    a:
+      label:
         it: Numero dell'incipit
         fr: "Numéro de l'œuvre"
         de: Incipitnummer
         en: Work number
         pt: "Número de obra"
         es: "Número de obra"
-      edit_label: 
+        pl: Numer dzieła
+      edit_label:
         it: Numero
         fr: "No. de l'œuvre"
         de: Nummer
         en: Work number
         pt: "Número de obra"
         es: "Número de obra"
-    b: 
-      label: 
+        pl: Numer dzieła
+    b:
+      label:
         it: Movimento N.
         fr: "Numéro du mouvement"
         de: Satznummer
         en: Movement number
         pt: "Número de movimento"
         es: "Número de movimiento"
-      edit_label: 
+        pl: Numer części
+      edit_label:
         it: Movimento N.
         fr: "No. du mouvement"
         de: Satznummer
         en: Movement number
         pt: "Número de movimento"
         es: "Número de movimiento"
-    c: 
-      label: 
+        pl: Numer części
+    c:
+      label:
         it: Numero dell'estratto
         fr: "Numéro de l'extrait"
         de: Abschnitt
         en: Incipit number
         pt: "Número de incipit"
         es: "Número de íncipit"
-      edit_label: 
+        pl: Numer incipitu
+      edit_label:
         it: Estratto No.
         fr: "No. de l'extrait"
         de: Nummer Abschnitt
         en: Incipit number
         pt: "Número de incipit"
         es: "Número de íncipit"
-    m: 
-      label: 
+        pl: Numer incipitu
+    m:
+      label:
         it: Organico
         fr: Voix/instrument
         de: Besetzung
         en: Voice/instrument
         pt: Voz/instrumento
         es: Voz/instrumento
-    n: 
-      label: 
+        pl: Głos/instrument
+    n:
+      label:
         it: Armatura di chiave
         fr: Armure
         de: Akzidentien
         en: Key signature
         pt: "Armadura de clave"
         es: "Armadura de clave"
-      edit_label: 
+        pl: Znaki przykluczowe
+      edit_label:
         it: Armat.
         fr: Armure
         de: Vorzeichen
         en: Key signature
         pt: "Armadura de clave"
         es: "Armadura de clave"
-    d: 
-      label: 
+        pl: Znaki przykluczowe
+    d:
+      label:
         it: Intestazione, Tempo
         fr: Titre/tempo
         de: Satztitel, Tempo
         en: Title of movement, tempo
         pt: "Título do movimento, tempo"
         es: "Título del movimiento, tempo"
-    o: 
-      label: 
+        pl: Tytuł części, tempo
+    o:
+      label:
         it: Misura
         fr: Indication de mesure
         de: Metrum
         en: Time signature
         pt: Compasso
         es: "Indicación de compás"
-      edit_label: 
+        pl: Metrum
+      edit_label:
         it: Misura
         fr: Ind. mesure
         de: Metrum
         en: Time signature
-        pt: Compasso 
+        pt: Compasso
         es: "Indicación de compás"
-    e: 
-      label: 
+        pl: Metrum
+    e:
+      label:
         it: Ruolo
         fr: "Rôle"
         de: Rolle
         en: Role
         pt: Personagem
         es: Personaje
-    p: 
-      label: 
+        pl: Rola
+    p:
+      label:
         it: Incipit musicale
         fr: Notation musicale
         de: Musikincipit
         en: Music incipit
         pt: Incipit musical
         es: "Íncipit musical"
-    q: 
-      label: 
+        pl: Incipit muzyczny
+    q:
+      label:
         it: Commento all'incipit mus.
         fr: "Note générale"
         de: Kommentar zum Musikincipit
         en: General note
         pt: Nota geral
         es: Nota general
-    g: 
-      label: 
+        pl: Uwaga ogólna
+    g:
+      label:
         it: Chiave
         fr: "Clé"
         de: "Schlüssel"
         en: Clef
         pt: Clave
         es: Clave
-      edit_label: 
+        pl: Klucz
+      edit_label:
         it: Chiave
         fr: "Clé"
         de: "Schlüssel"
         en: Clef
         pt: Clave
         es: Clave
-    r: 
-      label: 
+        pl: Klucz
+    r:
+      label:
         it: "Tonalità, modo"
         fr: "Tonalité, mode"
         de: Tonart, Modus
         en: Key or mode
         pt: Tonalidade ou modo
         es: Tonalidad o modo
-      edit_label: 
+        pl: Tonacja lub modus
+      edit_label:
         it: "Tonalità"
         fr: "Tonalité"
         de: Tonart
         en: Key
-        pt: Tonalidade  
+        pt: Tonalidade
         es: Tonalidad
-    s: 
-      label: 
+        pl: Tonacja
+    s:
+      label:
         it: "Validità"
         fr: "Validité"
         de: "Gültigkeit"
         en: Validity
         pt: Validade
         es: Validez
-      edit_label: 
+        pl: Ważność
+      edit_label:
         it: "Validità"
         fr: "Validité"
         de: "Gültigkeit"
         en: "Validity"
         pt: Validade
         es: Validez
-    t: 
-      label: 
+        pl: Ważność
+    t:
+      label:
         it: Incipit testuale
         fr: Incipit du texte
         de: Textincipit
         en: Text incipit
         pt: "Incipit literário"
         es: "Íncipit literario"
-    z: 
-      label: 
+        pl: Incipit tekstowy
+    z:
+      label:
         it: Organico del movimento
         fr: Distribution du mouvement
         de: Besetzung Satz
         en: Scoring in movement
         pt: "Formação instrumental no movimento"
         es: "Plantilla/orgánico del movimiento"
-"033": 
-  label: 
+        pl: Obsada w części
+"033":
+  label:
     it: Data
     fr: Date
     de: Datum
     en: Coded date
     pt: Data codificada
     es: Fecha codificada
-  fields: 
-    a: 
-      label: 
+    pl: Znormalizowana data
+  fields:
+    a:
+      label:
         it: Data e luogo di un evento
         fr: "Date et lieu d'un événement"
         de: Datum und Ort eines Ereignisses (codiert)
         en: Coded date
         pt: Data codificada
         es: Fecha codificada
-    indicator: 
-      label: 
+        pl: Znormalizowana data
+    indicator:
+      label:
         it: Tipo di datazione
         fr: Type de date
         de: Datierungtypus
         en: Date type
         pt: Tipo de data
         es: Tipo de fecha
-    2#: 
-      label: 
+        pl: Rodzaj daty
+    2#:
+      label:
         it: Ambito di datazione
         fr: Intervalle de dates
         de: Datierungsbereich
         en: Range of dates
         pt: Faixa de datas
         es: Rango de fechas
-    1#: 
-      label: 
+        pl: Zakres dat
+    1#:
+      label:
         it: Date singole multiple
         fr: Dates uniques multiples
         de: Mehrere Einzeldaten
         en: Multiple single dates
         pt: "Datas múltiplas"
         es: "Fechas múltiples"
-    0#: 
-      label: 
+        pl: Wiele pojedynczych dat
+    0#:
+      label:
         it: Data singola
         fr: Date unique
         de: Einzeldatum
         en: Single date
         pt: "Data única"
         es: "Fecha única"
-"035": 
-  label: 
+        pl: Pojedyncza data
+"035":
+  label:
     it: Num. locale
     fr: No. local
     de: Lokale Nummer
     en: Local Number
     pt: "Número local"
     es: "Número local"
-  fields: 
-    a: 
-      label: 
+    pl: Numer kontrolny
+  fields:
+    a:
+      label:
         it: Num. locale
         fr: No. local
         de: Lokale Nummer
         en: Local ID no.
         pt: "Número local"
         es: "Número local"
+        pl: Local ID no.
       edit_label:
         en: ""
-"040": 
-  label: 
+"040":
+  label:
     it: Fonte della catalogazione
     fr: Source du catalogage
     de: Katalogisierungsquelle
     en: Cataloguing agency
     pt: "Agência de catalogação"
     es: "Agencia de catalogación"
-  fields: 
-    b: 
-      label: 
+    pl: Jednostka katalogująca
+  fields:
+    b:
+      label:
         it: Lingua della catalogazione
         fr: Langue de catalogage
         de: Katalogisierungssprache
         en: Language of cataloguing
         pt: "Idioma de catalogação"
         es: "Idioma de catalogación"
-"041": 
-  label: 
+        pl: Język katalogowania
+"041":
+  label:
     it: Codice di lingua
     fr: Code de langue
     de: Sprachcode
     en: Language code
     pt: "Código de idioma"
     es: "Código de idioma"
-  fields: 
-    a: 
-      label: 
+    pl: Kod języka
+  fields:
+    a:
+      label:
         it: Lingua del testo cantato
         fr: "Langue du texte chanté"
         de: Sprachcode
         en: Language of text
         pt: "Idioma do texto"
         es: "Idioma del texto"
-    e: 
-      label: 
+        pl: Język tekstu
+    e:
+      label:
         it: Lingua del libretto
         fr: Langue du livret
         de: Sprachcode von Libretti
         en: Language of libretto
         pt: "Idioma do libreto"
         es: "Idioma del libreto"
-    h: 
-      label: 
+        pl: Język libretta
+    h:
+      label:
         it: Lingua del testo originale
         fr: Langue du texte original
         de: Sprachcode des Originaltextes
         en: Language of original text
         pt: "Idioma do texto original"
         es: "Idioma del texto original"
-    indicator: 
-      label: 
+        pl: Język tekstu oryginalnego
+    indicator:
+      label:
         it: Traduzione
         fr: Traduction
         de: "Übersetzung"
         en: Translation
         pt: "Tradução"
         es: "Traducción"
-    1#: 
-      label: 
+        pl: Tłumaczenie
+    1#:
+      label:
         it: "Sì"
         fr: Oui
         de: Ja
         en: "Yes"
         pt: Sim
         es: "Sí"
-    0#: 
-      label: 
+        pl: Tak
+    0#:
+      label:
         it: "No"
         fr: Non
         de: Nein
         en: "No"
         pt: "Não"
         Es: "No"
-"100": 
-  label: 
+        pl: Nie
+"100":
+  label:
     it: Compositore/Autore
     fr: Compositeur/Auteur
     de: Komponist/Autor
     en: Composer/Author
     pt: "Compositor/Autor"
     es: Compositor/Autor
-  fields: 
-    a: 
-      label: 
+    pl: Kompozytor / Autor
+  fields:
+    a:
+      label:
         it: Nome
         fr: Nom
         de: Name
         en: Name
         pt: Nome
         es: Nombre
-    d: 
-      label: 
+        pl: Imię i nazwisko
+    d:
+      label:
         it: Data di nascita e di morte
         fr: Dates de vie
         de: Geburts- und Todesdaten
         en: Life dates
         pt: Datas de nascimento e morte
         es: Fechas de nacimiento y muerte
-    j: 
-      label: 
+        pl: Daty urodzenia i śmierci
+    j:
+      label:
         it: Qualificazione d'attribuzione
         fr: Qualificatif d'attribution
         de: Zuschreibungsvermerk
         en: Attribution qualifier
         pt: "Atribuição"
         es: "Atribución"
-      edit_label: 
+        pl: Kwalifikator atrybucji
+      edit_label:
         it: Attribuzione
         fr: Attribution
         de: Zuschreibung
         en: Attribution
         pt: "Atribuição"
         es: "Atribución"
-"240": 
-  label: 
+        pl: Atrybucja
+"240":
+  label:
     it: Titolo uniforme
     fr: Titre uniforme
     de: Einordnungstitel
     en: Standardized title
     pt: "Título uniforme"
     es: "Título uniforme"
-  fields: 
-    k: 
-      label: 
+    pl: Znormalizowany tytuł
+  fields:
+    k:
+      label:
         it: Suddivisione formale
         fr: Sous-vedette de forme
         de: Unterteilung nach der Form
         en: Subheading
         pt: Tipo especial de fonte
         es: Tipo especial de fuente
-    a: 
-      label: 
+        pl: Pod-nagłówek
+    a:
+      label:
         it: Titolo uniforme
         fr: Titre uniforme
         de: Einordnungstitel
         en: Standardized title
         pt: "Título uniforme"
         es: "Título uniforme"
-    m: 
-      label: 
+        pl: Znormalizowany tytuł
+    m:
+      label:
         it: Organico sintetico
         fr: Distribution
         de: Besetzungshinweis
         en: Scoring summary
         pt: "Sintese da formação instrumental"
         es: "Resumen de Plantilla/Orgánico"
-    o: 
-      label: 
+        pl: Podsumowanie obsady
+    o:
+      label:
         it: Arrangiamento
         fr: Mention d'arrangement
         de: Bearbeitung
         en: Arrangement statement
         pt: "Menção de arranjo"
         es: "Declaración de arreglo"
-    p: 
-      label: 
+        pl: Uwaga do aranżacji
+    p:
+      label:
         it: Titolo della sezione o parte
         fr: Nom de la partie/section
         en: Title of section or part
         es: "Título de la sección o parte"
-    r: 
-      label: 
+        pl: Tytuł sekcji lub części
+    r:
+      label:
         it: "Tonalità"
         fr: "Tonalité"
         de: Tonart
         en: Key or mode
         pt: Tonalidade ou modo
         es: Tonalidad o modo
-"245": 
-  label: 
+        pl: Tonacja lub modus
+"245":
+  label:
     it: Titolo diplomatico
     fr: Titre diplomatique
     de: Diplomatischer Titel
     en: Title on source
     pt: "Título na fonte"
     es: "Título en fuente (diplomático)"
-  fields: 
-    a: 
-      label: 
+    pl: Tytuł w źródle
+  fields:
+    a:
+      label:
         it: Titolo diplomatico
         fr: Titre diplomatique
         de: Diplomatischer Titel
         en: Title on source
         pt: Título na fonte
         es: "Título en fuente"
-"246": 
-  label: 
+        pl: Tytuł w źródle
+"246":
+  label:
     it: Varianti del titolo diplomatico
     fr: Variante du titre diplomatique
     de: Weiterer diplomatischer Titel
     en: Variant title on source
     pt: "Título variante na fonte"
     es: "Variante de título en fuente"
-  fields: 
-    a: 
-      label: 
+    pl: Alternatywny tytuł w źródle
+  fields:
+    a:
+      label:
         it: Varianti del titolo diplomatico
         fr: Variante du titre diplomatique
         de: Weiterer diplomatischer Titel
         en: Variant title on manuscript
         pt: "Variante de título na fonte"
         es: "Variante de título en fuente"
-      edit_label: 
+        pl: Alternatywny tytuł w rękopisie
+      edit_label:
         en: ""
-"260": 
-  label: 
+"260":
+  label:
     it: Copia o dati editoriali
     fr: Copie ou impressum
     de: Abschrift oder Impressum
     en: "Publishing, Printing and Production Information"
     pt: "Informação de publicação, impressão e produção"
     es: "Información de publicación, impresión y producción"
-  fields: 
-    a: 
-      label: 
+    pl: Informacje o publikacji, druku i produkcji
+  fields:
+    a:
+      label:
         it: Luogo
         fr: Lieu
         de: Ort
         en: Place
         pt: Local
         es: Lugar
-    b: 
-      label: 
+        pl: Miejsce
+    b:
+      label:
         it: Copista, editore, casa editrice
         fr: "Copiste ou maison d'édition"
         de: Schreiber, Verleger, Verlag
         en: Publisher, copyist
         pt: Editor, copista
         es: Editor, copista
-    c: 
-      label: 
+        pl: Wydawca, kopista
+    c:
+      label:
         it: Anno
         fr: "Année"
         de: Jahr
         en: Date
         pt: Data
         es: Fecha
-    e: 
-      label: 
+        pl: Data
+    e:
+      label:
         it: Luogo di stampa
         fr: Lieu d'impression
         de: Druckort
         en: Location of printer
         pt: Local de impressão
         es: "Lugar de impresión"
-    f: 
-      label: 
+        pl: Lokalizacja drukarni
+    f:
+      label:
         it: Stampatore, stamperia
         fr: Imprimeur, imprimerie
         de: Drucker, Druckerei
         en: Name of printer
         pt: Nome do impressor
         es: Nombre del impresor
-    "8": 
-      label: 
+        pl: Nazwa drukarni
+    "8":
+      label:
         it: Gruppo di materiale
         fr: Documents
         de: Set
         en: Set
         pt: Set
         es: Set
-"300": 
-  label: 
+        pl: Zbiór
+"300":
+  label:
     it: Materiale
     fr: "Matériel"
     de: Material
     en: Physical description
     pt: "Descrição física"
     es: "Descripción física"
-  fields: 
-    a: 
-      label: 
+    pl: Opis fizyczny
+  fields:
+    a:
+      label:
         it: Categoria di fonte, estensione
         fr: Type de source
         de: Quellenart, Umfang
         en: Format, extent
         pt: "Formato, extensão"
         es: "Formato, extensión"
-    b: 
-      label: 
+        pl: Rodzaj źródła, objętość
+    b:
+      label:
         it: Altri dettagli sul materiale
         fr: Autres détails du matériau
         de: Zusätzliche Materialbeschreibung
         en: Other physical details
         pt: "Outros detalhes físicos"
         es: "Otros detalles físicos"
-    c: 
-      label: 
+        pl: Pozostałe dane fizyczne
+    c:
+      label:
         it: Dimensioni
         fr: Dimension
         de: Format
         en: Dimensions
         pt: "Dimensões"
         es: "Dimensiones"
-    "8": 
-      label: 
+        pl: Wymiary
+    "8":
+      label:
         it: Gruppo di materiale
         fr: Documents
         de: Set
         en: Set
         pt: Set
         es: Set
-"340": 
-  label: 
+        pl: Zbiór
+"340":
+  label:
     it: Tecnica di produzione speciale
     fr: "Technique de production spéciale"
     de: Spezielle Fertigungstechnik
     en: Special production technique
     pt: "Técnica de produção especial"
     es: "Técnica de producción específica"
-  fields: 
-    d: 
-      label: 
+    pl: Specjalna technika produkcji
+  fields:
+    d:
+      label:
         it: Tecnica di stampa
         fr: "Technique d'impression"
         de: Drucktechnik
         en: Printing technique
         pt: "Técnica de impressão"
         es: "Técnica de impresión"
-    m: 
-      label: 
+        pl: Technika druku
+    m:
+      label:
         it: Formato librario
         fr: Format du livre
         de: Buchformat
         en: Book format
         pt: Formato do livro
         es: Formato de libro
+        pl: Format książki
       comment: "NEW IN 2018"
-    "8": 
-      label: 
+    "8":
+      label:
         it: Gruppo di materiale
         fr: Documents
         de: Set
         en: Set
         pt: Set
         es: Set
-"383": 
-  label: 
+        pl: Zbiór
+"383":
+  label:
     it: Num. d'opera
     fr: "Opus"
     de: Opus
     en: Opus number
     pt: Número de Opus
     es: "Número de Opus"
-  fields: 
-    b: 
-      label: 
+    pl: Numer opus
+  fields:
+    b:
+      label:
         it: Num. d'opera
         fr: "No. de Opus"
         de: Opus
         en: Opus number
         pt: "Número de opus"
-"500": 
-  label: 
+        pl: Numer opus
+"500":
+  label:
     it: Osservazioni
     fr: "Remarque générale"
     de: Bemerkungen
     en: General note
     pt: Nota geral
     es: Nota general
-  fields: 
-    a: 
-      label: 
+    pl: Uwaga ogólna
+  fields:
+    a:
+      label:
         it: Osservazioni
         fr: "Remarque générale"
         de: Bemerkungen
         en: General note
         pt: Nota geral
         es: Nota general
-      edit_label: 
+        pl: Uwaga ogólna
+      edit_label:
         en: ""
-    "8": 
-      label: 
+    "8":
+      label:
         it: Gruppo di materiale
         fr: Documents
         de: Set
         en: Set
         pt: Set
         es: Set
-"505": 
-  label: 
+        pl: Zbiór
+"505":
+  label:
     it: Nota di contenuto
     fr: Remarque sur le contenu
     de: Bemerkungen zu Inhaltsangaben
     en: Contents note
     pt: "Nota de conteúdo"
     es: Nota sobre el contenido
-  fields: 
-    a: 
-      label: 
+    pl: Uwaga do zawartości
+  fields:
+    a:
+      label:
         it: Nota di contenuto
         fr: Remarque sur le contenu
         de: Bemerkungen zu Inhaltsangaben
         en: Contents note
         pt: "Nota de conteúdo"
         es: Nota sobre el contenido
-      edit_label: 
+        pl: Uwaga do zawartości
+      edit_label:
         en: ""
-"506": 
-  label: 
+"506":
+  label:
     it: Restrizioni all'accesso
     fr: Restriction d'accès
     de: "Zugangsbeschränkungen"
     en: Access restrictions
     pt: "Restrições de acesso"
     es: Restricciones de acceso
-  fields: 
-    a: 
-      label: 
+    pl: Ograniczenia dostępu
+  fields:
+    a:
+      label:
         it: Restrizioni all'accesso
         fr: Restriction d'accès
         de: "Zugangsbeschränkungen"
         en: Access restriction
         pt: "Restrições de acesso"
         es: Restricciones de acceso
-      edit_label: 
+        pl: Ograniczenie dostępu
+      edit_label:
         en: ""
-"508": 
-  label: 
+"508":
+  label:
     it: Nota sulle responsabilità di creazione/produzione
     fr: "Remarque sur la création/production"
     de: Bemerkung zur Person / Körperschaft
     en: Creation/production note
     pt: "Nota de produção/criação"
     es: "Nota de producción/creación"
-  fields: 
-    a: 
-      label: 
+    pl: Uwagi do wytworzenia / produkcji
+  fields:
+    a:
+      label:
         it: Nota sulle responsabilità di creazione/produzione
         fr: "Note sur la création/production"
         de: Bemerkung zur Person / Körperschaft
         en: Creation/production note
         pt: "Nota de produção/criação"
         es: "Nota de producción/creación"
-      edit_label: 
+        pl: Uwagi do wytworzenia / produkcji
+      edit_label:
         en: ""
-"510": 
-  label: 
+"510":
+  label:
     it: Serie RISM
     fr: Série RISM
     de: RISM Series
     en: RISM Series
     pt: "Série RISM"
     es: Serie RISM
-  fields: 
-    a: 
-      label: 
+    pl: Seria RISM
+  fields:
+    a:
+      label:
         it: Serie
         fr: Série
         de: Series
         en: Series
         pt: "Séries"
         es: Serie
-    c: 
-      label: 
+        pl: Seria
+    c:
+      label:
         it: N.o
         fr: No
         de: No
         en: No
         pt: "Não"
         es: No
-"518": 
-  label: 
+        pl: Nie
+"518":
+  label:
     it: Nota sull'esecuzione
     fr: "Remarque sur les interprètes"
     de: "Bemerkungen zu den Aufführungen"
     en: Note on performance
     pt: Nota sobre performance
     es: "Nota sobre ocasión de interpretación"
-  fields: 
-    a: 
-      label: 
+    pl: Uwaga o wykonaniu
+  fields:
+    a:
+      label:
         it: Nota sull'esecuzione
         fr: "Remarque sur les interprètes"
         de: "Bemerkungen zu den Aufführungen"
         en: Note on Performance
         pt: Nota sobre performance
         es: "Nota sobre ocasión de interpretación"
-      edit_label: 
+        pl: Uwaga o wykonaniu
+      edit_label:
         en: ""
-"520": 
-  label: 
+"520":
+  label:
     it: Riassunto
     fr: "Résumé"
     de: Zusammenfassende Beschreibung
     en: Description summary
     pt: "Síntese da descrição"
     es: "Descripción sumaria"
-  fields: 
-    a: 
-      label: 
+    pl: Podsumowanie
+  fields:
+    a:
+      label:
         it: Riassunto
         fr: "Résumé"
         de: Zusammenfassende Beschreibung
         en: Description summary
         pt: "Síntese da descrição"
         es: "Descripción sumaria"
-      edit_label: 
+        pl: Podsumowanie
+      edit_label:
         en: ""
-"525": 
-  label: 
+"525":
+  label:
     it: Materiali allegati
     fr: "Matériel supplémentaire"
     de: Beigelegtes Material, Addenda
     en: Supplementary material
     pt: Material suplementar
     es: Material suplementario
-  fields: 
-    a: 
-      label: 
+    pl: Materiał uzupełniający
+  fields:
+    a:
+      label:
         it: Materiali allegati
         fr: "Matériel supplémentaire"
         de: Beigelegtes Material, Addenda
         en: Supplementary material
         pt: Material suplementar
         es: Material suplementario
-      edit_label: 
+        pl: Materiał uzupełniający
+      edit_label:
         en: ""
-"541": 
-  label: 
+"541":
+  label:
     it: Fonte immediata d'acquisto
     fr: Source d'acquisition
     de: Unmittelbare Beschaffungsquelle
     en: Source of acquisition
     pt: "Origem da aquisição"
     es: "Fuente de adquisición"
-  fields: 
-    a: 
-      label: 
+    pl: Źródło nabycia
+  fields:
+    a:
+      label:
         it: Nota sulla fonte d'acquisto
         fr: Source d'acquisition
         de: Beschaffungsquelle
         en: Source of acquisition note
         pt: "Nota de origem da aquisição"
         es: "Nota sobre la fuente de adquisición"
-    c: 
-      label: 
+        pl: Uwaga o źródle nabycia
+    c:
+      label:
         it: Metodo d'acquisto
         fr: "Méthode d'acquisition"
         de: Beschaffungsart
         en: Method of acquisition
         pt: "Método de aquisição"
         es: "Método de adquisición"
-    d: 
-      label: 
+        pl: Sposób nabycia
+    d:
+      label:
         it: Data d'acquisto
         fr: Date d'acquisition
         de: Beschaffungsdatum
         en: Date of acquisition
         pt: "Data de aquisição"
         es: "Fecha de adquisición"
-    e: 
-      label: 
+        pl: Data nabycia
+    e:
+      label:
         it: Numero di acquisizione
         fr: Numéro d'acquisition
         de: Akzessionsnumer
         en: Accession number
         pt: "Número de aquisição"
         es: "Número de accesión"
-"546": 
-  label: 
+        pl: Numer akcesji
+"546":
+  label:
     it: Nota sulla lingua
     fr: Note sur la langue
     de: Sprachenvermerk
     en: Language note
     pt: "Nota de idioma"
     es: "Nota de idioma"
-  fields: 
-    a: 
-      label: 
+    pl: Uwaga o języku
+  fields:
+    a:
+      label:
         it: Nota sulla lingua
         fr: Note sur la langue
         de: Sprachenvermerk
         en: Language note
         pt: "Nota de idioma"
         es: "Nota de idioma"
-      edit_label: 
+        pl: Uwaga o języku
+      edit_label:
         en: ""
-"561": 
-  label: 
+"561":
+  label:
     it: Provenienza
     fr: Provenance
     de: Provenienzvermerke
     en: Provenance note
     pt: "Nota de proveniência"
     es: Nota de procedencia
-  fields: 
-    a: 
-      label: 
+    pl: Uwaga o pochodzeniu
+  fields:
+    a:
+      label:
         it: Provenienza
         fr: Provenance
         de: Provenienzvermerke
         en: Provenance notes
         pt: "Nota de proveniência"
         es: Nota de procedencia
-      edit_label: 
+        pl: Uwagi o pochodzeniu
+      edit_label:
         en: ""
-"563": 
-  label: 
+"563":
+  label:
     it: Rilegatura
     fr: Reliure
     de: Einband
     en: Binding note
     pt: "Nota de encadernação"
     es: "Nota de encuadernación"
-  fields: 
-    a: 
-      label: 
+    pl: Uwaga o oprawie
+  fields:
+    a:
+      label:
         it: Rilegatura
         fr: Reliure
         de: Einband
         en: Binding note
         pt: "Nota de encadernação"
         es: "Nota de encuadernación"
-    u: 
-      label: 
+        pl: Uwaga o oprawie
+    u:
+      label:
         it: "INUTILIZZATO - VERRÀ RIMOSSO"
         fr: "UNUSED - WILL BE REMOVED"
         de: "UNUSED - WILL BE REMOVED"
@@ -1383,1192 +1556,1336 @@ doc_record_status:
         pt: "UNUSED - WILL BE REMOVED"
         es: "EN DESUSO - SERÁ REMOVIDO"
         comment: "NEW IN 2018"
-"588": 
-  label: 
+        pl: NIEWYKORZYSTANE – DO USUNIĘCIA
+"588":
+  label:
     it: Copa esaminata per la catalogazione
     fr: Copie consultée pour le catalogage
     de: Vorlageexemplar
     en: Source of description note
     pt: "Exemplar examinado para catalogação"
     es: "Copia examinada para la catalogación"
-  fields: 
-    a: 
-      label: 
+    pl: Uwaga o źródle opisu
+  fields:
+    a:
+      label:
         it: Copa esaminata per la catalogazione
         fr: Copie consultée pour le catalogage
         de: Vorlageexemplar
         en: Copy examined for cataloging
         pt: "Exemplar examinado para catalogação"
         es: "Copia examinada para la catalogación"
+        pl: Katalogowany egzemplarz
       comment: "NEW IN 2018"
-"590": 
-  label: 
+"590":
+  label:
     it: Parti staccate
     fr: Parties
     de: Stimmenmaterial
     en: Parts held and extent
     pt: "Partes existentes e extensão"
     es: "Particellas conservadas y extensión de las mismas"
-  fields: 
-    a: 
-      label: 
+    pl: Głosy, objętość
+  fields:
+    a:
+      label:
         it: Parti staccate esistenti
         fr: Parties existantes
         de: Vorhandene Stimmen
         en: Parts held
         pt: Partes existentes
         es: Particellas conservadas
-    b: 
-      label: 
+        pl: Głosy
+    b:
+      label:
         it: Estensione (parti)
         fr: Extension (parties)
         de: Umfang Stimmenmaterial
         en: Extent (parts)
         pt: "Extensão das partes"
         es: "Extensión (particellas)"
-    "8": 
-      label: 
+        pl: Objętność
+    "8":
+      label:
         it: Gruppo di materiale
         fr: Documents
         de: Set
         en: Set
         pt: Set
         es: Set
-"591": 
-  label: 
+        pl: Zbiór
+"591":
+  label:
     it: Altra segnatura
     fr: Autre cote
     de: Weitere Signatur
     en: Other shelfmark
     pt: "Outro código"
     es: Otra signatura
-  fields: 
-    a: 
-      label: 
+    pl: Inna sygnatura
+  fields:
+    a:
+      label:
         it: Altra segnatura
         fr: Autre cote
         de: Weitere Signatur
         en: Other shelfmark
         pt: "Outro código"
         es: Otra signatura
-"592": 
-  label: 
+        pl: Inna sygnatura
+"592":
+  label:
     it: Filigrana
     fr: Filigrane
     de: Wasserzeichen
     en: Watermark description
     pt: "Descrição de Marca de água"
     es: "Descripción de las filigranas"
-  fields: 
-    a: 
-      label: 
+    pl: Opis znaku wodnego
+  fields:
+    a:
+      label:
         it: Filigrana
         fr: Filigrane
         de: Wasserzeichen
         en: Watermark description
         pt: "Descrição de Marca de água"
         es: "Descripción de las filigranas"
-    "8": 
-      label: 
+        pl: Opis znaku wodnego
+    "8":
+      label:
         it: Gruppo di materiale
         fr: Documents
         de: Set
         en: Set
         pt: Set
         es: Set
-"593": 
-  label: 
+        pl: Zbiór
+"593":
+  label:
     it: Categoria di fonte
     fr: Type de source
     de: Quellentyp
     en: Source type
     pt: Tipo de fonte
     es: Tipo de fuente
-  fields: 
-    a: 
-      label: 
+    pl: Rodzaj źródła
+  fields:
+    a:
+      label:
         it: Categoria
         fr: Type
         de: Typ
         en: Type
         pt: Tipo
         es: Tipo
-    "8": 
-      label: 
+        pl: Rodzaj
+    "8":
+      label:
         it: Gruppo di materiale
         fr: Documents
         de: Set
         en: Set
         pt: Set
         es: Set
-"594": 
-  label: 
+        pl: Zbiór
+"594":
+  label:
     it: Organico
     fr: Instrumentation
     de: Besetzung
     en: Total scoring
     pt: "Formação total"
     es: "Plantilla/orgánico total"
-  fields: 
-    b: 
-      label: 
+    pl: Szczegółowy opis obsady
+  fields:
+    b:
+      label:
         it: Organico
         fr: Instrumentation
         de: Besetzung
         en: "Voice/instrument"
         pt: "Voz/instrumento"
         es: "Voz/instrumento"
-        fields: 
-    c: 
-      label: 
+        pl: Głos/instrument
+ ##       fields:
+    c:
+      label:
         it: Numero
         fr: Nombre
         de: Anzahl
         en: Number
         pt: "Número"
         es: "Número"
-"595": 
-  label: 
+        pl: Liczba
+"595":
+  label:
     it: "Ruoli: nomi  dei personaggi"
     fr: "Rôles: noms"
     de: "Rollennamen: Schreibweise"
     en: Named dramatic roles
     pt: "Papéis dramáticos identificados"
     es: "Nombres de personajes"
-  fields: 
-    a: 
-      label: 
+    pl: Postaci
+  fields:
+    a:
+      label:
         it: Nomi di ruoli standardizzati
         fr: "Noms de rôles standardisés"
         de: Rollennamen, standardisierte Schreibweise
         en: Dramatic roles named, standardized
         pt: "Papéis dramáticos identificados, normalizados"
         es: "Nombres de personajes, normalizados"
-    u: 
-      label: 
+        pl: Znormalizowane nazwy postaci
+    u:
+      label:
         it: "Nomi originali dei personaggi"
         fr: "Noms originaux"
         de: "Originale Schreibweise"
         en: Dramatic roles named, original spelling
         pt: "Papéis dramáticos mencionado, grafia original"
         es: "Nombres de personajes, ortografía original"
-"596": 
-  label: 
+        pl: Postaci w oryginalnej pisowni
+"596":
+  label:
     it: Rimandi a RISM A/I e RISM B
     fr: "Référence au RISM A/I et B"
     de: Querverweise zu RISM A/I und RISM B
     en: RISM Series A/I and B references
     pt: "Referências às Séries RISM A/I e B"
     es: Referencias a las Series RISM A/I y B
-  fields: 
-    a: 
-      label: 
+    pl: Odniesienia do serii RISM A/I i B
+  fields:
+    a:
+      label:
         it: Serie RISM
         fr: "Références au RISM A/I et B"
         de: Querverweise zu RISM A/I und RISM B
         en: RISM Series A/I and B references
         pt: "Referências às séries RISM A/I e B"
         es: Referencias a las Series RISM A/I y B
-      edit_label: 
+        pl: Odniesienia do serii RISM A/I i B
+      edit_label:
       en: ""
-    b: 
-      label: 
+    b:
+      label:
         it: Numero RISM
         fr: Numéro RISM
         de: RISM-Nummer
         en: RISM series number
         pt: "Número de série RISM"
         es: "Número de serie RISM"
-      edit_label: 
+        pl: Nr seryjny RISM
+      edit_label:
       en: ""
-    c: 
-      label: 
+    c:
+      label:
         it: Numero identificativo della scheda di riferimento
         fr: REFERENCE RECORD ID
         de: REFERENCE RECORD ID
         en: REFERENCE RECORD ID
         pt: REFERENCE RECORD ID
         es: ID del Registro de Referencia
-      edit_label: 
+        pl: Referncyjny identyfikator RISM
+      edit_label:
       comment: "NEW IN 2018"
-"597": 
-  label: 
+"597":
+  label:
     it: Colofone
     fr: COLOPHON
     de: Kolophon
     en: Colophon
     pt: "Colofão"
     es: "Colofón"
-  fields: 
-    a: 
-      label: 
+    pl: Kolofon
+  fields:
+    a:
+      label:
         it: Colofone
         fr: COLOPHON
         de: Kolophon
         en: Colophon
         pt: "Colofão"
         es: "Colofón"
-"598": 
-  label: 
+        pl: Kolofon
+"598":
+  label:
     it: Codice della strumentazione
     fr: Instrumentation codée
     de: "Kodierte Besetzung"
     en: Coded instrumentation
     pt: "Instrumentação codificada"
     es: "Intrumentación codificada"
-  fields: 
-    a: 
-      label: 
+    pl: Standaryzowany zapis instrumentacji
+  fields:
+    a:
+      label:
         it: Voce solista
         fr: Voix seule
         de: Solostimme
         en: Solo voice
         pt: Voz solista
         es: Voz solista
+        pl: Głos solowy
 
-      edit_label: 
+      edit_label:
         it: Vsolo
         fr: Vsolo
         de: Vsolo
         en: Vocal solo
         pt: Voz solista
         es: Voz solista
+        pl: Solo wokalne
 
-    b: 
-      label: 
+    b:
+      label:
         it: Voce solista aggiuntiva
         fr: Voix seule additionnelle
         de: "Zusätzliche Solostimme"
         en: Additional solo voice
         es: Voz solista adicional
-      edit_label: 
+        pl: Dodatkowy głos solowy
+      edit_label:
         it: Vsolo
         fr: Vsolo
         de: Vsolo
         en: Vocal solo
         pt: Voz solista
         es: Voz solista
-    c: 
-      label: 
+        pl: Solo wokalne
+    c:
+      label:
         it: Voci di coro
         fr: Voix de choeur
         de: Chorstimmen
         en: Choir voice
         es: Voz en coro
-      edit_label: 
+        pl: Głos chóralny
+      edit_label:
         it: Coro
         fr: Coro
         de: Coro
         en: Chorus
         pt: Coro
         es: Coro
+        pl: Chór
 
-    d: 
-      label: 
+    d:
+      label:
         it: Voci di coro aggiuntive
         fr: Voix de choeur additionnelles
         de: "Zusätzliche Chorstimmen"
         en: Additional choir voice
         es: Voz en coro adicional
-      edit_label: 
+        pl: Dodatkowy głos chóralny
+      edit_label:
         it: Coro
         fr: Coro
         de: Coro
         en: Coro
         pt: Coro
         es: Coro
+        pl: Chór
 
-    e: 
-      label: 
+    e:
+      label:
         it: Strumento solista
         fr: Instrument soliste
         de: Solistisches Instrument
         en: Soloist intrument
         es: Instrumento solista
-      edit_label: 
+        pl: Instrument solowy
+      edit_label:
         it: iSol
         fr: iSol
         de: iSol
         en: Solo instruments
         pt: Instrumento solista
         es: Instrumento solista
-    f: 
-      label: 
+        pl: Instrumenty solowe
+    f:
+      label:
         it: Archi
         fr: Cordes
         de: Streichinstrumente
         en: Strings
         pt: Cordas
         es: Cuerdas
-      edit_label: 
+        pl: Instrumenty strunowe
+      edit_label:
         it: strings
         fr: strings
         de: strings
         en: Strings
         pt: Cordas
         es: Cuerdas
-    g: 
-      label: 
+        pl: Instrumenty strunowe
+    g:
+      label:
         it: Legni
         fr: Bois
         de: Holzblasinstrumente
         en: Woodwinds
         pt: Madeiras
         es: Vientos-madera
-      edit_label: 
+        pl: Instrumenty dęte drewniane
+      edit_label:
         it: woodwinds
         fr: woodwinds
         de: woodwinds
         en: Woodwinds
         pt: Madeiras
         es: Vientos-madera
-    h: 
-      label: 
+        pl: Instrumenty dęte drewniane
+    h:
+      label:
         it: Ottoni
         fr: Cuivres
         de: Blechblasinstrumente
         en: Brass instruments
         pt: Metais
         es: Vientos-metal
-      edit_label: 
+        pl: Instrumenty dęte blaszane
+      edit_label:
         it: brasses
         fr: brasses
         de: brass instruments
         en: Brass instruments
         pt: Metais
         es: Vientos-metal
-    i: 
-      label: 
+        pl: Instrumenty dęte blaszane
+    i:
+      label:
         it: Strumenti a pizzico
         fr: "Instruments à cordes pincées"
         de: Zupfinstrumente
         en: Plucked instruments
         pt: Cordas dedilhadas
         es: Cuerdas pulsadas
-      edit_label: 
+        pl: Instrumenty szarpane
+      edit_label:
         it: plck
         fr: plck
         de: plck
         en: Plucked
         pt: Cordas dedilhadas
         es: Cuerdas pulsadas
-    k: 
-      label: 
+        pl: Instrumenty szarpane
+    k:
+      label:
         it: Strumenti a percussione
         fr: Percussions
         de: Schlaginstrumente
         en: Percussion
         pt: "Percussão"
-      edit_label: 
+        pl: Perkusja
+      edit_label:
         it: stck
         fr: stck
         de: stck
         en: Percussion
         pt: "Percussão"
         es: "Percusión"
-    l: 
-      label: 
+        pl: Perkusja
+    l:
+      label:
         it: Strumenti a tastiera
         fr: "Instruments à clavier"
         de: Tasteninstrumente
         en: Keyboards
         pt: Teclados
-      edit_label: 
+        pl: Instrumenty klawiszowe
+      edit_label:
         it: keyb
         fr: keby
         de: keyb
         en: Keyboards
         pt: Teclados
         es: Teclados
-    m: 
-      label: 
+        pl: Instrumenty klawiszowe
+    m:
+      label:
         it: Altri strumenti
         fr: Autres instruments
         de: Weitere Instrumente
         en: Other instruments
         pt: Outros instrumentos
         es: Otros instrumentos
-      edit_label: 
+        pl: Pozostałe instrumenty
+      edit_label:
         it: other instr.
         fr: other instr.
         de: other instr.
         en: other instruments
         pt: Outros instrumentos
         es: Otros instrumentos
-    n: 
-      label: 
+        pl: Pozostałe instrumenty
+    n:
+      label:
         it: Basso continuo
         fr: Basso continuo
         de: Basso continuo
         en: Basso continuo
         pt: "Contínuo"
         es: Bajo continuo
-      edit_label: 
+        pl: Basso continuo
+      edit_label:
         it: B.c.
         fr: B.c.
         de: B.c.
         en: Continuo
         pt: "Contínuo"
         es: Continuo
-"599": 
-  label: 
+        pl: Continuo
+"599":
+  label:
     it: Commenti interni
     fr: Commentaires internes
     de: Interne Fussnoten
     en: Internal note
     pt: Campo de notas locais
     es: Nota interna
-  fields: 
-    a: 
-      label: 
+    pl: Uwaga wewnętrzna
+  fields:
+    a:
+      label:
         it: Commenti interni
         fr: Commentaires internes
         de: Interne Fussnoten
         en: Internal note
         pt: Campo de notas locais
         es: Nota interna
-      edit_label: 
+        pl: Uwaga wewnętrzna
+      edit_label:
         en: ""
-    b: 
-      label: 
+    b:
+      label:
         it: RECORD AUDIT
         fr: RECORD AUDIT
         de: RECORD AUDIT
         en: RECORD AUDIT
         pt: RECORD AUDIT
         es: RECORD AUDIT
-      edit_label: 
+        pl: RECORD AUDIT
+      edit_label:
         en: ""
       comment: "NEW IN 2018; filled out automatically by wf_stage"
-"650": 
-  label: 
+"650":
+  label:
     it: Parola chiave
     fr: Sujets
     de: Schlagworteintragung
     en: Subject heading
     pt: "Cabeçalho de assunto"
     es: "Descriptor"
-  fields: 
-    a: 
-      label: 
+    pl: Słowo kluczowe
+  fields:
+    a:
+      label:
         it: Parola chiave
         de: Sachschlagwort
         fr: Sujet
         en: Subject heading
         pt: "Cabeçalho de assunto"
         es: "Descriptor"
-      edit_label: 
+        pl: Słowo kluczowe
+      edit_label:
         en: ""
-"651": 
-  label: 
+"651":
+  label:
     it: Luogo di un evento
     fr: "Lieu d'un événement"
     de: "Aufführungsort"
     en: Location of performance
     pt: "Local de performance"
     es: "Lugar de interpretación"
-  fields: 
-    a: 
-      label: 
+    pl: Lokalizacja wykonania
+  fields:
+    a:
+      label:
         it: Luogo di un evento
         fr: "Lieu d'un événement"
         de: "Aufführungsort"
         en: Location of performance
         pt: "Local de performance"
         es: "Lugar de interpretación"
-      edit_label: 
+        pl: Lokalizacja wykonania
+      edit_label:
         en: ""
-"657": 
-  label: 
+"657":
+  label:
     it: Feste liturgiche
     fr: "Fête liturgique"
     de: Liturgische Feste
     en: Liturgical festival
     pt: "Festa litúrgica"
     es: "Festividad litúrgica"
-  fields: 
-    a: 
-      label: 
+    pl: Święto liturgiczne
+  fields:
+    a:
+      label:
         it: Feste liturgiche
         fr: "Fête liturgique"
         de: Liturgische Feste
         en: Liturgical feasts
         pt: "Festa litúrgica"
         es: "Festividad litúrgica"
-      edit_label: 
+        pl: Święta liturgiczne
+      edit_label:
         en: ""
-"690": 
-  label: 
+"690":
+  label:
     it: Catalogo tematico
     fr: Nom de catalogue
     de: Werkverzeichnis
     en: Catalog of works
     pt: "Catálogo de obras"
     es: "Catálogo de obras"
-  fields: 
-    a: 
-      label: 
+    pl: Katalog dzieł
+  fields:
+    a:
+      label:
         it: Catalogo tematico
         fr: Nom de catalogue
         de: Werkverzeichnis
         en: Catalog of works
         pt: "Catálogo de obras"
         es: "Catálogo de obras"
-    n: 
-      label: 
+        pl: Katalog dzieł
+    n:
+      label:
         it: Numero/pagina
         fr: "Numéro/page"
         de: Nummer/Seitenzahl
         en: Number/page
         pt: "Número/página"
         es: "Número/página"
-"691": 
-  label: 
+        pl: Numer / strona
+"691":
+  label:
     it: Riferimenti bibliografici
     fr: "Référence bibliographique"
     de: Literaturverweis
     en: Bibliographic reference
     pt: "Referência bibliográfica"
     es: "Referencia bibliográfica"
-  fields: 
-    a: 
-      label: 
+    pl: Odniesienie bibliograficzne
+  fields:
+    a:
+      label:
         it: Bibliografia
         fr: "Référence bibliographique"
         de: Literatur
         en: Bibliographic reference
         pt: "Referência bibliográfica"
         es: "Referencia bibliográfica"
-    n: 
-      label: 
+        pl: Odniesienie bibliograficzne
+    n:
+      label:
         it: Numero/pagina
         fr: "Numéro/page"
         de: Fundstelle
         en: Number/page
         pt: "Número/página"
         es: "Número/página"
-"700": 
-  label: 
+        pl: Numer / strona
+"700":
+  label:
     it: Nomi di persone aggiuntivi
     fr: Noms de personnes additionnels
     de: Nebeneintragung Personen
     en: Additional personal name
     pt: Nome de pessoa adicional
     es: Nombre personal adicional
-  fields: 
-    a: 
-      label: 
+    pl: Dodatkowa osoba
+  fields:
+    a:
+      label:
         it: Nome
         fr: Nom
         de: Personenname
         en: Name
         pt: Nome
         es: Nombre
-    d: 
-      label: 
+        pl: Imię i nazwisko
+    d:
+      label:
         it: Date di nascita e di morte
         fr: Dates de vie
         de: Geburts- und Todesdaten
         en: Life dates
         pt: Datas de nascimento e morte
         es: Fechas de nacimiento y muerte
-    j: 
-      label: 
+        pl: Daty urodzenia i śmierci
+    j:
+      label:
         it: Qualificazione d'attribuzione
         fr: Qualificatif d'attribution
         de: Zuschreibungsvermerk
         en: Attribution qualifier
         pt: "Atribuição"
         es: "Calificador de atribución"
-      edit_label: 
+        pl: Kwalifikator atrybucji
+      edit_label:
         it: Attribuzione
         fr: Attribution
         de: Zuschreibung
         en: Attribution
         pt: "Atribuição"
         es: "Atribución"
-    "4": 
-      label: 
+        pl: Atrybucja
+    "4":
+      label:
         it: Funzione
         fr: Function
         de: Funktionsbezeichnung
         en: Function
         pt: "Função"
         es: "Función"
-    "8": 
-      label: 
+        pl: Funkcja
+    "8":
+      label:
         it: Gruppo di materiale
         fr: Documents
         de: Set
         en: Set
         pt: Set
         es: Set
-"710": 
-  label: 
+        pl: Zbiór
+"710":
+  label:
     it: Nome di ente
     fr: "Nom de la collectivité"
     de: Nebeneintragung Körperschaften
     en: Additional institution
     pt: "Instituição adicional"
     es: "Institución adicional"
-  fields: 
-    a: 
-      label: 
+    pl: Dodatkowa instytucja
+  fields:
+    a:
+      label:
         it: Nome di ente
         fr: "Nom de la collectivité"
         de: Körperschaftsname
         en: Institution
         pt: "Instituição"
         es: "Institución"
-    b: 
-      label: 
+        pl: Instytucja
+    b:
+      label:
         it: Ente subordinato
         fr: "Collectivité subordonnée"
         de: Untergeordnete Körperschaft
         en: Department
         pt: Departamento
         es: Departamento
-    g: 
-      label: 
+        pl: Wydział
+    g:
+      label:
         it: Qualificazione d'attribuzione
         fr: Qualificatif d'attribution
         de: Zuschreibungsvermerk
         en: Attribution qualifier
         pt: "Atribuição"
         es: "Atribución"
-      edit_label: 
+        pl: Kwalifikator atrybucji
+      edit_label:
         it: Attribuzione
         fr: Attribution
         de: Zuschreibung
         en: Attribution
         pt: "Atribuição"
         es: "Atribución"
+        pl: Atrybucja
 
-    "4": 
-      label: 
+    "4":
+      label:
         it: Funzione
         fr: Fonction
         de: Funktionsbezeichnung
         en: Function
         pt: "Função"
         es: "Función"
-    "8": 
-      label: 
+        pl: Funkcja
+    "8":
+      label:
         it: Gruppo di materiale
         fr: Documents
         de: Set
         en: Set
         pt: Set
         es: Set
-"730": 
-  label: 
+        pl: Zbiór
+"730":
+  label:
     it: Titolo uniforme alternativo
     fr: Titres uniformes additionnels
     de: Alternativer Titel
     en: Additional title
     pt: "Título adicional"
     es: "Título adicional"
-  fields: 
-    a: 
-      label: 
+    pl: Dodatkowy tytuł
+  fields:
+    a:
+      label:
         it: Titolo uniforme alternativo
         fr: Titres uniformes additionnels
         de: Alternativer Titel
         en: Additional title
         pt: "Título adicional"
         es: "Título adicional"
-    g: 
-      label: 
+        pl: Dodatkowy tytuł
+    g:
+      label:
         it: Regole di cat.
         fr: Règle de cat.
         de: Regelwerk
         en: Rule type
         pt: "Regras de catalogação"
         es: "Tipo de regla"
-    k: 
-      label: 
+        pl: Standard
+    k:
+      label:
         it: Suddivisione formale
         fr: Sous-vedette de forme
         de: Unterteilung nach der Form
         en: Subheading
         pt: "Subdivisão de forma"
         es: Tipo especial de fuente
-    m: 
-      label: 
+        pl: Pod-nagłówek
+    m:
+      label:
         it: Organico sintetico
         fr: Distribution
         de: Besetzungshinweis
         en: Scoring summary
         pt: "Sintese da formação instrumental"
         es: "Resumen de plantilla/orgánico"
-    n: 
-      label: 
+        pl: Podsumowanie obsady
+    n:
+      label:
         it: Catalogo/Numero d'opera
         fr: "No. de catalogue thématique/Opus"
         de: Werkverzeichnis/Opus
         en: Catalogue number/Opus number
         pt: "Número de catalogo/Número de Opus"
-    o: 
-      label: 
+        pl: Numer katalogu / numer opus
+    o:
+      label:
         it: Arrangiamento
         fr: Mention d'arrangement
         de: Bearbeitung
         en: Arrangement statement
         pt: "Menção de arranjo"
         es: "Declaración de arreglo"
-    r: 
-      label: 
+        pl: Uwaga do aranżacji
+    r:
+      label:
         it: "Tonalità"
         fr: "Tonalité"
         de: Tonart
         en: Key
         pt: Tonalidade
         es: Tonalidad
-"774": 
-  label: 
+        pl: Tonacja
+"774":
+  label:
     it: Singoli oggetti nella fonte
     fr: Contenu de la source
     de: Untergeordnete Einträge
     en: Items in this source
     pt: Itens nesta fonte
     es: "Ítems en esta fuente"
-  fields: 
-    w: 
-      label: 
+    pl: Pozycje w tym źródle
+  fields:
+    w:
+      label:
         it: Singolo oggetto nella fonte
         fr: Source dans cette collection
         de: Untergeordneter Eintrag
         en: Item in this collection
         pt: Itens nesta fonte
         es: "Ítems en esta fuente"
-      edit_label: 
+        pl: Pozycja w tej kolekcji
+      edit_label:
         en: ""
-"773": 
-  label: 
+"773":
+  label:
     it: Notizia principale
     fr: Source principale
     de: Übergeordneter Eintrag
     en: Parent record
     pt: "Registro principal"
     es: Registro madre
-  fields: 
-    w: 
-      label: 
+    pl: Rekord macierzysty
+  fields:
+    w:
+      label:
         it: Notizia principale
         fr: Source principale
         de: Übergeordneter Eintrag
         en: Parent record
         pt: "Registro principal"
         es: Registro madre
-      edit_label: 
+        pl: Rekord macierzysty
+      edit_label:
         en: ""
-"775": 
-  label: 
+"775":
+  label:
     it: Prima notizia
     fr: "Première entrée"
     de: Ersteintrag
     en: Initial entry
     pt: Entrada inicial
     es: Entrada inicial
-  fields: 
-    w: 
-      label: 
+    pl: Początkowy wpis
+  fields:
+    w:
+      label:
         it: Prima notizia
         fr: "Première entrée"
         de: Ersteintrag
         en: Initial entry
         pt: Entrada inicial
         es: Entrada inicial
-      edit_label: 
+        pl: Początkowy wpis
+      edit_label:
         en: ""
-"787": 
-  label: 
+"787":
+  label:
     it: Inserimenti
     fr: Insertions
     de: Einlagen
     en: Insertions
     pt: "Inserções"
     es: Inserciones
-  fields: 
-    w: 
-      label: 
+    pl: Wstawienia
+  fields:
+    w:
+      label:
         it: Numero RISM dell'opera principale
         fr: "Numéro RISM de la source"
         de: RISM Dokumentnummer des Hauptwerks
         en: RISM ID number
         pt: "Número ID RISM"
         es: "Número de ID de RISM"
-    n: 
-      label: 
+        pl: RISM ID
+    n:
+      label:
         it: Collocazione dell'inserimento nell'opera principale
         fr: Remarque sur l'endroit de l'insertion
         de: Stelle der Einlage im Hauptwerk
         en: Location of insertion
         pt: "Localização da inserção"
         es: "Ubiación de la inserción"
-    g: 
-      label: 
+        pl: Lokalizacja wstawienia
+    g:
+      label:
         it: N.o dell'incipit
         fr: No. d'incipit
         de: Incipitnummer
         en: Incipit number
         pt: "Número de incipit"
         es: "Número de íncipit"
-    s: 
-      label: 
+        pl: Numer incipitu
+    s:
+      label:
         it: Titolo uniforme
         fr: Titre uniforme
         de: Einordnungstitel des Hauptwerks
         en: Standardized title
         pt: "Título uniforme"
         es: "Título uniforme"
-"852": 
-  label: 
+        pl: Znormalizowany tytuł
+"852":
+  label:
     it: Sigla della biblioteca
     fr: "Sigle de bibliothèque"
     de: Bibliothekssigel
     en: Library siglum
     pt: "Sigla da Instituição"
     es: "Sigla del repositorio"
-  fields: 
-    a: 
-      label: 
+    pl: Siglum
+  fields:
+    a:
+      label:
         it: Sigla della biblioteca
         fr: "Sigle de bibliothèque"
         de: Bibliothekssigel
         en: Library siglum
         pt: "Sigla da Instituição"
         es: "Sigla del repositorio"
-    b: 
-      label: 
+        pl: Siglum
+    b:
+      label:
         it: Dipartimento
         fr: Section
         de: Abteilung
         en: Department
         pt: Departamento
-        es: Departamento 
-    c: 
-      label: 
+        es: Departamento
+        pl: Wydział
+    c:
+      label:
         it: Segnatura
         fr: Cote
         de: Signatur
         en: Shelfmark
         pt: "Código"
         es: "Signatura"
-    d: 
-      label: 
+        pl: Sygnatura
+    d:
+      label:
         it: Segnatura vecchia (olim)
         fr: Ancienne cote (olim)
         de: Alte Signatur (olim)
         en: Shelfmark (olim)
         pt: "Código antigo (olim)"
         es: Signatura antigua (olim)
-    e: 
-      label: 
+        pl: Sygnatura (wcześniejsza)
+    e:
+      label:
         it: Biblioteca
         fr: "Bibliothèque"
         de: Bibliothek
         en: Library
         pt: "Instituição"
         es: "Repositorio"
-    q: 
-      label: 
+        pl: Biblioteka
+    q:
+      label:
         it: Materiale conservato
         fr: Matériaux préservées
         de: Erhaltenes Material
         en: Material held
         pt: Material existente
         es: Material conservado
-    u: 
-      label: 
+        pl: Posiadany materiał
+    u:
+      label:
         it: URI
         fr: URI
         de: URI
         en: URI
         pt: URI
         es: URI
-    z: 
-      label: 
+        pl: URI
+    z:
+      label:
         it: Nome del fondo
         fr: Fonds
         de: Bestandsname
         en: Provenance
         pt: "Proveniência"
-        es: Procedencia 
-"856": 
-  label: 
+        es: Procedencia
+        pl: Pochodzenie
+"856":
+  label:
     it: Localizzazione e accesso elettronico
     fr: "Ressource électronique externe"
     de: Elektronische Lokalisierung und Zugriff
     en: External resource
     pt: Recurso externo
     es: Recurso externo
-  fields: 
-    z: 
-      label: 
+    pl: Zasób zewnętrzny
+  fields:
+    z:
+      label:
         it: Nota destinata al pubblico
         fr: Remarque sur la ressource externe
         de: "Für das Publikum bestimmte Fussnote"
         en: Note about external resource
         pt: Nota sobre recurso externo
         es: Nota sobre el recurso externo
-    u: 
-      label: 
+        pl: Uwaga o zasobie zewnętrznym
+    u:
+      label:
         it: Risorsa esterna
         fr: Ressource externe
         de: Uniform Resource Identifier
         en: External resource
         pt: Recurso externo
         es: Nota sobre recurso externo
-    x: 
-      label: 
+        pl: Zasób zewnętrzny
+    x:
+      label:
         it: Tipo di collegamento
         fr: Type de lien
         de: Linktyp
         en: Link type
         pt: Tipo de Link
         es: Tipo de enlace
-"930": 
-  label: 
+        pl: Typ odsyłacza
+"930":
+  label:
     it: Composizione
     fr: Oeuvre
     de: Werktitel
     en: Work
     pt: Obra
     es: Obra
-  fields: 
-    a: 
-      label: 
+    pl: Dzieło
+  fields:
+    a:
+      label:
         it: Composizione
         de: Werktitel
         fr: Oeuvre
         en: Work
         pt: Obra
         es: Obra
-      edit_label: 
+        pl: Dzieło
+      edit_label:
         en: ""
       comment: "NEW IN 2018; experimental stage"
-"980": 
-  label: 
+"980":
+  label:
     it: Origine della scheda
     fr: RECORD ORIGIN
     de: Herkunft
     en: Record origin
     pt: "Origem do registro"
     es: Origen del registro
-  fields: 
-    a: 
-      label: 
+    pl: Pochodzenie rekordu
+  fields:
+    a:
+      label:
         it: Origine
         fr: ORIGIN
         de: Herkunft
         en: Origin
         pt: Origem
         es: Origen
+        pl: Pochodzenie
       comment: "NEW IN 2018"
-    b: 
-      label: 
+    b:
+      label:
         it: Livello di catalogazione
         fr: CATALOGING LEVEL
         de: Erfassungstiefe
         en: Cataloging level
         es: Nivel de catalogación
         pt: "Nível de catalogação"
+        pl: Poziom katalogowania
       comment: "NEW IN 2018"
-    c: 
-      label: 
+    c:
+      label:
         it: Materiale esaminato
         fr: MATERIAL EXAMINED
         de: Autopsie
         en: Material examined
         es: Material examinado
+        pl: Zbadany materiał
       comment: "NEW IN 2018"
-        
+
 ################
 
-show_admin: 
-  label: 
+show_admin:
+  label:
     it: Amministrazione
     fr: Administration
     de: Administration
     en: Administration
     pt: "Administração"
     es: "Administración"
-show_content: 
-  label: 
+    pl: Administracja
+show_content:
+  label:
     it: Contenuto
     fr: Contenu
     de: Inhalt
     en: Content
     es: Contenido
-show_distribution: 
-  label: 
+    pl: Zawartość
+show_distribution:
+  label:
     it: Organico
     fr: Distribution
     de: Besetzung
     en: Distribution
     es: Distribución
-show_information: 
-  label: 
+    pl: Dystrybucja
+show_information:
+  label:
     it: Note
     fr: "Information supplémentaire"
     de: Anmerkungen
     en: Further information
     es: "Más información"
-show_library: 
-  label: 
+    pl: Dalsze informacje
+show_library:
+  label:
     it: Biblioteca
     fr: "Bibliothèque"
     de: Besitzerangaben
     en: Library information
     pt: "Informação da instituição"
     es: "Información del repositorio"
-show_links: 
-  label: 
+    pl: Informacje o bibliotece
+show_links:
+  label:
     it: Titoli connessi
     fr: Titres connexes
     de: Verlinkungen
     en: Related Titles
     es: "Títulos relacionados"
-show_material: 
-  label: 
+    pl: Powiązane tytuły
+show_material:
+  label:
     it: Descrizione del materiale
     fr: "Description du matériel"
     de: Materialbeschreibung
     en: Material description
     pt: "Descrição de material"
     es: "Descripción del material"
-show_references: 
-  label: 
+    pl: Opis materiału
+show_references:
+  label:
     it: Bibliografia
     fr: "Références"
     de: Literatur
     en: References
     pt: "Referências"
     es: "Referencias"
-show_resources: 
-  label: 
+    pl: Odniesienia
+show_resources:
+  label:
     it: Collegamenti
     fr: Liens
     de: Links
     en: Related resources
     es: Recursos relacionados
-show_summary: 
-  label: 
+    pl: Powiązane zasoby
+show_summary:
+  label:
     it: Riassunto
     fr: "Résumé"
     de: Zusammenfassung
     en: Summary
     es: Resumen
-show_terms: 
-  label: 
+    pl: Podsumowanie
+show_terms:
+  label:
     it: Descrittori
     fr: Termes
     de: Deskriptoren
     en: Index terms
     es: "Términos de indexación"
-        
+    pl: Pojęcia indeksowane
+
 ################
-        
+
 edit_administration:
-  label: 
+  label:
     it: Amministrazione
     fr: Administration
     de: Administration
     en: Administration
     pt: "Administração"
     es: "Administración"
-edit_content: 
-  label: 
+    pl: Administracja
+edit_content:
+  label:
     it: Titolo e descrizione del contenuto
     fr: Titre et description du contenu
     de: Titel und Inhaltsangaben
     en: Title and content description
     pt: "Título e descrição do conteúdo"
     es: "Título y descripción del contenido"
-edit_incipits: 
-  label: 
+    pl: Tytuł i opis źródła
+edit_incipits:
+  label:
     it: Incipit
     fr: Incipits
     de: Incipits
     en: Incipits
     pt: Incipit
     es: "Íncipits"
-edit_library: 
-  label: 
+    pl: Incipity
+edit_library:
+  label:
     it: Biblioteca e relazione
     fr: "Bibliothèque et relations"
     de: Besitzerangaben und Verlinkung
     en: Library information and relations
     pt: "Informação da instituição e relações"
     es: "Información del repositorio y sus relaciones"
-edit_material: 
-  label: 
+    pl: Informacje o bibliotece i powiązaniach
+edit_material:
+  label:
     it: Descrizione del materiale
     fr: "Description du matériel"
     de: Materialbeschreibung
     en: Material description
     pt: "Descrição de material"
     es: "Descripción del material"
+    pl: Opis materiału
 
-edit_names: 
-  label: 
+edit_names:
+  label:
     it: Persone e istituzione
     fr: Personnes et institutions
     de: Personen und Körperschaften
     en: People and institutions
     pt: "Pessoas e instituições"
     es: "Personas e instituciones"
-edit_references: 
-  label: 
+    pl: Osoby i instytucje
+edit_references:
+  label:
     it: Bibliografia e note
     fr: "Références et notes"
     de: Literatur und Fussnoten
     en: References and notes
     pt: "Notas e referências"
     es: "Notas y referencias"
-edit_works: 
-  label: 
+    pl: Odniesienia i uwagi
+edit_works:
+  label:
     it: Composizione
     fr: Oeuvre
     de: Werk
     en: Work
     pt: Obra
     es: Obra
+    pl: Dzieło
 
-unmatched: 
-  label: 
+unmatched:
+  label:
     it: Campi sconoscuti
     fr: Champs non reconnus
     de: Unbekannte Felder
     en: Unknown fields
     es: Campos desconocidos
+    pl: Pola nieznane
 
-ungrouped: 
-  label: 
+ungrouped:
+  label:
     it: Campi non raggruppati
     fr: "Champs non rgroupés"
     de: Nicht zugeteilte Felder
     en: Ungrouped fields
     es: Campos no agrupados
+    pl: Pola niezgrupowane
 
 ################
 
-arr: 
-  label: 
+arr:
+  label:
     it: Arrangiatore
     fr: Arrangeur
     de: Bearbeiter
     en: Arranger
     pt: "Arranjador [arr]"
     es: Arreglador
-art: 
-  label: 
+    pl: Aranżer
+art:
+  label:
     it: Scenografo
     fr: "Metteur en scène"
     de: "Bühnenbildner"
     en: Artist
     es: Puestista
+    pl: Artysta
 asg:
   label:
     it: Incaricato
@@ -2577,112 +2894,127 @@ asg:
     en: Assignee
     es: Asignatario
     pt: "Cessionário [asg]"
-asn: 
-  label: 
+    pl: Cesjonariusz
+asn:
+  label:
     it: Altro nome
     fr: Autre nom
     de: Weiterer Name
     en: Associated name
     pt: "Nome associado [asn]"
     es: Nombre asociado
-aut: 
-  label: 
+    pl: Powiązana osoba
+aut:
+  label:
     it: Autore
     fr: Auteur
     de: Autor
     en: Author
     pt: "Autor [aut]"
     es: Autor
-bnd: 
-  label: 
+    pl: Autor
+bnd:
+  label:
     it: Rilegatore
     fr: Relieur
     de: Buchbinder
     en: Binder
     es: Encuadernador
-bsl: 
-  label: 
+    pl: Introligator
+bsl:
+  label:
     it: Libraio musicale
     fr: Libraire
     de: "Musikalienhändler"
     en: Bookseller
     pt: "Livreiro [bsl]"
     es: Librero
-ccp: 
-  label: 
+    pl: Księgarz
+ccp:
+  label:
     it: Autore della fonte letteraria
     fr: Auteur du texte
     de: Autor der Textvorlage
     en: Conceptor
     pt: "Criador [ccp]"
     es: Autor del concepto
-chr: 
-  label: 
+    pl: Autor koncepcji
+chr:
+  label:
     it: Coreografo
     fr: "Chorégraphe"
     de: Choreograph
     en: Choreographer
     es: "Coreógrafo"
-clb: 
-  label: 
+    pl: Choreograf
+clb:
+  label:
     it: Autore secondario
     fr: Collabarateur
     de: Mitverfasser
     en: Contributor
     es: Colaborador
-cmp: 
-  label: 
+    pl: Kontrybutor
+cmp:
+  label:
     it: Rimando ad altro compositore
     fr: Compositeur / Co-compositeur
     de: Komponistenquerverweis
     en: Composer cross-reference
     pt: "Referência cruzada de compositor [cmp]"
     es: Referencia cruzada de compositor
-cnd: 
-  label: 
+    pl: Odniesienie do innego kompozytora
+cnd:
+  label:
     it: Direttore d'orchestra
     fr: Chef d'orchestre
     de: Dirigent
     en: Conductor
     es: Director musical
-cns: 
-  label: 
+    pl: Dyrygent
+cns:
+  label:
     it: Censore
     fr: Censeur
     de: Zensor
     en: Censor
     pt: "Censor [cns]"
     es: Censor
-com: 
-  label: 
+    pl: Cenzor
+com:
+  label:
     it: Compilatore
     fr: Compilateur
     de: Kompilator
     en: Compiler
     es: Compilador
-cph: 
-  label: 
+    pl: Kompilator
+cph:
+  label:
     it: Titolare dei diritti d'autore
     fr: Titulaire du droit d'auteur
     de: Rechteinhaber
     en: Copyright holder
     es: Titular de los derechos de copia
     pt: "Detentor dos direitos de cópia/reprodução [cph]"
-cst: 
-  label: 
+    pl: Posiadacz praw autorskich
+cst:
+  label:
     it: Costumista
     fr: Costumier
     de: "Kostümbildner"
     en: Costume designer
     es: Vestuarista
-ctb: 
-  label: 
+    pl: Projektant kostiumów
+ctb:
+  label:
     it: Compositore secondario
     fr: Contributeur
     de: Mitkomponist
     en: Co-composer
     pt: "Co-compositor [ctb]"
     es: "Co-compositor"
+    pl: Współkompozytor
 ccp:
   label:
     it: Ideatore
@@ -2691,230 +3023,260 @@ ccp:
     en: Conceptor
     pt: "Conceptor [ccp]"
     es: Autor del concepto
-dnc: 
-  label: 
+    pl: Autor koncepcji
+dnc:
+  label:
     it: Ballerino
     fr: Danceur
     de: "Tänzer"
     en: Dancer
     es: "Bailarín(a)"
-dnr: 
-  label: 
+    pl: Tancerz
+dnr:
+  label:
     it: Donatore
     fr: Donateur
     de: Donator
     en: Donor
     es: Donante
-dpt: 
-  label: 
+    pl: Donator
+dpt:
+  label:
     it: Depositante
     fr: Dépositeur
     de: Depositor
     en: Depositor
     pt: "Depositante [dpt]"
     es: Depositario
-dsr: 
-  label: 
+    pl: Deponent
+dsr:
+  label:
     it: Progettista
     fr: Décorateur
     de: Designer
     en: Designer
     es: "Diseñador"
-dte: 
-  label: 
+    pl: Projektant
+dte:
+  label:
     it: Dedicatario
     fr: "Dédicataire"
     de: "Widmungsträger"
     en: Dedicatee
     pt: "Dedicatário(a) [dte]"
     es: "Dedicatario(a)"
-dst: 
-  label: 
+    pl: Adresat dedykacji
+dst:
+  label:
     it: Distributore
     fr: "Distributeur"
     de: "Vertrieb"
     en: Distributor
     pt: "Distribuidor [dst]"
     es: Distribuidor
-asn: 
-  label: 
+    pl: Dystrybutor
+asn:
+  label:
     it: Nome associato
     fr: Nom associé
     de: Zugehöriger Name
     en: Associated name
     es: Nombre asociado
     pt: "Nome associado [asn]"
-edt: 
-  label: 
+    pl: Powiązana osoba
+edt:
+  label:
     it: Curatore
     fr: Editeur
     de: Herausgeber
     en: Editor
     pt: "Editor [edt]"
     es: "Editor (curador)/Editorial"
-egr: 
-  label: 
+    pl: Edytor
+egr:
+  label:
     it: Incisore
     fr: Graveur
     de: Stecher
     en: Engraver
     pt: "Gravador [egr]"
     es: Grabador
+    pl: Rytownik
 evp:
-  label: 
+  label:
     it: "Luogo dell’evento"
     fr: "Lieu de l'événement"
     de: Veranstaltungsort
     en: Event place
     pt: "Local do evento [evp]"
     es: Lugar del evento
-fmo: 
-  label: 
+    pl: Miejsce wydarzenia
+fmo:
+  label:
     it: Proprietario precedente
     fr: "Propriétaire précédent"
     de: Vorbesitzer
     en: Former owner
     pt: "Proprietário anterior [fmo]"
     es: Propietario anterior
-ill: 
-  label: 
+    pl: Poprzedni właściciel
+ill:
+  label:
     it: Disegnatore
     fr: Illustrateur
     de: Illustrator
     en: Illustrator
     pt: "Ilustrador [ill]"
     es: Ilustrador
-itr: 
-  label: 
+    pl: Ilustrator
+itr:
+  label:
     it: Strumentista
     fr: Instrumentiste
     de: Instrumentalist
     en: Instrumentalist
     es: Instrumentista
-lbt: 
-  label: 
+    pl: Instrumentalista
+lbt:
+  label:
     it: Librettista
     fr: Librettiste
     de: Librettist
     en: Librettist
     pt: "Libretista [lbt]"
     es: Libretista
-lse: 
-  label: 
+    pl: Autor libretta
+lse:
+  label:
     it: Licenziatario
     fr: Licencié
     de: Lizenzinhaber
     en: Licensee
     es: Licenciatario
     pt: "Titular [lse]"
-ltg: 
-  label: 
+    pl: Licencjobiorca
+ltg:
+  label:
     it: Litografo
     fr: Litographe
     de: Lithograph
     en: Lithographer
     pt: "Litógrafo [ltg]"
     es: "Litógrafo"
-lyr: 
-  label: 
+    pl: Litograf
+lyr:
+  label:
     it: Poeta
     fr: Parolier
     de: Textdichter
     en: Text author
     pt: "Autor literário [lyr]"
     es: Autor del texto
-oth: 
-  label: 
+    pl: Autor tekstu
+oth:
+  label:
     it: Altra funzione
     fr: Autre function
     de: Sonstige Funktion
     en: Other
     pt: "Outro(a) [oth]"
     es: Otro
-otm: 
-  label: 
+    pl: Pozostałe
+otm:
+  label:
     it: Organizzatore
     fr: Organisateur
     de: Veranstalter
     en: Event organizer
     es: Organizador de evento
-pat: 
-  label: 
+    pl: Organizator wydarzenia
+pat:
+  label:
     it: Committente
     fr: "Mécène"
     de: "Mäzen/Auftraggeber"
     en: Patron
     es: Comitente
-pbl: 
-  label: 
+    pl: Sponsor
+pbl:
+  label:
     it: Editore
     fr: Editeur
     de: Verleger
-    en: Publisher 
+    en: Publisher
     pt: "Casa editora [pbl]"
     es: "Editor (publicador)/Editorial (publicadora)"
-ppm: 
-  label: 
+    pl: Wydawca
+ppm:
+  label:
     it: Fabbricante di carta
     fr: Papetier
     de: Papierhersteller
     en: Papermaker
     es: Fabricante de papel
-    pt: "Fabricante de papel [ppm]" 
-prd: 
-  label: 
+    pt: "Fabricante de papel [ppm]"
+    pl: Producent papieru
+prd:
+  label:
     it: Personale alla produzione
     fr: "Personnel de réalisation"
     de: Produktionspersonal
     en: Production personnel
     es: "Personal de producción"
-prf: 
-  label: 
+    pl: Personel produkcyjny
+prf:
+  label:
     it: Interprete
     fr: "Interprète"
     de: Interpret
     en: Performer
     pt: "Intérprete [prf]"
     es: "Intérprete"
-prt: 
-  label: 
+    pl: Wykonawca
+prt:
+  label:
     it: Stampatore
     fr: Imprimeur
     de: Drucker
     en: Printer
     pt: "Impressor(a) [prt]"
     es: Impresor
-pub: 
-  label: 
+    pl: Drukarnia
+pub:
+  label:
     it: Editore
     fr: Editeur
     de: Verleger
     en: Publisher
     pt: "Publicador [pub]"
     es: Editor
-scr: 
-  label: 
+    pl: Wydawca
+scr:
+  label:
     it: Copista
     fr: Copiste / Scribe
     de: Schreiber
     en: Copyist
     pt: "Copista [scr]"
     es: Copista
-trl: 
-  label: 
+    pl: Kopista
+trl:
+  label:
     it: Traduttore
     fr: Traducteur
     de: "Übersetzer"
     en: Translator
     pt: "Tradutor [trl]"
     es: Traductor
-voc: 
-  label: 
+    pl: Tłumacz
+voc:
+  label:
     it: Cantante
     fr: Vocaliste
     de: "Sänger"
     en: Vocalist
     es: Cantante
+    pl: Wokalista
 #Attribution qualifier for 100/700$j
 "Verified":
   label:
@@ -2924,6 +3286,7 @@ voc:
     en: Verified
     es: Verificada
     pt: Verificada
+    pl: Zweryfikowane
 "Ascertained":
   label:
     it: Accertata
@@ -2932,6 +3295,7 @@ voc:
     en: Ascertained
     es: Certificada
     pt: Certificada
+    pl: Stwierdzone
 "Alleged":
   label:
     it: Presunta
@@ -2940,7 +3304,8 @@ voc:
     en: Alleged
     es: Supuesta
     pt: Suposta
-"Doubtful":   
+    pl: Domniemane
+"Doubtful":
   label:
     it: Dubbia
     fr: "Douteux"
@@ -2948,7 +3313,8 @@ voc:
     en: Doubtful
     es: Dudosa
     pt: Duvidosa
-"Misattributed":   
+    pl: Wątpliwe
+"Misattributed":
   label:
     it: Erronea
     fr: "Erroné"
@@ -2956,7 +3322,8 @@ voc:
     en: Misattributed
     es: Mal atribuida
     pt: Equivocada
-"Conjectural":   
+    pl: Błędnie przypisane
+"Conjectural":
   label:
     it: Congetturale
     fr: Conjectural
@@ -2964,31 +3331,35 @@ voc:
     en: Conjectural
     es: Conjetural
     pt: Conjetural
+    pl: Spekulatywne
 # Marc Language codes
-afr: 
-  label: 
+afr:
+  label:
     IT: Afrikaans
     FR: Afrikaans
     de: Afrikaans
     en: Afrikaans
     pt: "Africânder"
     es: "Afrikáans"
-ara: 
-  label: 
+    pl: Afrykanerski
+ara:
+  label:
     IT: Arabo
     FR: Arabe
     de: Arabisch
     en: Arabic
     pt: "Árabe"
     es: "Árabe"
-arg: 
-  label: 
+    pl: Arabski
+arg:
+  label:
     IT: Aragonese
     FR: Aragonais
     de: Aragonesisch
     en: Aragonese
     pt: "Aragonês"
     es: "Aragonés"
+    pl: Aragoński
 arm:
   label:
     it: Armeno
@@ -2997,6 +3368,7 @@ arm:
     en: Armenian
     pt: Arménio
     es: Armenio
+    pl: Armeński
 art:
   label:
     it: Artificial (Other)
@@ -3005,14 +3377,16 @@ art:
     en: Artificial (Other)
     pt: Artificial (Other)
     es: Artificial (otros)
-baq: 
-  label: 
+    pl: Sztuczny (inny)
+baq:
+  label:
     it: Basco
     fr: Basque
     de: Baskisch
     en: Basque
     pt: Basco
     es: Vasco
+    pl: Baskijski
 bos:
   label:
     it: Bosniaco
@@ -3021,6 +3395,7 @@ bos:
     en: Bosnian
     pt: Bósnio
     es: Bosnio
+    pl: Bośniacki
 bul:
   label:
     it: Bulgaro
@@ -3029,14 +3404,16 @@ bul:
     en: Bulgarian
     pt: "Búlgaro"
     es: "Búlgaro"
-cat: 
-  label: 
+    pl: Bułgarski
+cat:
+  label:
     it: Catalano
     fr: Catalan
     de: Katalanisch
     en: Catalan
     pt: "Catalão"
     es: "Catalán"
+    pl: Kataloński
 cel:
   label:
     it: Celtic (Other)
@@ -3045,22 +3422,25 @@ cel:
     en: Celtic (Other)
     pt: Celtic (Other)
     es: Céltico (otros)
-chi: 
-  label: 
+    pl: Celtycki (inny)
+chi:
+  label:
     it: Cinese
     fr: Chinois
     de: Chinesisch
     en: Chinese
     pt: "Chinês"
     es: Chino
-chu: 
-  label: 
+    pl: Chiński
+chu:
+  label:
     it: Lingua slava ecclesiastica antica
     fr: "Slave ancien ecclésiastique"
     de: Altkirchenslawisch
     en: Old Church Slavonic
     pt: "Antigo eslavo eclesiástico"
     es: "Antiguo eslavo eclesiástico"
+    pl: Starocerkiewny
 crp:
   label:
     it: Creoles and Pidgins (Other)
@@ -3069,54 +3449,61 @@ crp:
     en: Creoles and Pidgins (Other)
     pt: Creoles and Pidgins (Other)
     es: Creoles y Pidgins (otros)
-cze: 
-  label: 
+    pl: Kreolski i Pidgin (inne)
+cze:
+  label:
     it: Ceco
     fr: Tchèque
     de: Tschechisch
     en: Czech
     pt: Tcheco
     es: Checo
-dan: 
-  label: 
+    pl: Czeski
+dan:
+  label:
     it: Danese
     fr: Danois
     de: Dänisch
     en: Danish
     pt: "Dinamarquês"
     es: "Danés"
-dut: 
-  label: 
+    pl: Duński
+dut:
+  label:
     it: Olandese
     fr: Néerlandais
     de: Niederländisch
     en: Dutch
     pt: "Holandês"
     es: "Holandés"
-eng: 
-  label: 
+    pl: Holenderski
+eng:
+  label:
     it: Inglese
     fr: Anglais
     de: Englisch
     en: English
     pt: "Inglês"
     es: "Inglés"
-enm: 
-  label: 
+    pl: Angielski
+enm:
+  label:
     IT: Lingua inglese medievale
     FR: Anglais médiéval
     de: Mittelenglisch
     en: Middle English
     pt: "Inglês médio"
     es: "Inglés medio"
-est: 
-  label: 
+    pl: Środkowoangielski
+est:
+  label:
     IT: Estone
     FR: Estonien
     de: Estnisch
     en: Estonian
     pt: Estoniano
     es: Estonio
+    pl: Estoński
 fas:
   label:
     IT: Persiano
@@ -3125,6 +3512,7 @@ fas:
     en: Persian
     pt: Persa
     es: Persa
+    pl: Perski
 fij:
   label:
     it: Figi
@@ -3133,14 +3521,16 @@ fij:
     en: Fijian
     pt: Fijianas
     es: Fijiano
-fin: 
-  label: 
+    pl: Fidżyjski
+fin:
+  label:
     IT: Finlandese
     FR: Finlandais
     de: Finnisch
     en: Finnish
     pt: "Finlandês"
     es: "Finés"
+    pl: Fiński
 frm:
   label:
     it: "Francese, medio (ca. 1300-1600)"
@@ -3149,6 +3539,7 @@ frm:
     en: "French, Middle (ca. 1300-1600)"
     pt: "Francês, Médio (ca. 1300-1600)"
     es: "Francés, Medio (ca. 1300-1600)"
+    pl: Średniofrancuski (ok. 1300-1600)
 fro:
   label:
     it: "Francese, antico (ca. 842-1300)"
@@ -3157,53 +3548,60 @@ fro:
     en: "French, Old (ca. 842-1300)"
     pt: "Francês, antigo (ca. 842-1300)"
     es: "Francés, antiguo (ca. 842-1300)"
-frr: 
-  label: 
+    pl: Starofrancuski (ok. 842-1300)
+frr:
+  label:
     IT: Dialetto frisone settentrionale
     FR: Frison du Nord
     de: Nordfriesisch
     en: North Frisian
     pt: "Frisão setentrional"
     es: "Frisón septentrional"
-fry: 
-  label: 
+    pl: Północnofryzyjski
+fry:
+  label:
     IT: Dialetto frisone occidentale
     FR: Frison occidental
     de: Westfriesisch
     en: West Frisian
     pt: "Frisão ocidental"
     es: "Frisón occidental"
-fre: 
-  label: 
+    pl: Zchodniofryzyjski
+fre:
+  label:
     it: Francese
     fr: Français
     de: Französisch
     en: French
     pt: "Francês"
     es: "Francés"
+    pl: Francuski
 fur:
   label:
     it: Friulano
-    ft: Friulano
+    fr: Friulano
     de: Friulano
     en: Friulano
     pt: Friulano
     es: Friulano
-gem: 
-  label: 
+    pl: Friulijski
+gem:
+  label:
     IT: Germanico
     FR: Germanique
     de: Germanisch
     en: Germanic
     es: "Germánico"
-ger: 
-  label: 
+    pl: Germański
+ger:
+  label:
     it: Tedesco
     fr: Allemand
     de: Deutsch
     en: German
     pt: "Alemão"
     es: "Alemán"
+    pl: Niemiecki
 gez:
   label:
     it: Etiope
@@ -3212,30 +3610,34 @@ gez:
     en: Ethiopic
     pt: "Etíope"
     es: "Etiópico"
-gle: 
-  label: 
+    pl: Etiopski
+gle:
+  label:
     IT: Irlandese
     FR: Irlandais
     de: Irisch
     en: Irish
     pt: "Irlandês"
     es: "Irlandés"
-glg: 
-  label: 
+    pl: Irlandzki
+glg:
+  label:
     IT: Galiziano
     FR: Galician
     de: Galizisch
     en: Galician
     pt: Galego
     es: Galego
-gmh: 
-  label: 
+    pl: Galicyjski
+gmh:
+  label:
     IT: Tedesco medievale
     FR: Allemand médiéval
     de: Mittelhochdeutsch
     en: Middle High German
     pt: "Alto-alemão médio"
     es: "Alto alemán medio"
+    pl: Średniowysokoniemiecki
 goh:
   label:
     it: German, Old High (ca. 750-1050)
@@ -3244,54 +3646,61 @@ goh:
     en: German, Old High (ca. 750-1050)
     pt: German, Old High (ca. 750-1050)
     es: Alemán culto antiguo (aprox. 750-1050)
-grc: 
-  label: 
+    pl: Staro-wysoko-niemiecki (ok. 750-1050)
+grc:
+  label:
     it: Greco antico (fino al 1453)
     fr: Grec ancien (jusqu'en 1453)
     de: Altgriechisch (bis 1453)
     en: Greek, Ancient (to 1453)
     pt: Grego antigo (até 1453)
     es: Griego, Antiguo (hasta 1453)
-gre:  
-  label: 
+    pl: Grecki, historyczny (do 1453 r.)
+gre:
+  label:
     it: Greco moderno (1453-)
     fr: Grec moderne (1453-)
     de: Neugriechisch (1453-)
     en: Greek, Modern (1453-)
     pt: Grego moderno (1453-)
     es: Griego moderno (1453-)
-gsw: 
-  label: 
+    pl: Grecki, współczesny (1453-)
+gsw:
+  label:
     it: Svizzero tedesco
     fr: Suisse allemand
     de: Schweizerdeutsch
     en: Swiss German
     pt: "Suíço-alemão"
     es: "Suizo-alemán"
-heb: 
-  label: 
+    pl: Niemiecki szwajcarski
+heb:
+  label:
     it: Ebreo
     fr: "Hébraïque"
     de: Hebräisch
     en: Hebrew
     pt: Hebraico
     es: Hebreo
-hrv: 
-  label: 
+    pl: Hebrajski
+hrv:
+  label:
     it: Croato
     fr: Croate
     de: Kroatisch
     en: Croatian
     pt: Croata
     es: Croata
-hun: 
-  label: 
+    pl: Chorwacki
+hun:
+  label:
     it: Ungherese
     fr: Hongrois
     de: Ungarisch
     en: Hungarian
     pt: "Húngaro"
     es: "Húngaro"
+    pl: Węgierski
 ice:
   label:
     it: Islandese
@@ -3300,6 +3709,7 @@ ice:
     en: Icelandic
     pt: Islandês
     es: Islandés
+    pl: Islandzki
 iii:
   label:
     it: Sichuan Yi
@@ -3308,70 +3718,79 @@ iii:
     en: Sichuan Yi
     pt: Sichuan Yi
     es: Sichuan Yi
-ita: 
-  label: 
+    pl: Syczuański Yi
+ita:
+  label:
     it: Italiano
     fr: Italien
     de: Italienisch
     en: Italian
     pt: Italiano
     es: Italiano
-jpn: 
-  label: 
+    pl: Włoski
+jpn:
+  label:
     it: Giapponese
     fr: Japonais
     de: Japanisch
     en: Japanese
     pt: "Japonês"
     es: "Japonés"
-kor: 
-  label: 
+    pl: Japoński
+kor:
+  label:
     it: Coreano
     fr: "Coréen"
     de: Koreanisch
     en: Korean
     pt: Coreano
     es: Coreano
-lat: 
-  label: 
+    pl: Koreański
+lat:
+  label:
     it: Latino
     fr: Latin
     de: Lateinisch
     en: Latin
     pt: Latim
     es: "Latín"
-lav: 
-  label: 
+    pl: Łaciński
+lav:
+  label:
     IT: Lettone
     FR: Letton
     de: Lettisch
     en: Latvian
     pt: "Letão"
     es: "Letón"
-lit: 
-  label: 
+    pl: Łotewski
+lit:
+  label:
     IT: Lituano
     FR: Lituanien
     de: Litauisch
     en: Lithuanian
     pt: Lituano
     es: Lituano
-ltz: 
-  label: 
+    pl: Litewski
+ltz:
+  label:
     IT: Lussemburghese
     FR: Luxembourgeois
     de: Luxemburgisch
     en: Luxembourgish
     pt: "Luxemburguês"
     es: "Luxemburgués"
+    pl: Luksemburski
 mac:
-  label: 
+  label:
     IT: Macedone
     FR: Macédonien
     de: Mazedonisch
     en: Macedonian
     pt: "Macedônio"
     es: Macedonio
+    pl: Macedoński
 mao:
   label:
     it: Māori
@@ -3380,14 +3799,16 @@ mao:
     en: Maori
     pt: Maori
     es: Maorí
-mon: 
-  label: 
+    pl: Maoryski
+mon:
+  label:
     IT: Mongolo
     FR: Mongole
     de: Mongolisch
     en: Mongolian
     pt: Mongol
     es: Mongol
+    pl: Mongolski
 mul:
   label:
     it: Multiple
@@ -3396,94 +3817,106 @@ mul:
     en: Multiple
     pt: Múltiplos
     es: Múltiples
-nap: 
-  label: 
+    pl: Wielojęzyczny
+nap:
+  label:
     it: Napoletano
     fr: Néapolitain
     de: Neapolitanisch
     en: Neapolitan
     pt: Napolitano
     es: Napolitano
-nds: 
-  label: 
+    pl: Neapolitański
+nds:
+  label:
     it: Basso sassone
     fr: Bas allemand
     de: Niederdeutsch
     en: Low German
     pt: "Baixo alemão"
     es: "Bajo alemán"
-nor: 
-  label: 
+    pl: Dolnoniemiecki
+nor:
+  label:
     IT: Norvegese
     FR: Norvégien
     de: Norwegisch
     en: Norwegian
     pt: "Norueguês"
     es: "Noruego"
-oci: 
-  label: 
+    pl: Norweski
+oci:
+  label:
     IT: Occitano
     FR: Occitan
     de: Okzitanisch
     en: Occitan
-    pt: Occitano 
+    pt: Occitano
     es: Occitano
+    pl: Prowansalski
 per:
-  label: 
+  label:
     it: Persiano
     fr: Persan
     de: Persisch
     en: Persian
     pt: Persa
     es: Persa
-pol: 
-  label: 
+    pl: Perski
+pol:
+  label:
     it: Polacco
     fr: Polonais
     de: Polnisch
     en: Polish
     pt: Polaco
     es: Polaco
-por: 
-  label: 
+    pl: Polski
+por:
+  label:
     it: Portoghese
     fr: Portugais
     de: Portugiesisch
     en: Portuguese
     pt: "Português"
     es: "Portugués"
-roh: 
-  label: 
+    pl: Portugalski
+roh:
+  label:
     it: Romancio
     fr: Rhéto-roman
     de: Bündnerromanisch (Rätoromanisch)
     en: Romansh
     pt: "Reto-romano"
     es: "Reto-romano"
-rom: 
-  label: 
+    pl: Retoromański
+rom:
+  label:
     IT: Romani
     FR: Romani
     de: Romani
     en: Romani
     pt: Romani
     es: "Romaní"
-rum: 
-  label: 
+    pl: Romski
+rum:
+  label:
     IT: Romeno
     FR: Roumain
     de: Rumänisch
     en: Romanian
     pt: Romeno
     es: Rumano
-rus: 
-  label: 
+    pl: Rumuński
+rus:
+  label:
     it: Russo
     fr: Russe
     de: Russisch
     en: Russian
     pt: Russo
     es: Ruso
+    pl: Rosyjski
 san:
   label:
     it: Sanscrito
@@ -3492,6 +3925,7 @@ san:
     en: Sanskrit
     pt: "Sânscrito"
     es: "Sánscrito"
+    pl: Sanskryt
 sco:
   label:
     it: Scozzese
@@ -3500,38 +3934,43 @@ sco:
     en: Scots
     pt: Escocês
     es: Scozzese
-scn: 
-  label: 
+    pl: Szkocki
+scn:
+  label:
     IT: Siciliano
     FR: Sicilien
     de: Sizilianisch
     en: Sicilian
     pt: Siciliano
     es: Siciliano
-sla: 
-  label: 
+    pl: Sycylijski
+sla:
+  label:
     IT: Slavico
     FR: Slave
     de: Slawisch
     en: Slavic
     pt: Eslava
     es: Eslavo
-slo: 
-  label: 
+    pl: Słowiański
+slo:
+  label:
     it: Slovacco
     fr: Slovaque
     de: Slowakisch
     en: Slovak
     pt: Eslovaco
     es: Eslovaco
-slv: 
-  label: 
+    pl: Słowacki
+slv:
+  label:
     it: Sloveno
     fr: "Slovène"
     de: Slowenisch
     en: Slovenian
     pt: Esloveno
     es: Esloveno
+    pl: Słoweński
 smn:
   label:
     it: Inari Sami
@@ -3540,14 +3979,16 @@ smn:
     en: Inari Sami
     pt: Inari Sami
     es: Inari Sami
-srp: 
-  label: 
+    pl: Samski inarski
+srp:
+  label:
     IT: Serbo
     FR: Serbe
     de: Serbisch
     en: Serbian
     pt: "Sérvio"
     es: Serbio
+    pl: Serbski
 dsb:
   label:
     it: Sorabo inferiore
@@ -3556,6 +3997,7 @@ dsb:
     en: Sorbian, Lower Sorbian
     pt: "Sorábio, Baixo Sorábio"
     es: Sorbio, Bajo Sorbio
+    pl: Dolnołużycki
 hsb:
   label:
     it: Sorabo superiore
@@ -3564,30 +4006,34 @@ hsb:
     en: Sorbian, Upper Sorbian
     pt: "Sorábio, Alto Sorábio"
     es: Sorbio, Alto Sorbio
-spa: 
-  label: 
+    pl: Gbórnołużycki
+spa:
+  label:
     it: Spagnolo
     fr: Espagnol
     de: Spanisch
     en: Spanish
     pt: Castelhano
     es: Español
-srp: 
-  label: 
+    pl: Hiszpański
+srp:
+  label:
     it: Serbo
     fr: Serbe
     de: Serbisch
     en: Serbian
     pt: "Sérvio"
     es: Serbio
-swe: 
-  label: 
+    pl: Serbski
+swe:
+  label:
     it: Svedese
     fr: "Suédois"
     de: Schwedisch
     en: Swedish
     pt: Sueco
     es: Sueco
+    pl: Szwedzki
 tat:
   label:
     it: Tataro
@@ -3596,6 +4042,7 @@ tat:
     en: Tatar
     pt: Tártaro
     es: Tártaro
+    pl: Tatarski
 tha:
   label:
     it: Thailandese
@@ -3604,6 +4051,7 @@ tha:
     en: Thai
     pt: Tailandês
     es: Tailandés
+    pl: Tajski
 tgl:
   label:
     it: Tagalog
@@ -3612,14 +4060,16 @@ tgl:
     en: Tagalog
     pt: Tagalog
     es: Tagalog
-tib: 
-  label: 
+    pl: Tagalski
+tib:
+  label:
     it: Tibetano
     fr: TIBETAN
     de: Tibetanisch
     en: Tibetan
     pt: Tibetano
     es: Tibetano
+    pl: Tybetański
 tsi:
   label:
     it: Tsimshian
@@ -3628,14 +4078,16 @@ tsi:
     en: Tsimshian
     pt: Tsimshian
     es: Tsimshian
-tur: 
-  label: 
+    pl: Tsimshiański
+tur:
+  label:
     IT: Turco
     FR: Turque
     de: Türkisch
     en: Turkish
     pt: Turco
     es: Turco
+    pl: Turecki
 und:
   label:
     it: Indeterminato
@@ -3644,14 +4096,16 @@ und:
     en: Undetermined
     pt: Indeterminado
     es: Indeterminado
-ukr: 
-  label: 
+    pl: Nieokreślony
+ukr:
+  label:
     IT: Ucraino
     FR: Ukrainien
     de: Ukrainisch
     en: Ukrainian
     pt: Ucraniano
     es: Ucraniano
+    pl: Ukraiński
 vie:
   label:
     IT: Vietnamita
@@ -3660,22 +4114,25 @@ vie:
     en: Vietnamese
     pt: Vietnamita
     es: Vietnamita
-wel: 
-  label: 
+    pl: Wietnamska
+wel:
+  label:
     IT: Gallese
     FR: Gallois
     de: Walisisch
     en: Welsh
     pt: "Galês"
     es: "Galés"
-wen: 
-  label: 
+    pl: Walijski
+wen:
+  label:
     it: Sorabo
     fr: Sorabe
     de: Sorbisch
     en: Sorbian
     pt: "Sorábio"
     es: Sorbio
+    pl: Łużycki
 xal:
   label:
     it: Oirato
@@ -3684,22 +4141,25 @@ xal:
     en: Oirat
     pt: Oirato
     es: Oirato
-yid: 
-  label: 
+    pl: Ojracki
+yid:
+  label:
     IT: Yiddish
     FR: Yiddish
     de: Jiddisch
     en: Yiddish
     pt: "Iídiche"
     es: Yidis
-zxx: 
-  label: 
+    pl: Jidysz
+zxx:
+  label:
     it: Nessun contenuto linguistico
     fr: Sans contenu linguistique
     de: ohne Sprache
     en: No linguistic content
     pt: "Sem conteúdo linguístico"
     es: "Sin contenido linguístico"
+    pl: Brak zawartości językowej
 #Subheading 240k / 730k
 Excerpts:
   label:
@@ -3709,6 +4169,7 @@ Excerpts:
     en: Excerpts
     es: Extractos
     pt: Excertos
+    pl: Wyjątki
 Sketches:
   label:
     it: Schizzi
@@ -3717,6 +4178,7 @@ Sketches:
     en: Sketches
     es: Bosquejos
     pt: "Esboços"
+    pl: Szkice
 Fragments:
   label:
     it: Frammenti
@@ -3725,6 +4187,7 @@ Fragments:
     en: Fragments
     es: Fragmentos
     pt: Fragmentos
+    pl: Fragmenty
 Inserts:
   label:
     it: Inserimenti
@@ -3733,6 +4196,7 @@ Inserts:
     en: Inserts
     pt: "Inserções"
     es: Inserciones
+    pl: Wstawienia
 #Arrangement statement 240o / 730o
 Arr:
   label:
@@ -3742,6 +4206,7 @@ Arr:
     en: Arrangement
     pt: Arranjo
     es: Arreglo
+    pl: Aranżacja
 Var:
   label:
     it: Variazioni
@@ -3749,6 +4214,7 @@ Var:
     de: Variationen
     en: Variations
     es: Variaciones
+    pl: Wariacje
 #Keys
 A:
   label:
@@ -3758,6 +4224,7 @@ A:
     en: "A major"
     pt: "Lá  maior"
     es: "La Mayor"
+    pl: A-dur
 a:
   label:
     it: "La minore"
@@ -3766,7 +4233,8 @@ a:
     en: "A minor"
     pt: "Lá menor"
     es: "La menor"
-A|x: 
+    pl: a-moll
+A|x:
   label:
     it: "La♯ maggiore"
     fr: "La♯ majeur"
@@ -3774,7 +4242,8 @@ A|x:
     en: "A♯ major"
     pt: "Lá sustenido maior"
     es: "La sostenido Mayor"
-a|x: 
+    pl: Ais-dur
+a|x:
   label:
     it: "La♯ minore"
     fr: "La♯ mineur"
@@ -3782,7 +4251,8 @@ a|x:
     en: "A♯ minor"
     pt: "Lá sustenido menor"
     es: "La sostenido menor"
-A|b: 
+    pl: ais-moll
+A|b:
   label:
     it: "La♭ maggiore"
     fr: "La♭ majeur"
@@ -3790,7 +4260,8 @@ A|b:
     en: "A♭ major"
     pt: "Lá bemol maior"
     es: "La bemol Mayor"
-a|b: 
+    pl: As-Dur
+a|b:
   label:
     it: "La♭ minore"
     fr: "La♭ mineur"
@@ -3798,6 +4269,7 @@ a|b:
     en: "A♭ minor"
     pt: "Lá bemol menor"
     es: "La bemol menor"
+    pl: as-moll
 B:
   label:
     it: "Si maggiore"
@@ -3806,6 +4278,7 @@ B:
     en: "B major"
     pt: Si maior
     es: "Si Mayor"
+    pl: H-dur
 b:
   label:
     it: "Si minore"
@@ -3814,7 +4287,8 @@ b:
     en: "B minor"
     pt: Si menor
     es: "Si menor"
-B|b: 
+    pl: h-moll
+B|b:
   label:
     it: "Si♭ maggiore"
     fr: "Si♭ majeur"
@@ -3822,7 +4296,8 @@ B|b:
     en: "B♭ major"
     pt: Si bemol maior
     es: "Si bemol Mayor"
-b|b: 
+    pl: B-dur
+b|b:
   label:
     it: "Si♭ minore"
     fr: "Si♭ mineur"
@@ -3830,6 +4305,7 @@ b|b:
     en: "B♭ minor"
     pt: Si bemol menor
     es: "Si bemol menor"
+    pl: b-moll
 C:
   label:
     it: "Do maggiore"
@@ -3838,6 +4314,7 @@ C:
     en: "C major"
     pt: "Dó maior"
     es: "Do Mayor"
+    pl: C-dur
 c:
   label:
     it: "Do minore"
@@ -3846,7 +4323,8 @@ c:
     en: "C minor"
     pt: "Dó menor"
     es: "Do menor"
-C|x: 
+    pl: c-moll
+C|x:
   label:
     it: "Do♯ maggiore"
     fr: "Do♯ majeur"
@@ -3854,7 +4332,8 @@ C|x:
     en: "C♯ major"
     pt: "Dó sustenido maior"
     es: "Do sostenido Mayor"
-c|x: 
+    pl: Cis-dur
+c|x:
   label:
     it: "Do♯ minore"
     fr: "Do♯ mineur"
@@ -3862,7 +4341,8 @@ c|x:
     en: "C♯ minor"
     pt: "Dó sustenido menor"
     es: "Do sostenido menor"
-C|b: 
+    pl: cis-moll
+C|b:
   label:
     it: "Do♭ maggiore"
     fr: "Do♭ majeur"
@@ -3870,7 +4350,8 @@ C|b:
     en: "C♭ major"
     pt: "Dó bemol maior"
     es: "Do bemol Mayor"
-c|b: 
+    pl: Ces-dur
+c|b:
   label:
     it: "Do♭ minore"
     fr: "Do♭ mineur"
@@ -3878,6 +4359,7 @@ c|b:
     en: "C♭ minor"
     pt: "Dó bemol menor"
     es: "Do bemol menor"
+    pl: ces-moll
 D:
   label:
     it: "Re maggiore"
@@ -3886,6 +4368,7 @@ D:
     en: "D major"
     pt: "Ré maior"
     es: "Re Mayor"
+    pl: D-dur
 d:
   label:
     it: "Re minore"
@@ -3894,7 +4377,8 @@ d:
     en: "D minor"
     pt: "Ré menor"
     es: "Re menor"
-D|x: 
+    pl: d-moll
+D|x:
   label:
     it: "Re♯ maggiore"
     fr: "Ré♯ majeur"
@@ -3902,7 +4386,8 @@ D|x:
     en: "D♯ major"
     pt: "Ré sustenido maior"
     es: "Re sostenido Mayor"
-d|x: 
+    pl: Dis-dur
+d|x:
   label:
     it: "Re♯ minore"
     fr: "Ré♯ mineur"
@@ -3910,7 +4395,8 @@ d|x:
     en: "D♯ minor"
     pt: "Ré sustenido menor"
     es: "Re sostenido menor"
-D|b: 
+    pl: dis-moll
+D|b:
   label:
     it: "Re♭ maggiore"
     fr: "Ré♭ majeur"
@@ -3918,7 +4404,8 @@ D|b:
     en: "D♭ major"
     pt: "Ré bemol maior"
     es: "Re bemol Mayor"
-d|b: 
+    pl: Des-dur
+d|b:
   label:
     it: "Re♭ minore"
     fr: "Ré♭ mineur"
@@ -3926,6 +4413,7 @@ d|b:
     en: "D♭ minor"
     pt: "Ré bemol menor"
     es: "Re bemol menor"
+    pl: des-moll
 E:
   label:
     it: "Mi maggiore"
@@ -3934,6 +4422,7 @@ E:
     en: "E major"
     pt: "Mi maior"
     es: "Mi Mayor"
+    pl: E-dur
 e:
   label:
     it: "Mi minore"
@@ -3942,7 +4431,8 @@ e:
     en: "E minor"
     pt: "Mi menor"
     es: "Mi menor"
-E|b: 
+    pl: e-moll
+E|b:
   label:
     it: "Mi♭ maggiore"
     fr: "Mi♭ majeur"
@@ -3950,7 +4440,8 @@ E|b:
     en: "E♭ major"
     pt: "Mi bemol maior"
     es: "Mi bemol Mayor"
-e|b: 
+    pl: Es-dur
+e|b:
   label:
     it: "Mi♭ minore"
     fr: "Mi♭ mineur"
@@ -3958,6 +4449,7 @@ e|b:
     en: "E♭ minor"
     pt: "Mi bemol menor"
     es: "Mi bemol menor"
+    pl: es-moll
 F:
   label:
     it: "Fa maggiore"
@@ -3966,6 +4458,7 @@ F:
     en: "F major"
     pt: "Fá maior"
     es: "Fa Mayor"
+    pl: F-dur
 f:
   label:
     it: "Fa minore"
@@ -3974,7 +4467,8 @@ f:
     en: "F minor"
     pt: "Fá menor"
     es: "Fa menor"
-F|x: 
+    pl: f-moll
+F|x:
   label:
     it: "Fa♯ maggiore"
     fr: "Fa♯ majeur"
@@ -3982,7 +4476,8 @@ F|x:
     en: "F♯ major"
     pt: "Fá sustenido maior"
     es: "Fa sostenido menor"
-f|x: 
+    pl: Fis-dur
+f|x:
   label:
     it: "Fa♯ minore"
     fr: "Fa♯ mineur"
@@ -3990,6 +4485,7 @@ f|x:
     en: "F♯ minor"
     pt: "Fá sustenido menor"
     es: "Fa sostenido Mayor"
+    pl: fis-moll
 G:
   label:
     it: "Sol maggiore"
@@ -3998,6 +4494,7 @@ G:
     en: "G major"
     pt: "Sol maior"
     es: "Sol Mayor"
+    pl: G-dur
 g:
   label:
     it: "Sol minore"
@@ -4006,7 +4503,8 @@ g:
     en: "G minor"
     pt: "Sol menor"
     es: "Sol menor"
-G|x: 
+    pl: g-moll
+G|x:
   label:
     it: "Sol♯ maggiore"
     fr: "Sol♯ majeur"
@@ -4014,7 +4512,8 @@ G|x:
     en: "G♯ major"
     pt: "Sol sustenido maior"
     es: "Sol sostenido menor"
-g|x: 
+    pl: Gis-dur
+g|x:
   label:
     it: "Sol♯ minore"
     fr: "Sol♯ mineur"
@@ -4022,7 +4521,8 @@ g|x:
     en: "G♯ minor"
     pt: "Sol sustenido menor"
     es: "Sol sostenido menor"
-G|b: 
+    pl: gis-moll
+G|b:
   label:
     it: "Sol♭ maggiore"
     fr: "Sol♭ majeur"
@@ -4030,7 +4530,8 @@ G|b:
     en: "G♭ major"
     pt: "Sol bemol maior"
     es: "Sol bemol Mayor"
-g|b: 
+    pl: Ges-dur
+g|b:
   label:
     it: "Sol♭ minore"
     fr: "Sol♭ mineur"
@@ -4038,6 +4539,7 @@ g|b:
     en: "G♭ minor"
     pt: "Sol bemol menor"
     es: "Sol bemol menor"
+    pl: ges-moll
 # modes
 1t:
   label:
@@ -4047,6 +4549,7 @@ g|b:
     en: "Mode:  1t – Dorian"
     pt: "Modo:  1º tom (Dórico)"
     es: "Modo: 1º tono (Dórico)"
+    pl: Skala: 1t – dorycka
 2t:
   label:
     it: "Mode:  2t – Hypodorian"
@@ -4055,6 +4558,7 @@ g|b:
     en: "Mode:  2t – Hypodorian"
     pt: "Modo:  2º tom (Hipodórico)"
     es: "Modo:  2º tono (Hipodórico)"
+    pl: Skala: 2t – hypodorycka
 3t:
   label:
     it: "Mode:  3t – Phrygian"
@@ -4063,6 +4567,7 @@ g|b:
     en: "Mode:  3t – Phrygian"
     pt: "Modo:  3º tom (Frígio)"
     es: "Modo:  3º tono (Frigio)"
+    pl: Skala: 3t – frygijska
 4t:
   label:
     it: "Mode:  4t – Hypophrygian"
@@ -4071,6 +4576,7 @@ g|b:
     en: "Mode:  4t – Hypophrygian"
     pt: "Modo:  4º tom (Hipofrígio)"
     es: "Modo:  4º tono (Hipofrigio)"
+    pl: Skala: 4t – hypofrygijska
 5t:
   label:
     it: "Mode:  5t – Lydian"
@@ -4079,6 +4585,7 @@ g|b:
     en: "Mode:  5t – Lydian"
     pt: "Modo:  5º tom (Lídio)"
     es: "Modo:  5º tono (Lidio)"
+    pl: Skala: 5t – lidyjska
 6t:
   label:
     it: "Mode:  6t – Hypolydian"
@@ -4087,6 +4594,7 @@ g|b:
     en: "Mode:  6t – Hypolydian"
     pt: "Modo:  6º tom (Hipolídio)"
     es: "Modo:  6º tono (Hipolidio)"
+    pl: Skala: 6t – hypolidyjska
 7t:
   label:
     it: "Mode:  7t – Mixolydian"
@@ -4095,6 +4603,7 @@ g|b:
     en: "Mode:  7t – Mixolydian"
     pt: "Modo:  7º tom (Mixolídio)"
     es: "Modo:  7º tono (Mixolidio)"
+    pl: Skala: 7t – miksolidyjska
 8t:
   label:
     it: "Mode:  8t – Hypomixolydian"
@@ -4103,6 +4612,7 @@ g|b:
     en: "Mode:  8t – Hypomixolydian"
     pt: "Modo:  8º tom (Hipomixolídio)"
     es: "Modo:  8º tono (Hipomixolidio)"
+    pl: Skala: 8t – hypomiksolidyjska
 9t:
   label:
     it: "Mode:  9t – Aeolian"
@@ -4111,6 +4621,7 @@ g|b:
     en: "Mode:  9t – Aeolian"
     pt: "Modo:  9º tom (Eólio)"
     es: "Modo:  9º tono (Eólico)"
+    pl: Skala: 9t – eolska
 10t:
   label:
     it: "Mode: 10t – Hypoaeolian"
@@ -4119,6 +4630,7 @@ g|b:
     en: "Mode: 10t – Hypoaeolian"
     pt: "Modo: 10º tom (Hipoeólio)"
     es: "Modo: 10º tono (Hipoeólico)"
+    pl: Skala: 10t – hypoeolska
 11t:
   label:
     it: "Mode: 11t – Ionian"
@@ -4127,6 +4639,7 @@ g|b:
     en: "Mode: 11t – Ionian"
     pt: "Modo:  11º tom (Jônio)"
     es: "Modo:  11º tono (Jónico)"
+    pl: Skala: 11t – jońska
 12t:
   label:
     it: "Mode: 12t – Hypoionian"
@@ -4135,6 +4648,7 @@ g|b:
     en: "Mode: 12t – Hypoionian"
     pt: "Modo:  12º modo (Hipojônio)"
     es: "Modo:  12º tono (Hipojónico)"
+    pl: Skala: 12t – hypojońska
 1tt:
   label:
     it: "Mode:  1tt – Dorian, transposed"
@@ -4143,6 +4657,7 @@ g|b:
     en: "Mode:  1tt – Dorian, transposed"
     pt: "Modo:  1º tom (Dórico), transposta"
     es: "Modo: 1º tono (Dórico), transpuesto"
+    pl: Skala: 1tt – dorycka transponowana
 2tt:
   label:
     it: "Mode:  2tt – Hypodorian, transposed"
@@ -4151,6 +4666,7 @@ g|b:
     en: "Mode:  2tt – Hypodorian, transposed"
     pt: "Modo:  2º tom (Hipodórico), transposta"
     es: "Modo:  2º tono (Hipodórico), transpuesto"
+    pl: Skala: 2tt – hypodorycka transponowana
 3tt:
   label:
     it: "Mode:  3tt – Phrygian, transposed"
@@ -4159,6 +4675,7 @@ g|b:
     en: "Mode:  3tt – Phrygian, transposed"
     pt: "Modo:  3º tom (Frígio), transposta"
     es: "Modo:  3º tono (Frigio), transpuesto"
+    pl: Skala: 3tt – frygijska transponowana
 4tt:
   label:
     it: "Mode:  4tt – Hypophrygian, transposed"
@@ -4167,6 +4684,7 @@ g|b:
     en: "Mode:  4tt – Hypophrygian, transposed"
     pt: "Modo:  4º tom (Hipofrígio), transposta"
     es: "Modo:  4º tono (Hipofrigio), transpuesto"
+    pl: Skala: 4tt – hypofrygijska transponowana
 5tt:
   label:
     it: "Mode:  5tt – Lydian, transposed"
@@ -4175,6 +4693,7 @@ g|b:
     en: "Mode:  5tt – Lydian, transposed"
     pt: "Modo:  5º tom (Lídio), transposta"
     es: "Modo:  5º tono (Lidio), transpuesto"
+    pl: Skala: 5tt – lidyjska transponowana
 6tt:
   label:
     it: "Mode:  6tt – Hypolydian, transposed"
@@ -4183,6 +4702,7 @@ g|b:
     en: "Mode:  6tt – Hypolydian, transposed"
     pt: "Modo:  6º tom (Hipolídio), transposta"
     es: "Modo:  6º tono (Hipolidio), transpuesto"
+    pl: Skala: 6tt – hypolidyjska transponowana
 7tt:
   label:
     it: "Mode:  7tt – Mixolydian, transposed"
@@ -4191,6 +4711,7 @@ g|b:
     en: "Mode:  7tt – Mixolydian, transposed"
     pt: "Modo:  7º tom (Mixolídio), transposta"
     es: "Modo:  7º tono (Mixolidio), transpuesto"
+    pl: Skala: 7tt – miksolidyjska transponowana
 8tt:
   label:
     it: "Mode:  8tt – Hypomixolydian, transposed"
@@ -4199,6 +4720,7 @@ g|b:
     en: "Mode:  8tt – Hypomixolydian, transposed"
     pt: "Modo:  8º tom (Hipomixolídio), transposta"
     es: "Modo:  8º tono (Hipomixolidio), transpuesto"
+    pl: Skala: 8tt – hypomiksolidyjska transponowana
 9tt:
   label:
     it: "Mode:  9tt – Aeolian, transposed"
@@ -4207,6 +4729,7 @@ g|b:
     en: "Mode:  9tt – Aeolian, transposed"
     pt: "Modo:  9º tom (Eólio), transposta"
     es: "Modo:  9º tono (Eólico), transpuesto"
+    pl: Skala: 9tt – eolska transponowana
 10tt:
   label:
     it: "Mode: 10tt – Hypoaeolian, transposed"
@@ -4215,6 +4738,7 @@ g|b:
     en: "Mode: 10tt – Hypoaeolian, transposed"
     pt: "Modo: 10º tom (Hipoeólio), transposta"
     es: "Modo: 10º tono (Hipoeólico), transpuesto"
+    pl: Skala: 10tt – hypoeolska transponowana
 11tt:
   label:
     it: "Mode: 11tt – Ionian, transposed"
@@ -4223,6 +4747,7 @@ g|b:
     en: "Mode: 11tt – Ionian, transposed"
     pt: "Modo:  11º tom (Jônio), transposta"
     es: "Modo:  11º tono (Jónico), transpuesto"
+    pl: Skala: 11tt – jońska transponowana
 12tt:
   label:
     it: "Mode: 12tt – Hypoionian, transposed"
@@ -4231,6 +4756,7 @@ g|b:
     en: "Mode: 12tt – Hypoionian, transposed"
     pt: "Modo:  12º modo (Hipojônio), transposta"
     es: "Modo:  12º tono (Hipojónico), transpuesto"
+    pl: Skala: 12tt – hypojońska transponowana
 1byz:
   label:
     it: "Octoechos 1: Ēchos prōtos (First mode of Byzantine music)"
@@ -4239,6 +4765,7 @@ g|b:
     en: "Octoechos 1: Ēchos prōtos (First mode of Byzantine music)"
     pt: "Octoechos 1: Ēchos prōtos (Primeiro modo bizantino)"
     es: "Octoechos 1: Ēchos prōtos (Primer modo bizantino)"
+    pl: Octoechos 1: Ēchos prōtos (pierwsza skala muzyki bizantyjskiej)
 2byz:
   label:
     it: "Octoechos 2: Ēchos deuteros (Second mode of Byzantine music)"
@@ -4247,6 +4774,7 @@ g|b:
     en: "Octoechos 2: Ēchos deuteros (Second mode of Byzantine music)"
     pt: "Octoechos 2: Ēchos deuteros (Segundo modo bizantino)"
     es: "Octoechos 2: Ēchos deuteros (Segundo modo bizantino)"
+    pl: Octoechos 2: Ēchos deuteros (druga skala muzyki bizantyjskiej)
 3byz:
   label:
     it: "Octoechos 3: Ēchos tritos (Third mode of Byzantine music)"
@@ -4255,46 +4783,52 @@ g|b:
     en: "Octoechos 3: Ēchos tritos (Third mode of Byzantine music)"
     pt: "Octoechos 3: Ēchos tritos (Terceiro modo bizantino)"
     es: "Octoechos 3: Ēchos tritos (Tercer modo bizantino)"
+    pl: Octoechos 3: Ēchos tritos (trzecia skala muzyki bizantyjskiej)
 4byz:
-  label: 
+  label:
     it: "Octoechos 4: Ēchos tetartos (Fourth mode of Byzantine music)"
     fr: "Octoechos 4: Ēchos tetartos (Fourth mode of Byzantine music)"
     de: "Octoechos 4: Ēchos tetartos (Fourth mode of Byzantine music)"
     en: "Octoechos 4: Ēchos tetartos (Fourth mode of Byzantine music)"
     pt: "Octoechos 4: Ēchos tetartos (Quarto modo bizantino)"
     pt: "Octoechos 4: Ēchos tetartos (Cuarto modo bizantino)"
+    pl: Octoechos 4: Ēchos tetartos (czwarta skala muzyki bizantyjskiej)
 5byz:
-  label: 
+  label:
     it: "Octoechos 5: Ēchos plagios prōtos (First plagal mode of Byzantine music)"
     fr: "Octoechos 5: Ēchos plagios prōtos (First plagal mode of Byzantine music)"
     de: "Octoechos 5: Ēchos plagios prōtos (First plagal mode of Byzantine music)"
     en: "Octoechos 5: Ēchos plagios prōtos (First plagal mode of Byzantine music)"
     pt: "Octoechos 5: Ēchos plagios prōtos (Primeiro modo bizantino plagal)"
     es: "Octoechos 5: Ēchos plagios prōtos (Primer modo bizantino plagal)"
+    pl: Octoechos 5: Ēchos plagios prōtos (pierwsza skala plagalna muzyki bizantyjskiej)
 6byz:
-  label: 
+  label:
     it: "Octoechos 6: Ēchos plagios deuteros (Second plagal mode of Byzantine music)"
     fr: "Octoechos 6: Ēchos plagios deuteros (Second plagal mode of Byzantine music)"
     de: "Octoechos 6: Ēchos plagios deuteros (Second plagal mode of Byzantine music)"
     en: "Octoechos 6: Ēchos plagios deuteros (Second plagal mode of Byzantine music)"
     pt: "Octoechos 6: Ēchos plagios deuteros (Segundo modo bizantino plagal)"
     es: "Octoechos 6: Ēchos plagios deuteros (Segundo modo bizantino plagal)"
+    pl: Octoechos 6: Ēchos plagios deuteros (druga skala plagalna muzyki bizantyjskiej)
 7byz:
-  label: 
+  label:
     it: "Octoechos 7: Ēchos barys (Third plagal mode of Byzantine music)"
     fr: "Octoechos 7: Ēchos barys (Third plagal mode of Byzantine music)"
     de: "Octoechos 7: Ēchos barys (Third plagal mode of Byzantine music)"
     en: "Octoechos 7: Ēchos barys (Third plagal mode of Byzantine music)"
     pt: "Octoechos 7: Ēchos barys (Terceiro modo bizantino plagal)"
     es: "Octoechos 7: Ēchos barys (Tercer modo bizantino plagal)"
+    pl: Octoechos 7: Ēchos barys (trzecia skala plagalna muzyki bizantyjskiej)
 8byz:
-  label: 
+  label:
     it: "Octoechos 8: Ēchos plagios tetartos (Fourth plagal mode of Byzantine music)"
     fr: "Octoechos 8: Ēchos plagios tetartos (Fourth plagal mode of Byzantine music)"
     de: "Octoechos 8: Ēchos plagios tetartos (Fourth plagal mode of Byzantine music)"
     en: "Octoechos 8: Ēchos plagios tetartos (Fourth plagal mode of Byzantine music)"
     pt: "Octoechos 8: Ēchos plagios tetartos (Quarto modo bizantino plagal)"
     es: "Octoechos 8: Ēchos plagios tetartos (Cuarto modo bizantino plagal)"
+    pl: Octoechos 8: Ēchos plagios tetartos (czwarta skala plagalna muzyki bizantyjskiej)
 #Clefs (031)
 01_modern_clefs:
   label:
@@ -4304,6 +4838,7 @@ g|b:
     en: "Common clefs"
     pt: Claves comuns
     es: Claves comunes
+    pl: Klucze współczesne
 C-1:
   label:
     it: "C-1"
@@ -4312,6 +4847,7 @@ C-1:
     en: "C-1"
     pt: "C-1"
     es: "C-1"
+    pl: C-1
 C-2:
   label:
     it: "C-2"
@@ -4320,6 +4856,7 @@ C-2:
     en: "C-2"
     pt: "C-2"
     es: "C-2"
+    pl: C-2
 C-3:
   label:
     it: "C-3"
@@ -4328,6 +4865,7 @@ C-3:
     en: "C-3"
     pt: "C-3"
     es: "C-3"
+    pl: C-3
 C-4:
   label:
     it: "C-4"
@@ -4336,6 +4874,7 @@ C-4:
     en: "C-4"
     pt: "C-4"
     es: "C-4"
+    pl: C-4
 C-5:
   label:
     it: "C-5"
@@ -4344,6 +4883,7 @@ C-5:
     en: "C-5"
     pt: "C-5"
     es: "C-5"
+    pl: C-5
 F-1:
   label:
     it: "F-1"
@@ -4352,6 +4892,7 @@ F-1:
     en: "F-1"
     pt: "F-1"
     es: "F-1"
+    pl: F-1
 F-2:
   label:
     it: "F-2"
@@ -4360,6 +4901,7 @@ F-2:
     en: "F-2"
     pt: "F-2"
     es: "F-2"
+    pl: F-2
 F-3:
   label:
     it: "F-3"
@@ -4368,6 +4910,7 @@ F-3:
     en: "F-3"
     pt: "F-3"
     es: "F-3"
+    pl: F-3
 F-4:
   label:
     it: "F-4 (chiave di basso)"
@@ -4376,6 +4919,7 @@ F-4:
     en: "F-4 (bass clef)"
     pt: "F-4 (clave grave)"
     es: "F-4 (clave de bajo)"
+    pl: F-4 (klucz basowy)
 F-5:
   label:
     it: "F-5"
@@ -4384,6 +4928,7 @@ F-5:
     en: "F-5"
     pt: "F-5"
     es: "F-5"
+    pl: F-5
 G-1:
   label:
     it: "G-1"
@@ -4392,6 +4937,7 @@ G-1:
     en: "G-1"
     pt: "G-1"
     es: "G-1"
+    pl: G-1
 G-2:
   label:
     it: "G-2 (chiave di violino)"
@@ -4400,6 +4946,7 @@ G-2:
     en: "G-2 (treble clef)"
     pt: "G-2 (clave aguda)"
     es: "G-2(clave aguda estándar)"
+    pl: G-2 (klucz wiolinowy)
 G-3:
   label:
     it: "G-3"
@@ -4408,6 +4955,7 @@ G-3:
     en: "G-3"
     pt: "G-3"
     es: "G-3"
+    pl: G-3
 G-4:
   label:
     it: "G-4"
@@ -4416,6 +4964,7 @@ G-4:
     en: "G-4"
     pt: "G-4"
     es: "G-4"
+    pl: G-4
 G-5:
   label:
     it: "G-5"
@@ -4424,6 +4973,7 @@ G-5:
     en: "G-5"
     pt: "G-5"
     es: "G-5"
+    pl: G-5
 g-2:
   label:
     it: "g-2 (Chiave di violino ottavizzata)"
@@ -4432,6 +4982,7 @@ g-2:
     en: "g-2 (octave treble clef)"
     pt: "g-2 (clave aguda à oitava)"
     es: "g-2 (clave de sol octava baja)"
+    pl: g-2 (oktawowy klucz wiolinowy)
 02_mensural_clefs:
   label:
     it: "Chiavi mensurali"
@@ -4440,6 +4991,7 @@ g-2:
     en: "Mensural clefs"
     pt: Claves mensurais
     es: "Claves mensurales"
+    pl: Klucze menzuralne
 C+1:
   label:
     it: "C+1"
@@ -4448,6 +5000,7 @@ C+1:
     en: "C+1"
     pt: "C+1"
     es: "C+1"
+    pl: C+1
 C+2:
   label:
     it: "C+2"
@@ -4456,6 +5009,7 @@ C+2:
     en: "C+2"
     pt: "C+2"
     es: "C+2"
+    pl: C+2
 C+3:
   label:
     it: "C+3"
@@ -4464,6 +5018,7 @@ C+3:
     en: "C+3"
     pt: "C+3"
     es: "C+3"
+    pl: C+3
 C+4:
   label:
     it: "C+4"
@@ -4472,6 +5027,7 @@ C+4:
     en: "C+4"
     pt: "C+4"
     es: "C+4"
+    pl: C+4
 C+5:
   label:
     it: "C+5"
@@ -4480,6 +5036,7 @@ C+5:
     en: "C+5"
     pt: "C+5"
     es: "C+5"
+    pl: C+5
 F+1:
   label:
     it: "F+1"
@@ -4488,6 +5045,7 @@ F+1:
     en: "F+1"
     pt: "F+1"
     es: "F+1"
+    pl: F+1
 F+2:
   label:
     it: "F+2"
@@ -4496,6 +5054,7 @@ F+2:
     en: "F+2"
     pt: "F+2"
     es: "F+2"
+    pl: F+2
 F+3:
   label:
     it: "F+3"
@@ -4504,6 +5063,7 @@ F+3:
     en: "F+3"
     pt: "F+3"
     es: "F+3"
+    pl: F+3
 F+4:
   label:
     it: "F+4"
@@ -4512,6 +5072,7 @@ F+4:
     en: "F+4"
     pt: "F+4"
     es: "F+4"
+    pl: F+4
 F+5:
   label:
     it: "F+5"
@@ -4520,6 +5081,7 @@ F+5:
     en: "F+5"
     pt: "F+5"
     es: "F+5"
+    pl: F+5
 G+1:
   label:
     it: "G+1"
@@ -4528,6 +5090,7 @@ G+1:
     en: "G+1"
     pt: "G+1"
     es: "G+1"
+    pl: G+1
 G+2:
   label:
     it: "G+2"
@@ -4536,6 +5099,7 @@ G+2:
     en: "G+2"
     pt: "G+2"
     es: "G+2"
+    pl: G+2
 G+3:
   label:
     it: "G+3"
@@ -4544,6 +5108,7 @@ G+3:
     en: "G+3"
     pt: "G+3"
     es: "G+3"
+    pl: G+3
 G+4:
   label:
     it: "G+4"
@@ -4552,6 +5117,7 @@ G+4:
     en: "G+4"
     pt: "G+4"
     es: "G+4"
+    pl: G+4
 G+5:
   label:
     it: "G+5"
@@ -4560,6 +5126,7 @@ G+5:
     en: "G+5"
     pt: "G+5"
     es: "G+5"
+    pl: G+5
 #Physical medium (340 $a) - currently not used by the partial
 Autography:
   label:
@@ -4569,6 +5136,7 @@ Autography:
     en: "Autography"
     pt: "Autografia"
     es: "Autografía"
+    pl: Autografia
 "Computer printout":
   label:
     it: "Stampata da computer"
@@ -4577,6 +5145,7 @@ Autography:
     en: "Computer printout"
     pt: "Impressão de computador"
     es: "Impreso de computadora"
+    pl: Wydruk komputerowy
 Engraving:
   label:
     it: "Incisione"
@@ -4585,6 +5154,7 @@ Engraving:
     en: "Engraving"
     pt: "Gravação"
     es: "Grabado"
+    pl: Sztych
 Facsimile:
   label:
     it: "Facsimile"
@@ -4593,6 +5163,7 @@ Facsimile:
     en: "Facsimile"
     pt: "Fac-símile"
     es: "Facsímil"
+    pl: Faksymile
 Lithography:
   label:
     it: "Litografia"
@@ -4601,6 +5172,7 @@ Lithography:
     en: "Lithography"
     pt: "Litografia"
     es: "Litografía"
+    pl: Litografia
 "Photoreproductive process":
   label:
     it: "Cianografia"
@@ -4609,6 +5181,7 @@ Lithography:
     en: "Photoreproductive process (bluprint)"
     pt: "Processo foto-reprodutivo"
     es: "Proceso fotoreproductivo"
+    pl: Proces optyczny (światłokopia)
 Reproduction:
   label:
     it: "Riproduzione"
@@ -4617,6 +5190,7 @@ Reproduction:
     en: "Reproduction"
     pt: "Reprodução"
     es: "Reproducción"
+    pl: Reprodukcja
 Transparency:
   label:
     it: "Trasparente"
@@ -4625,6 +5199,7 @@ Transparency:
     en: "Transparency"
     pt: "Transparência"
     es: "Transparencia"
+    pl: Przezrocze
 Typescript:
   label:
     it: "Dattiloscritto"
@@ -4633,6 +5208,7 @@ Typescript:
     en: "Typescript"
     pt: "Datilografia"
     es: "Escrito mecanografiado"
+    pl: Maszynopis
 Typography:
   label:
     it: "Stampa tipografica"
@@ -4641,6 +5217,7 @@ Typography:
     en: "Typography"
     pt: "Tipografia"
     es: "Tipografía"
+    pl: Typografia
 # new for 980
 origin:
   label:
@@ -4650,6 +5227,7 @@ origin:
     en: "Origin"
     pt: "Origem"
     es: "Orígen"
+    pl: Pochodzenie
 level:
   label:
     it: "Livello di catalogazione"
@@ -4658,6 +5236,7 @@ level:
     en: "Cataloging level"
     pt: "Nível de catalogação"
     es: "Nivel de catalogación"
+    pl: Poziom katalogowania
 autopsie:
   label:
     it: "Materiale esaminato"
@@ -4666,6 +5245,7 @@ autopsie:
     en: "Material examined"
     es: "Material examinado"
     pt: "Material examinado"
+    pl: Zbadany materiał
 RISM:
   label:
     it: "RISM"
@@ -4674,6 +5254,7 @@ RISM:
     en: "RISM"
     pt: "RISM"
     es: "RISM"
+    pl: RISM
 retro:
   label:
     it: "Conversione retrospettiva"
@@ -4682,6 +5263,7 @@ retro:
     en: "Retrospective conversion"
     pt: "Conversão restropectiva"
     es: "Conversión retrospectiva"
+    pl: Konwersja retrospektywna
 import:
   label:
     it: "Dati importati"
@@ -4690,6 +5272,7 @@ import:
     en: "Import"
     pt: "Importação"
     es: "Importación"
+    pl: Import
 full:
   label:
     it: "Completo"
@@ -4698,6 +5281,7 @@ full:
     en: "Full"
     pt: "Completo"
     es: "Completo"
+    pl: Pełny
 standard:
   label:
     it: "Standard"
@@ -4706,6 +5290,7 @@ standard:
     en: "Standard"
     pt: "Normalizado"
     es: "Estándar"
+    pl: Standardowy
 brief:
   label:
     it: "Breve"
@@ -4713,6 +5298,7 @@ brief:
     de: "Kurzkatalogisat"
     en: "Brief"
     pt: "Breve"
+    pl: Streszczenie
 examined:
   label:
     it: "Materiale esaminato"
@@ -4721,6 +5307,7 @@ examined:
     en: "Material examined"
     pt: Material examinado
     es: Material examinado
+    pl: Zbadany materiał
 not_examined:
   label:
     it: "Materiale non esaminato"
@@ -4729,6 +5316,7 @@ not_examined:
     en: "Material not examined"
     pt: "Material não examinado"
     es: "Material no examinado"
+    pl: Materiał nie zbadany
 
 
 
@@ -4748,6 +5336,7 @@ in_024:
     de: "Normdaten referenz"
     pt: "Referência de autoridade"
     es: "Referencia de autoridad"
+    pl: Odniesienie do bazy haseł wzorcowych
 in_040:
   label:
     en: "Cataloging agency"
@@ -4755,6 +5344,7 @@ in_040:
     de: "Katalogisierungsagentur"
     pt: "Agência catalogadora"
     es: "Agencia catalogadora"
+    pl: Jednostka katalogująca
 in_043:
   label:
     en: "Country code"
@@ -4762,13 +5352,15 @@ in_043:
     de: "Ländercode"
     pt: "Código de país"
     es: "Código de país"
+    pl: Kod kraju
 in_034:
   label:
     en: "Location"
     it: "Luogo"
     de: "Ort"
     pt: "Local"
-    es: "Lugar" 
+    es: "Lugar"
+    pl: Lokalizacja
 in_110:
   label:
     en: "Institution"
@@ -4776,6 +5368,7 @@ in_110:
     de: "Körperschaft"
     pt: "Instituição"
     es: "Institución"
+    pl: Instytucja
 in_510:
   label:
     en: "Paralell form of name"
@@ -4783,6 +5376,7 @@ in_510:
     de: "Paralelle Namensform"
     pt: "Forma paralela do nome"
     es: "Forma paralela de nombre"
+    pl: Współistniejąca forma nazwy
 in_410:
   label:
     en: "Other form of name"
@@ -4790,6 +5384,7 @@ in_410:
     de: "Andere Namensform"
     pt: "Outra forma do nome"
     es: "Otra forma de nombre"
+    pl: Wariant nazwy instytucji
 in_373:
   label:
     en: "Now in"
@@ -4797,6 +5392,7 @@ in_373:
     de: "Heute in"
     pt: "Fontes agora em"
     es: "Actualmente en"
+    pl: Obecnie w …
 in_368:
   label:
     en: "Type of institution"
@@ -4804,6 +5400,7 @@ in_368:
     de: "Körperschaftstyp"
     pt: "Tipo de instituição"
     es: "Tipo de institución"
+    pl: Rodzaj instytucji
 in_580:
   label:
     en: "Now in"
@@ -4811,6 +5408,7 @@ in_580:
     de: "Heute in"
     pt: "Agora em"
     es: "Actualmente en"
+    pl: Obecnie w …
 in_371:
   label:
     en: "Location and address"
@@ -4818,6 +5416,7 @@ in_371:
     de: "Lokalisierung und Adresse"
     pt: "Local e endereço"
     es: "Ubicación y dirección"
+    pl: Lokalizacja i adres
 in_678:
   label:
     en: "History of institution"
@@ -4825,6 +5424,7 @@ in_678:
     de: "Geschichte der Körperschaft"
     pt: "História da instituição"
     es: "Historia de la institución"
+    pl: Historia instytucji
 in_670:
   label:
     en: "Literature"
@@ -4832,6 +5432,7 @@ in_670:
     de: "Literatur"
     pt: "Literatura"
     es: "Literatura"
+    pl: Literatura
 in_680:
   label:
     en: "General note"
@@ -4839,6 +5440,7 @@ in_680:
     de: "Allgemeine Bemerkungen"
     pt: "Nota geral"
     es: "Nota general"
+    pl: Uwaga ogólna
 in_856:
   label:
     en: "Online finding aids"
@@ -4846,6 +5448,7 @@ in_856:
     de: "ONLINE FINDING AIDS"
     pt: "Recursos de ajuda on-line"
     es: "Recursos de ayuda online"
+    pl: Pomoce do wyszukiwania on-line
 in_551:
   label:
     en: "Places"
@@ -4853,6 +5456,7 @@ in_551:
     de: "Orte"
     pt: "Locais"
     es: "Lugares"
+    pl: Miejsca
 in_710:
   label:
     en: "Related institution"
@@ -4860,6 +5464,7 @@ in_710:
     de: "Zugehörige Körperschaften"
     pt: "Instituição relacionada"
     es: "Institución relacionada"
+    pl: Powiązana instytucja
 in_700:
   label:
     en: "Person"
@@ -4867,6 +5472,7 @@ in_700:
     de: "Person"
     pt: "Pessoa"
     es: "Persona"
+    pl: Osoba
 in_000:
   label:
     en: "Leader"
@@ -4874,6 +5480,7 @@ in_000:
     de: "Leader"
     pt: "Líder"
     es: "Líder"
+    pl: Leader
 in_001:
   label:
     en: "RISM ID Number"
@@ -4881,6 +5488,7 @@ in_001:
     de: "RISM ID NUMBER"
     pt: "Número de ID RISM"
     pt: "Número de ID de RISM"
+    pl: RISM ID
 in_003:
   label:
     en: "Control number identifier"
@@ -4888,6 +5496,7 @@ in_003:
     de: "CONTROL NUMBER IDENTIFIER"
     pt: "Identificador de número de controle"
     es: "Identificador del número de control"
+    pl: Identyfikator numeru kontrolnego
 in_005:
   label:
     en: "Date and time of last transaction"
@@ -4895,6 +5504,7 @@ in_005:
     de: "Zeitpunkt der letzten Transaktion"
     pt: "Data e hora da última transação"
     es: "Fecha y hora de la última transacción"
+    pl: Data i godzina ostatniej operacji
 in_008:
   label:
     en: "Date of creation"
@@ -4902,6 +5512,7 @@ in_008:
     de: "Erstellungszeit"
     pt: "Data de criação"
     es: "Fecha de creación"
+    pl: Data utworzenia
 in_667:
   label:
     en: "Internal notes"
@@ -4909,6 +5520,7 @@ in_667:
     de: "Interne Bemerkungen"
     pt: "Notas internas"
     es: "Notas internas"
+    pl: Uwagi wewnętrzne
 doc_in_identity:
   label:
     en: "Identity area"
@@ -4916,6 +5528,7 @@ doc_in_identity:
     de: "IDENTITY AREA"
     pt: "Identidade"
     es: "Identidad"
+    pl: Obszar tożsamości
 doc_in_contact:
   label:
     en: "Contact area"
@@ -4923,6 +5536,7 @@ doc_in_contact:
     de: "Kontakt"
     pt: "Contato"
     es: "Contacto"
+    pl: Obszar kontaktu
 doc_in_description:
   label:
     en: "Description area"
@@ -4930,6 +5544,7 @@ doc_in_description:
     de: "Beschreibung"
     pt: "Descrição"
     es: "Descripción"
+    pl: Obszar opisu
 doc_in_control:
   label:
     en: "Control fields"
@@ -4937,6 +5552,7 @@ doc_in_control:
     de: "Kontrollfelder"
     pt: "Campos de controle"
     es: "Campos de control"
+    pl: Pola kontrolne
 
 pe_100:
   label:
@@ -4945,6 +5561,7 @@ pe_100:
     de: "Personenname"
     pt: "Título-Nome de pessoa"
     es: "Nombre personal principal"
+    pl: Nagłówek – nazwisko
 pe_042:
   label:
     en: "Authentication code"
@@ -4952,6 +5569,7 @@ pe_042:
     de: "Authentifizierungscode"
     pt: "Código de autenticação"
     es: "Código de autenticación"
+    pl: Kod uwierzytelnienia
 pe_375:
   label:
     en: "Gender"
@@ -4959,6 +5577,7 @@ pe_375:
     de: "Geschlecht"
     pt: "Gênero"
     es: "Género"
+    pl: Płeć społeczno-kulturowa
 pe_043:
   label:
     en: "Nationality"
@@ -4966,6 +5585,7 @@ pe_043:
     de: "Nationalität"
     pt: "Nacionalidade"
     es: "Nacionalidad"
+    pl: Narodowość
 pe_024:
   label:
     en: "Other standard identifier"
@@ -4973,6 +5593,7 @@ pe_024:
     de: "OTHER STANDARD IDENTIFIER"
     pt: "Outro identificador padronizado"
     es: "Otro identificador estándar"
+    pl: Identyfikator innego standardu
 pe_400:
   label:
     en: "Name variant"
@@ -4980,6 +5601,7 @@ pe_400:
     de: "Namensvarianten"
     pt: "Variante de nome"
     es: "Variante de nombre"
+    pl: Alternatywna nazwa osoby
 pe_500:
   label:
     en: "Related personal name"
@@ -4987,6 +5609,7 @@ pe_500:
     de: "Zugehörige Personen"
     pt: "Nome de pessoa relacionado"
     es: "Nombre personal relacionado"
+    pl: Powiązana osoba
 pe_510:
   label:
     en: "Associated institution"
@@ -4994,6 +5617,7 @@ pe_510:
     de: "Zugehörige Körperschaften"
     pt: "Instituição associada"
     es: "Institución asoaciada"
+    pl: Powiązana instytucja
 pe_550:
   label:
     en: "Profession or function"
@@ -5001,6 +5625,7 @@ pe_550:
     de: "Beruf oder Funktion"
     pt: "Profissão ou função"
     es: "Profesión o función"
+    pl: Zawód lub funkcja
 pe_551:
   label:
     en: "Geographic name"
@@ -5008,6 +5633,7 @@ pe_551:
     de: "Geographischer Name"
     pt: "Nome geográfico"
     es: "Nombre geográfico"
+    pl: Nazwa geograficzna
 pe_667:
   label:
     en: "Internal note"
@@ -5015,6 +5641,7 @@ pe_667:
     de: "Interne Bemerkungen"
     pt: "Nota interna"
     es: "Nota interna"
+    pl: Uwaga wewnętrzna
 pe_670:
   label:
     en: "Source data found"
@@ -5022,6 +5649,7 @@ pe_670:
     de: "SOURCE DATA FOUND"
     pt: "Fonte dos dados encontrados"
     es: "Datos de fuente encontrados"
+    pl: Odnalezione źródło danych
 pe_678:
   label:
     en: "Additional biographical information"
@@ -5029,6 +5657,7 @@ pe_678:
     de: "zusätzliche biographische Informationen"
     pt: "Informação biográfica adicional"
     es: "Información biográfica adicional"
+    pl: Dodatkowe informacje biograficzne
 pe_680:
   label:
     en: "General note"
@@ -5036,6 +5665,7 @@ pe_680:
     de: "Allgemeine Bemerkungen"
     pt: Nota geral
     es: Nota general
+    pl: Uwaga ogólna
 pe_856:
   label:
     en: "External resource"
@@ -5043,6 +5673,7 @@ pe_856:
     de: "EXTERNAL RESOURCE"
     pt: "Recurso externo"
     es: "Recurso externo"
+    pl: Zasób zewnętrzny
 pe_040:
   label:
     en: "Cataloging source"
@@ -5050,6 +5681,7 @@ pe_040:
     de: "Katalogisierungsquelle"
     pt: "Agência catalogadora"
     es: "Agencia catalogadora"
+    pl: Katalogowanie źródła
 pe_main_entry_fields:
   label:
     de: "Haupteintragungen"
@@ -5057,6 +5689,7 @@ pe_main_entry_fields:
     en: "Main entry fields"
     pt: Campos de entrada principal
     es: Campos principales
+    pl: Główne pola edycji
 pe_numbers:
   label:
     de: "Nummern und Codes"
@@ -5064,6 +5697,7 @@ pe_numbers:
     en: "Numbers and code fields"
     pt: "Números e campos de código"
     es: "Números y códigos"
+    pl: Pola liczb i kodów
 pe_name_variants:
   label:
     de: "Namensvarianten"
@@ -5071,6 +5705,7 @@ pe_name_variants:
     en: "Name variants"
     pt: Variante de nome
     es: "Variantes del nombre"
+    pl: Alternatywne nazwy osoby
 pe_relations:
   label:
     de: "Beziehungen"
@@ -5078,14 +5713,16 @@ pe_relations:
     it: "Relazioni"
     pt: "Relacionamentos"
     es: "Relaciones"
-pe_references: 
-  label: 
+    pl: Relacje
+pe_references:
+  label:
     it: Bibliografia e note
     fr: "Références et notes"
     de: Literatur und Fussnoten
     en: References and notes
     pt: "Notas e referências"
     es: Notas y referencias
+    pl: Odniesienia i uwagi
 pe_control:
   label:
     en: "Control fields"
@@ -5093,6 +5730,7 @@ pe_control:
     de: "Kontrollfelder"
     pt: Campos de controle
     es: "Campos de control"
+    pl: Pola kontrolne
 doc_places:
   label:
     en: "Places"
@@ -5100,6 +5738,7 @@ doc_places:
     de: "Orte"
     pt: "Locais"
     es: "Lugares"
+    pl: Miejsca
 li_100:
   label:
     en: "Author / Editor"
@@ -5107,6 +5746,7 @@ li_100:
     de: "Autor / Herausgeber"
     pt: Autor/editor
     es: "Autor/editor"
+    pl: Autor / edytor
 li_700:
   label:
     en: "Additional personal name"
@@ -5114,6 +5754,7 @@ li_700:
     de: "Zusätzliche Personen"
     pt: Nome de pessoa adicional
     es: Nombre personal adicional
+    pl: Dodatkowa osoba
 li_240:
   label:
     en: "Title of item"
@@ -5121,6 +5762,7 @@ li_240:
     de: "Titel"
     pt: "Título do item"
     es: "Título del ítem"
+    pl: Tytuł pozycji
 li_260:
   label:
     en: "Imprint"
@@ -5128,6 +5770,7 @@ li_260:
     de: "IMPRINT"
     pt: "Carimbo/marca"
     es: "Datos editoriales"
+    pl: Stopka wydawnicza
 li_300:
   label:
     en: "Physical description"
@@ -5135,6 +5778,7 @@ li_300:
     de: "Materialbeschreibung"
     pt: "Descrição física"
     es: "Descripción del material"
+    pl: Opis fizyczny
 li_337:
   label:
     en: "Media type"
@@ -5142,6 +5786,7 @@ li_337:
     de: "Medientyp"
     pt: "Tipo de mídia"
     es: "Tipo de medio"
+    pl: Rodzaj nośnika
 li_210:
   label:
     en: "Short title"
@@ -5149,13 +5794,15 @@ li_210:
     de: "Kurztitel"
     pt: "Título abreviado"
     es: "Título breve"
-li_250: 
-  label: 
+    pl: Skrócony tytuł
+li_250:
+  label:
     it: Edizione
     fr: Édition
     de: Ausgabe
     en: Edition statement
     es: "Declaración de edición"
+    pl: Wydanie
 li_020:
   label:
     en: "ISBN"
@@ -5163,6 +5810,7 @@ li_020:
     de: "ISBN"
     pt: "ISBN"
     es: "ISBN"
+    pl: ISBN
 li_022:
   label:
     en: "ISSN"
@@ -5170,6 +5818,7 @@ li_022:
     de: "ISSN"
     pt: "ISSN"
     es: "ISSN"
+    pl: ISSN
 li_024:
   label:
     en: "ISSN"
@@ -5177,6 +5826,7 @@ li_024:
     de: "ISSN"
     pt: "ISSN"
     es: "ISSN"
+    pl: ISSN
 li_041:
   label:
     en: "Language code"
@@ -5184,6 +5834,7 @@ li_041:
     de: "Sprachcode"
     pt: "Código de idioma"
     es: "Código de idioma"
+    pl: Kod języka
 li_044:
   label:
     en: "Country of publication"
@@ -5191,6 +5842,7 @@ li_044:
     de: "Erscheinungsland"
     pt: "País de publicação"
     es: "País de publicación"
+    pl: Kraj publikacji
 li_710:
   label:
     en: "Additional institution"
@@ -5198,6 +5850,7 @@ li_710:
     de: "Zusätzliche Körperschaften"
     pt: "Instituição adicional"
     es: "Institución adicional"
+    pl: Dodatkowa instytucja
 li_760:
   label:
     en: "Item part of"
@@ -5205,6 +5858,7 @@ li_760:
     de: "ITEM PART OF"
     pt: "Item parte de"
     es: "Ítem integrante de"
+    pl: Jest częścią…
 li_650:
   label:
     en: "Subject heading"
@@ -5212,6 +5866,7 @@ li_650:
     de: "Schlagworteintragung"
     pt: "Assunto"
     es: "Descriptor"
+    pl: Słowo kluczowe
 li_651:
   label:
     en: "Related place"
@@ -5219,6 +5874,7 @@ li_651:
     de: "Zugehörige Orte"
     pt: "Local relacionado"
     es: "Lugar relacionado"
+    pl: Powiązane miejsce
 li_780:
   label:
     en: "Preceding entry"
@@ -5226,6 +5882,7 @@ li_780:
     de: "Ersteintrag"
     pt: "Registro precedente"
     es: "Registro precedente"
+    pl: Poprzedzający wpis
 li_785:
   label:
     en: "Succeeding entry"
@@ -5233,20 +5890,23 @@ li_785:
     de: "Folgeeintrag"
     pt: "Registro subsequente"
     es: "Registro subsiguiente"
+    pl: Kolejny wpis
 li_500:
   label:
     en: "General note"
     it: "Nota generale"
     de: "Allgemeine Bemerkungen"
     pt: "Nota geral"
-    es: "Nota general" 
-li_502: 
-  label: 
+    es: "Nota general"
+    pl: Uwaga ogólna
+li_502:
+  label:
     it: Nota alla dissertazione
     fr: Note à la thèse
     de: Hinweis zur Dissertation
     en: Dissertation note
     es: "Nota de disertación"
+    pl: Uwaga do dysertacji
 li_599:
   label:
     en: "Local note field"
@@ -5254,6 +5914,7 @@ li_599:
     de: "Lokale Bemerkungen"
     pt: "Campo de nota local"
     es: "Campo de nota local"
+    pl: Pole uwagi lokalnej
 li_856:
   label:
     en: "External resource"
@@ -5261,6 +5922,7 @@ li_856:
     de: "Elektronische Lokalisierung und Zugriff"
     pt: "Recurso externo"
     es: "Recurso externo"
+    pl: Zasób zewnętrzny
 li_520:
   label:
     en: "Contents note"
@@ -5268,6 +5930,7 @@ li_520:
     de: "CONTENTS NOTE"
     pt: "Nota de Conteúdo"
     es: "Nota sobre el contenido"
+    pl: Uwaga do zawartości
 li_000:
   label:
     en: "Leader"
@@ -5275,6 +5938,7 @@ li_000:
     de: "Leader"
     pt: "Líder"
     es: "Líder"
+    pl: Leader
 li_001:
   label:
     en: "RISM ID Number"
@@ -5282,6 +5946,7 @@ li_001:
     de: "Zusammenfassende Beschreibung"
     pt: "Número ID RISM"
     es: "Número de ID de RISM"
+    pl: RISM ID
 li_003:
   label:
     en: "Control number identifier"
@@ -5289,6 +5954,7 @@ li_003:
     de: "CONTROL NUMBER IDENTIFIER"
     pt: "Identificador de número de controle"
     es: "Identificador del número de control"
+    pl: Identyfikator numeru kontrolnego
 li_005:
   label:
     en: "Date and time of last transaction"
@@ -5296,6 +5962,7 @@ li_005:
     de: "Zeitpunkt der letzten Transaktion"
     pt: "Data e hora da última transação"
     es: "Fecha y hora de la última transacción"
+    pl: Data i godzina ostatniej operacji
 li_main_entry_fields:
   label:
     de: "Haupteintragungen"
@@ -5303,6 +5970,7 @@ li_main_entry_fields:
     en: "Main entry fields"
     pt: "Campos principales"
     es: "Campos principales"
+    pl: Główne pola edycji
 li_subject:
   label:
     en: "Subject access fields"
@@ -5310,6 +5978,7 @@ li_subject:
     de: "SUBJECT ACCESS FIELDS"
     pt: "Campos de acesso por assunto"
     es: "Campos de acceso por asunto"
+    pl: Pola haseł tematycznych
 li_note:
   label:
     en: "Note fields"
@@ -5317,6 +5986,7 @@ li_note:
     de: "Bemerkungsfelder"
     pt: Campos de notas
     es: "Campos de notas"
+    pl: Pola uwag
 li_control:
   label:
     en: "Control fields"
@@ -5324,6 +5994,7 @@ li_control:
     de: "Kontrollfelder"
     pt: Campos de controle
     es: "Campos de control"
+    pl: Pola kontrolne
 li_lit:
   label:
     en: "Secondary literature"
@@ -5331,13 +6002,15 @@ li_lit:
     de: "Sekundärliteratur"
     pt: "Literatura secundária"
     es: "Bibliografía secundaria"
+    pl: Literatura pomocnicza
 doc_titles_and_text:
   label:
-    en: "Titles / text incipits"  
-    it: "Titoli / incipit testuali"  
+    en: "Titles / text incipits"
+    it: "Titoli / incipit testuali"
     de: "Titel und  Texte"
     pt: "Títulos / incipits literários"
     es: "Títulos/íncipits literarios"
+    pl: Tytuły / incipity tekstowe
 aid_terms:
   label:
     en: "Standard music terms"
@@ -5345,6 +6018,7 @@ aid_terms:
     de: "STANDARD MUSIC TERMS"
     pt: "Termos musicais normalizados"
     es: "Términos musicales estándar"
+    pl: Standardowe pojęcia muzyczne
 aid_watermarks:
   label:
     en: "Standard watermarks"
@@ -5352,6 +6026,7 @@ aid_watermarks:
     de: "Wasserzeichen"
     pt: "Marcas d'água normalizadas"
     es: "Marcas de agua estándar"
+    pl: Standardowe znaki wodne
 
 aid_general:
   label:
@@ -5360,6 +6035,7 @@ aid_general:
     de: "GENERAL ABBREVIATIONS AND TERMS"
     pt: Abreviaturas e termos gerais
     es: "Abreviaturas y términos generales"
+    pl: Ogólne skróty i pojęcia
 aid_dates:
   label:
     en: "Dates"
@@ -5367,6 +6043,7 @@ aid_dates:
     de: "Datierungen"
     pt: Datas
     es: Fechas
+    pl: Daty
 aid_eccl:
   label:
     en: "Ecclesiastical modes"
@@ -5374,6 +6051,7 @@ aid_eccl:
     de: "Kirchentonarten"
     pt: "Modos eclesiásticos ocidentais"
     es: "Modos eclesiásticos"
+    pl: Skale kościelne
 aid_keys:
   label:
     en: "Keys"
@@ -5381,6 +6059,7 @@ aid_keys:
     de: "Tonarten"
     es: Tonalidades
     pt: Tonalidades
+    pl: Tomacje
 aid_language:
   label:
     en: "Language codes"
@@ -5388,6 +6067,7 @@ aid_language:
     de: "Sprachcodes"
     pt: "Código de idioma"
     es: "Código de idioma"
+    pl: Kody języków
 doc_other:
   label:
     en: "Other help"
@@ -5395,13 +6075,15 @@ doc_other:
     de: "Weitere Hilfen"
     pt: "Outra ajuda"
     es: "Otra Ayuda"
+    pl: Inna pomoc
 aid_titles:
-  label: 
+  label:
     de: "Einordnungstitel - Schlagworte"
     en: "Standardized titles - Subject headings"
     it: "Titolo standard - intestazione del soggetto"
     pt: "Títulos uniformes – Cabeçalhos de assunto"
     es: "Títulos uniformes – Descriptores"
+    pl: Znormalizowane tytuły – słowa kluczowe
 aid_texts:
   label:
     en: "Standard texts of sacred works"
@@ -5409,6 +6091,7 @@ aid_texts:
     de: "Liturgische Texte"
     pt: "Textos padronizados de obras sacras"
     es: "Textos estándar de obras sacras"
+    pl: Standardowe teksty utworów sakralnych
 aid_lit:
   label:
     en: "Liturgical festivals"
@@ -5416,6 +6099,7 @@ aid_lit:
     de: "Liturgische Feste"
     pt: "Festa litúrgica"
     es: "Festividades litúrgicos"
+    pl: Święta liturgiczne
 aid_figured:
   label:
     en: "Figured bass in scores and/or other parts"
@@ -5423,6 +6107,7 @@ aid_figured:
     de: "Generalbass"
     pt: "Baixo cifrado"
     es: "Bajo cifrado"
+    pl: Bas cyfrowany w partyturze i / lub w innych częściach
 aid_transpose:
   label:
     en: "Help for transposing instruments"
@@ -5430,6 +6115,7 @@ aid_transpose:
     de: "Hilfe zu transponierenden Instrumenten"
     pt: "Ajuda para instrumentos transpositores"
     es: "Ayuda para instrumentos transpositores"
+    pl: Pomoc przy transpozycji instrumentów
 aid_opera:
   label:
     en: "Opera houses and concert halls"
@@ -5437,6 +6123,7 @@ aid_opera:
     de: "Opernhäuser und Konzerthallen"
     pt: "Teatros de ópera e salas de concerto"
     es: "Teatros de ópera y salas de concierto"
+    pl: Opery i sale koncertowe
 aid_faq:
   label:
     en: "Frequently asked questions"
@@ -5444,6 +6131,7 @@ aid_faq:
     de: "FAQ"
     pt: "Questões frequentes"
     es: "Preguntas frecuentes"
+    pl: Odpowiedzi na częste pytania
 aid_tt:
   label:
     en: "How do I ... Tips & Tricks"
@@ -5451,6 +6139,7 @@ aid_tt:
     de: "Wie kann ich ... Tipps & Tricks"
     pt: "Como faço ...dicas & truques"
     es: "¿Cómo hago ...? Sugerencias y trucos"
+    pl: Rady i wskazówki
 aid_best:
   label:
     en: "RISM best practices"
@@ -5458,6 +6147,7 @@ aid_best:
     de: "RISM BEST PRACTISES"
     pt: "Boas práticas no RISM"
     es: "Mejores prácticas en RISM"
+    pl: Dobre praktyki RISM
 aid_error:
   label:
     en: "Technical errors"
@@ -5465,28 +6155,31 @@ aid_error:
     de: "Technische Fehler"
     pt: "Problemas técnicos"
     es: "Problemas técnicos"
-IIIF: 
-  label: 
+    pl: Błędy techniczne
+IIIF:
+  label:
     it: "Manifesto IIIF"
     fr: "Manifeste IIIF"
     de: "IIIF manifest"
     en: "IIIF manifest"
     pt: Manifesto IIIF
     es: Manifiesto IIIF
-Digitalization: 
-  label: 
+    pl: Manifest IIIF
+Digitalization:
+  label:
     it: "Musica digitalizzata"
     fr: "Sources numériées"
     de: "Quellendigitalisat"
     en: "Digitized source"
     pt: Fonte digitalizada
     es: Fuente digitalizada
-Other: 
-  label: 
+    pl: Cyfrowa reprodukcja źródła
+Other:
+  label:
     it: "Altro"
     fr: "Autre"
     de: "Sonstiges"
     en: "Other"
     pt: Outros
     es: Otros
-
+    pl: Pozostałe

--- a/config/editor_profiles/default/configurations/WorkLabels.yml
+++ b/config/editor_profiles/default/configurations/WorkLabels.yml
@@ -5,48 +5,56 @@ doc_abbreviations:
     de: "Abkürzungen"
     en: Abbreviations
     es: Abreviaturas
+    pl: Skróty
 doc_aid:
   label:
     it: Aiuti
     de: Arbeitshilfen
     en: Aids
     es: Asistencia
+    pl: Pomoce
 doc_cataloguing_collections:
   label:
     it: Catalogazione di raccolte e volumi compositi
     de: Erfassung von Sammlungen
     en: Cataloging collection and convoluta
     es: "Catalogación de colecciones y volúmenes compuestos"
+    pl: Katalogowanie kolekcji i klocka introligatorskiego
 doc_edit_functions:
   label:
     it: Funzioni base
     de: "Grundsätzliche Funktionen"
     en: Basic functions
     es: "Funciones básicas"
+    pl: Podstawowe funkcje
 doc_introduction:
   label:
     it: Introduzione
     de: Einleitung
     en: Introduction
     es: "Introducción"
+    pl: Wprowadzenie
 doc_masks:
   label:
     it: Formulari di catalogazione
     de: Masken
     en: Cataloging forms
     es: "Formularios de catalogación"
+    pl: Formularze katalogowania
 doc_tag_index:
   label:
     it: Indice dei campi MARC
     de: MARC Tag Index
     en: MARC tag index
     es: "Índice de etiquetas MARC"
+    pl: Indeks znaczników MARC
 doc_templates:
   label:
     it: Template
     de: Templates
     en: Templates
     es: Plantillas
+    pl: Szablony
 
 ################
 
@@ -56,12 +64,14 @@ doc_editor:
     de: "Editor Hilfe"
     en: Editor help
     es: "Ayuda del editor"
+    pl: Pomoc do edycji
 doc_edit_workflow: 
   label: 
     it: Workflow
     de: "Workflow"
     en: Workflow
     es: Flujo de trabajo
+    pl: Przepływ pracy
     
 ################
 
@@ -73,6 +83,7 @@ doc_edit_workflow:
     de: Leader
     en: Leader
     es: "Líder"
+    pl: Leader
 "001":
   label:
     it: Numero documento RISM
@@ -80,6 +91,7 @@ doc_edit_workflow:
     de: RISM Dokumentnummer
     en: RISM ID number
     es: "Número de ID de RISM"
+    pl: RISM ID
 "003":
   label:
     it: Identificatore del numero di controllo
@@ -87,6 +99,7 @@ doc_edit_workflow:
     de: Kontrollnummer-Bezeichnung
     en: Control number identifier
     es: "Identificador de número de control"
+    pl: Identyfikator numeru kontrolnego
 "005":
   label:
     it: Data e ora dell'ultima transazione
@@ -94,6 +107,7 @@ doc_edit_workflow:
     de: Datum und Zeit der letzten Transaktion
     en: Date and time of last transaction
     es: "Fecha y hora de la última transacción"
+    pl: Data i godzina ostatniej operacji
 "024":
   label:
     it: "Riferimento autorità"
@@ -101,6 +115,7 @@ doc_edit_workflow:
     de: Normdatenverweise
     en: Other standard identifier
     es: "Otro identificador estándar"
+    pl: Identyfikator innego standardu
   fields:
     a:
       label:
@@ -109,6 +124,7 @@ doc_edit_workflow:
         de: Normdatenverweise
         en: Standard number or code
         es: "Número o código estándar"
+        pl: Standardowy numer lub kod
     "2":
       label:
         it: "Agenzia autorità"
@@ -116,6 +132,7 @@ doc_edit_workflow:
         de: Normdatenagentur
         en: Source of number or code
         es: "Fuente de número o código"
+        pl: Źródło numeru lub kodu
 "031": 
   label: 
     it: Incipit musicale
@@ -123,6 +140,7 @@ doc_edit_workflow:
     de: Musikincipit
     en: Incipit
     es: Íncipit
+    pl: Incipit
   fields: 
     a: 
       label: 
@@ -131,12 +149,14 @@ doc_edit_workflow:
         de: Incipitnummer
         en: Work number
         es: "Número de obra"
+        pl: Numer dzieła
       edit_label: 
         it: Numero
         fr: "No. de l'œuvre"
         de: Nummer
         en: Work number
         es: "Número de obra"
+        pl: Numer dzieła
     b: 
       label: 
         it: Movimento N.
@@ -144,12 +164,14 @@ doc_edit_workflow:
         de: Satznummer
         en: Movement number
         es: "Número de movimiento"
+        pl: Numer części
       edit_label: 
         it: Movimento N.
         fr: "No. du mouvement"
         de: Satznummer
         en: Movement number
         es: "Número de movimiento"
+        pl: Numer części
     c: 
       label: 
         it: Numero dell'estratto
@@ -157,12 +179,14 @@ doc_edit_workflow:
         de: Abschnitt
         en: Incipit number
         es: "Número de íncipit"
+        pl: Numer incipitu
       edit_label: 
         it: Estratto No.
         fr: "No. de l'extrait"
         de: Nummer Abschnitt
         en: Incipit number
         es: "Número de íncipit"
+        pl: Numer incipitu
     m: 
       label: 
         it: Organico
@@ -170,6 +194,7 @@ doc_edit_workflow:
         de: Besetzung
         en: Voice/instrument
         es: Voz/instrumento
+        pl: Głos / instrument
     n: 
       label: 
         it: Armatura di chiave
@@ -177,12 +202,14 @@ doc_edit_workflow:
         de: Akzidentien
         en: Key signature
         es: "Armadura de clave"
+        pl: Znaki przykluczowe
       edit_label: 
         it: Armat.
         fr: Armure
         de: Vorzeichen
         en: Key signature
         es: "Armadura de clave"
+        pl: Znaki przykluczowe
     d: 
       label: 
         it: Intestazione, Tempo
@@ -190,6 +217,7 @@ doc_edit_workflow:
         de: Satztitel, Tempo
         en: Title of movement, tempo
         es: "Título del movimiento, tempo"
+        pl: Tytuł części, tempo
     o: 
       label: 
         it: Misura
@@ -197,12 +225,14 @@ doc_edit_workflow:
         de: Metrum
         en: Time signature
         es: "Indicación de compás"
+        pl: Metrum
       edit_label: 
         it: Misura
         fr: Ind. mesure
         de: Metrum
         en: Time signature
         es: "Indicación de compás"
+        pl: Metrum
     e: 
       label: 
         it: Ruolo
@@ -210,6 +240,7 @@ doc_edit_workflow:
         de: Rolle
         en: Role
         es: Personaje
+        pl: Rola
     p: 
       label: 
         it: Incipit musicale
@@ -217,6 +248,7 @@ doc_edit_workflow:
         de: Musikincipit
         en: Music incipit
         es: "Íncipit musical"
+        pl: Incipit muzyczny
     q: 
       label: 
         it: Commento all'incipit mus.
@@ -224,6 +256,7 @@ doc_edit_workflow:
         de: Kommentar zum Musikincipit
         en: General note
         es: Nota general
+        pl: Uwaga ogólna
     g: 
       label: 
         it: Chiave
@@ -231,12 +264,14 @@ doc_edit_workflow:
         de: "Schlüssel"
         en: Clef
         es: Clave
+        pl: Klucz
       edit_label: 
         it: Chiave
         fr: "Clé"
         de: "Schlüssel"
         en: Clef
         es: Clave
+        pl: Klucz
     r: 
       label: 
         it: "Tonalità, modo"
@@ -244,12 +279,14 @@ doc_edit_workflow:
         de: Tonart, Modus
         en: Key or mode
         es: Tonalidad o modo
+        pl: Tonacja lub modus
       edit_label: 
         it: "Tonalità"
         fr: "Tonalité"
         de: Tonart
         en: Key
         es: Tonalidad
+        pl: Tonacja
     s: 
       label: 
         it: "Validità"
@@ -257,12 +294,14 @@ doc_edit_workflow:
         de: "Gültigkeit"
         en: Validity
         es: Validez
+        pl: Ważność
       edit_label: 
         it: "Validità"
         fr: "Validité"
         de: "Gültigkeit"
         en: "Validity"
         es: Validez
+        pl: Ważność
     t: 
       label: 
         it: Incipit testuale
@@ -270,6 +309,7 @@ doc_edit_workflow:
         de: Textincipit
         en: Text incipit
         es: "Íncipit literario"
+        pl: Incipit tekstowy
     z: 
       label: 
         it: Organico del movimento
@@ -277,6 +317,7 @@ doc_edit_workflow:
         de: Besetzung Satz
         en: Scoring in movement
         es: "Plantilla/orgánico del movimiento"
+        pl: Obsada w części
 
 "040":
   label:
@@ -285,6 +326,7 @@ doc_edit_workflow:
     de: Katalogisierungsquelle
     en: Cataloging source
     es: "Fuente de la catalogación"
+    pl: Katalogowanie źródła
   fields:
     a:
       label:
@@ -293,6 +335,7 @@ doc_edit_workflow:
         de: Original-Katalogisierungsstelle
         en: Original cataloging agency
         es: "Agencia de catalogación original"
+        pl: Jednostka katalogująca pierwotny rekord
     b:
       label:
         it: Lingua della catalogazione
@@ -300,6 +343,7 @@ doc_edit_workflow:
         de: Katalogisierungssprache
         en: Language of cataloging
         es: "Idioma de la catalogación"
+        pl: Język katalogowania
     c:
       label:
         it: Agenzia della trascrizione
@@ -307,6 +351,7 @@ doc_edit_workflow:
         de: "Übertragende Katalogisierungsstelle"
         en: Transcribing agency
         es: "Agencia de la transcripción"
+        pl: Jednostka transkrybująca
     d:
       label:
         it: Agenzia della modifica
@@ -314,6 +359,7 @@ doc_edit_workflow:
         de: Modifizierende Katalogisierungsstelle
         en: Modifying agency
         es: "Agencia de la modificación"
+        pl: Jednostka modyfikująca
 "042":
   label:
     it: Codice di autenticazione
@@ -321,6 +367,7 @@ doc_edit_workflow:
     de: Authentication Code
     en: Authentication Code
     es: "Código de autenticación"
+    pl: Kod uwierzytelnienia
   fields:
     a:
       label:
@@ -329,6 +376,7 @@ doc_edit_workflow:
         de: Authentication Code
         en: Authentication Code
         es: "Código de autenticación"
+        pl: Kod uwierzytelnienia
 "043":
   label:
     it: Codice del Paese
@@ -336,6 +384,7 @@ doc_edit_workflow:
     de: Länder-Code
     en: Nationality
     es: Nacionalidad
+    pl: Narodowość
   fields:
     c:
       label:
@@ -344,6 +393,7 @@ doc_edit_workflow:
         de: Länder-Code  
         en: Nationality
         es: Nacionalidad
+        pl: Narodowość
 "100":
   label:
     it: Nome di persona
@@ -351,6 +401,7 @@ doc_edit_workflow:
     de: Ansetzungsform
     en: Heading
     es: Encabezado
+    pl: Nagłówek
   fields:
     a:
       label:
@@ -359,6 +410,7 @@ doc_edit_workflow:
         de: Komponist
         en: Composer
         es: Compositor
+        pl: Kompozytor
     d:
       label:
         it: Data di nascita e di morte
@@ -366,6 +418,7 @@ doc_edit_workflow:
         de: Geburts- und Todesdaten
         en: Years of birth and death
         es: "Años de nacimiento y muerte"
+        pl: Lata urodzenia i śmierci
     m:
       label:
         it: Organico sintetico
@@ -373,6 +426,7 @@ doc_edit_workflow:
         de: Besetzungshinweis
         en: Scoring summary
         es: "Resumen de Plantilla/Orgánico"
+        pl: Podsumowanie obsady
     n:
       label:
         it: Numero della parte/sezione di una composizione
@@ -380,6 +434,7 @@ doc_edit_workflow:
         de: "Opus / WV-Nummer"
         en: "Opus / Thematic index number"
         es: "Número de Opus/Índice temático"
+        pl: Opus / Numer z katalogu tematycznego 
     r:
       label: 
         it: "Tonalità"
@@ -387,6 +442,7 @@ doc_edit_workflow:
         de: Tonart
         en: Key or mode
         es: Tonalidad o modo
+        pl: Tonacja lub modus
       comment: "(rdaw:P10221)"
     t:
       label:
@@ -395,6 +451,7 @@ doc_edit_workflow:
         de: Werktitel
         en: Title of work
         es: "Título de la obra"
+        pl: Tytuł dzieła
 "370":
   label:
     it: Luogo associato
@@ -402,6 +459,7 @@ doc_edit_workflow:
     de: Associated Place
     en: Associated Place
     es: Lugar asociado
+    pl: Powiązane miejsce
   fields:
     a:
       label:
@@ -410,6 +468,7 @@ doc_edit_workflow:
         de: Geburtsort  
         en: Place of birth
         es: Lugar de nacimiento
+        pl: Miejsce urodzenia
 "380": 
   label: 
     it: Parola chiave
@@ -417,6 +476,7 @@ doc_edit_workflow:
     de: Schlagworteintragung
     en: Subject heading
     es: Descriptor
+    pl: Słowo kluczowe
   fields: 
     a: 
       label: 
@@ -425,6 +485,7 @@ doc_edit_workflow:
         fr: Sujet
         en: Subject heading
         es: Descriptor
+        pl: Słowo kluczowe
       edit_label: 
       en: ""
 
@@ -435,6 +496,7 @@ doc_edit_workflow:
     de: Ansetzungsform
     en: Heading
     es: Encabezado
+    pl: Nagłówek
   fields:
     a:
       label:
@@ -443,6 +505,7 @@ doc_edit_workflow:
         de: Komponist
         en: Heading - composer name
         es: Compositor
+        pl: Nagłówek – imię i nazwisko kompozytora
     d:
       label:
         it: Data di nascita e di morte
@@ -450,6 +513,7 @@ doc_edit_workflow:
         de: Geburts- und Todesdaten
         en: Years of birth and death
         es: "Años de nacimiento y muerte"
+        pl: Lata urodzenia i śmierci
     m:
       label:
         it: Organico sintetico
@@ -457,6 +521,7 @@ doc_edit_workflow:
         de: Besetzungshinweis
         en: Scoring summary
         es: "Resumen de plantilla/orgánico"
+        pl: Podsumowanie obsady
     n:
       label:
         it: Numero della parte/sezione di una composizione
@@ -464,6 +529,7 @@ doc_edit_workflow:
         de: Anzahl Teile oder Abschnitte eines Werks
         en: Number of part/section of a work
         es: "Número de parte/sección de una obra"
+        pl: Numer części / sekcji dzieła
     r:
       label: 
         it: "Tonalità"
@@ -471,6 +537,7 @@ doc_edit_workflow:
         de: Tonart
         en: Key or mode
         es: Tonalidad o modo
+        pl: Tonacja lub modus
     t:
       label:
         it: Titolo della composizione
@@ -478,6 +545,7 @@ doc_edit_workflow:
         de: Werktitel
         en: Title of work
         es: "Título de obra"
+        pl: Tytuł dzieła
 
 "500":
   label:
@@ -486,6 +554,7 @@ doc_edit_workflow:
     de: Zugehörige Personen
     en: Related personal name
     es: Nombre personal relacionado
+    pl: Powiązana osoba
   fields:
     a:
       label:
@@ -494,6 +563,7 @@ doc_edit_workflow:
         de:  Name
         en:  Related personal name
         es:  Nombre personal relacionado
+        pl: Powiązana osoba
     y:
       label:
         it:  Relazione
@@ -501,6 +571,7 @@ doc_edit_workflow:
         de:  Beziehung
         en:  Type of relationship
         es:  "Tipo de relación"
+        pl: Rodzaj relacji
 
 "510":
   label:
@@ -509,6 +580,7 @@ doc_edit_workflow:
     de: Zugehörige Sigel 
     en: Associated institution
     es: "Institución asociada"
+    pl: Powiązana instytucja
   fields:
     a:
       label:
@@ -517,6 +589,7 @@ doc_edit_workflow:
         de:  Sigel
         en:  Associated institution
         es:  "Institución asociada"
+        pl: Powiązana instytucja
 "548":
   label:
     it: Date
@@ -524,6 +597,7 @@ doc_edit_workflow:
     de: Datierungen 
     en: Chronological term
     es: "Término cronológico"
+    pl: Datowanie
   fields:
     a:
       label:
@@ -532,6 +606,7 @@ doc_edit_workflow:
         de:  Datierung
         en:  Date
         es:  Fecha
+        pl: Data
     i:
       label:
         it:  Relazione
@@ -539,6 +614,7 @@ doc_edit_workflow:
         de:  Beziehung
         en:  Type of relationship
         es:  "Tipo de relación"
+        pl: Rodzaj relacji
  
 "550":
   label:
@@ -547,6 +623,7 @@ doc_edit_workflow:
     de: Sachbegriff
     en: Topical Term
     es: "Término temático"
+    pl: Pojęcie tematyczne
   fields:
     a:
       label:
@@ -555,6 +632,7 @@ doc_edit_workflow:
         de: Sachbegriff
         en: Topical Term
         es: "Término temático"
+        pl: Pojęcie tematyczne
     i:
       label:
         it:  Relazione
@@ -562,6 +640,7 @@ doc_edit_workflow:
         de:  Bedeutung
         en:  Relation
         es:  Relación
+        pl: Relacja
 "551":
   label:
     it: Nome geografico
@@ -569,6 +648,7 @@ doc_edit_workflow:
     de: Orte
     en: Geographic name
     es: "Nombre geográfico"
+    pl: Nazwa geograficzna
   fields:
     a:
       label:
@@ -577,6 +657,7 @@ doc_edit_workflow:
         de:  Ort
         en:  Geographic name
         es:  "Nombre geográfico"
+        pl: Nazwa geograficzna
     i:
       label:
         it:  Tipo
@@ -584,6 +665,7 @@ doc_edit_workflow:
         de:  Ort Bedeutung
         en:  Type
         es:  Tipo
+        pl: Rodzaj
 
 "667":
   label:
@@ -592,6 +674,7 @@ doc_edit_workflow:
     de:  Non public note
     en:  Internal note
     es:  Nota interna
+    pl: Uwaga wewnętrzna
   fields:
     a:
       label:
@@ -600,6 +683,7 @@ doc_edit_workflow:
         de:  Non public note
         en:  Internal note
         es:  Nota interna
+        pl: Uwaga wewnętrzna
 "670":
   label:
     it: Fonte dei dati 
@@ -607,6 +691,7 @@ doc_edit_workflow:
     de: Literaturnachweis
     en: Source data found 
     es: "Fuente de los datos encontrados"
+    pl: Odnalezione źródło danych
   fields:
     a:
       label:
@@ -615,6 +700,7 @@ doc_edit_workflow:
         de: Literaturnachweis
         en: Source data found
         es: "Fuente de los datos encontrados"
+        pl: Odnalezione źródło danych
     b:
       label:
         it: Informazione rinvenuta
@@ -622,6 +708,7 @@ doc_edit_workflow:
         de: Fundstelle
         en: Information found
         es: "Información encontrada"
+        pl: Odnaleziona informacja
 "675":
   label:
     it: Fonte consultata senza esito
@@ -629,6 +716,7 @@ doc_edit_workflow:
     de: Quelle ohne Ergebnis konsultiert
     en: Source data not found
     es: "Fuente de los datos no encontrados"
+    pl: Brak źródła danych
   fields:
     a:
       label:
@@ -637,6 +725,7 @@ doc_edit_workflow:
         de: Quelle ohne Ergebnis konsultiert
         en: Source data not found
         en: "Fuente de los datos no encontrados"
+        pl: Brak źródła danych
       edit_label: 
         en: ""
         de: ""
@@ -648,6 +737,7 @@ doc_edit_workflow:
     de: Weitere bibliographische Angaben
     en: Additional bibliographical information
     es: "Información bibliográfica adicional"
+    pl: Dodatkowe informacje bibliograficzne
   fields:
     a:
       label:
@@ -656,6 +746,7 @@ doc_edit_workflow:
         de: Weitere bibliographische Angaben
         en: Additional bibliographical information
         es: "Información bibliográfica adicional"
+        pl: Dodatkowe informacje bibliograficzne
 "680":
   label:
     it: Osservazioni
@@ -663,6 +754,7 @@ doc_edit_workflow:
     de: Allgemeine Bemerkungen
     en: General note
     es: Nota general
+    pl: Uwaga ogólna
   fields:
     a:
       label:
@@ -671,6 +763,7 @@ doc_edit_workflow:
         de: Externe Bemerkungen
         en: General note
         es: Nota general
+        pl: Uwaga ogólna
 "700": 
   label: 
     it: Nomi di persone aggiuntivi
@@ -678,6 +771,7 @@ doc_edit_workflow:
     de: Nebeneintragung Personen
     en: Additional personal name
     es: Nombre personal adicional
+    pl: Dodatkowa osoba
   fields: 
     a: 
       label: 
@@ -686,6 +780,7 @@ doc_edit_workflow:
         de: Personenname
         en: Name
         es: Nombre
+        pl: Imię i nazwisko 
     d: 
       label: 
         it: Date di nascita e di morte
@@ -693,6 +788,7 @@ doc_edit_workflow:
         de: Geburts- und Todesdaten
         en: Life dates
         es: Fechas de nacimiento y muerte
+        pl: Daty urodzenia i śmierci
     j: 
       label: 
         it: Qualificazione d'attribuzione
@@ -700,12 +796,14 @@ doc_edit_workflow:
         de: Zuschreibungsvermerk
         en: Attribution qualifier
         es: "Calificador de atribución"
+        pl: Kwalifikator atrybucji
       edit_label: 
         it: Attribuzione
         fr: Attribution
         de: Zuschreibung
         en: Attribution
         es: "Atribución"
+        pl: Atrybucja
     "4": 
       label: 
         it: Funzione
@@ -713,6 +811,7 @@ doc_edit_workflow:
         de: Funktionsbezeichnung
         en: Function
         es: "Función"
+        pl: Funkcja
 "710": 
   label: 
     it: Nome di ente collettivo
@@ -720,6 +819,7 @@ doc_edit_workflow:
     de: Nebeneintragung Körperschaften
     en: Additional institution
     es: "Institución adicional"
+    pl: Dodatkowa instytucja
   fields: 
     a: 
       label: 
@@ -728,6 +828,7 @@ doc_edit_workflow:
         de: Körperschaftsname
         en: Institution
         es: "Institución"
+        pl: Instytucja
     b: 
       label: 
         it: Ente subordinato
@@ -735,6 +836,7 @@ doc_edit_workflow:
         de: Untergeordnete Körperschaft
         en: Department
         es: Departamento
+        pl: Wydział
     g: 
       label: 
         it: Qualificazione d'attribuzione
@@ -742,12 +844,14 @@ doc_edit_workflow:
         de: Zuschreibungsvermerk
         en: Attribution qualifier
         es: "Calificador de atribución"
+        pl: Kwalifikator atrybucji
       edit_label: 
         it: Attribuzione
         fr: Attribution
         de: Zuschreibung
         en: Attribution
         es: "Atribución"
+        pl: Atrybucja
 
     "4": 
       label: 
@@ -756,6 +860,7 @@ doc_edit_workflow:
         de: Funktionsbezeichnung
         en: Function
         es: Función
+        pl: Funkcja
     "8": 
       label: 
         it: Gruppo di materiale
@@ -763,6 +868,7 @@ doc_edit_workflow:
         de: Set
         en: Set
         es: Conjunto de materiales
+        pl: Zbiór
 
 "747": 
   label: 
@@ -771,6 +877,7 @@ doc_edit_workflow:
     de: Liturgische Feste
     en: Liturgical festival
     es: "Festividad litúrgica"
+    pl: Święto liturgiczne
   fields: 
     a: 
       label: 
@@ -779,6 +886,7 @@ doc_edit_workflow:
         de: Liturgische Feste
         en: Liturgical feasts
         es: "Festividad litúrgica"
+        pl: Święta liturgiczne
       edit_label: 
         en: ""
 "856":
@@ -788,6 +896,7 @@ doc_edit_workflow:
     de: Elektronische Lokalisierung und Zugriff
     en: External resource URI
     es: URI de recurso externo
+    pl: URI zasobu zewnętrznego
   fields:
     y:
       label:
@@ -796,6 +905,7 @@ doc_edit_workflow:
         de: "Für das Publikum bestimmte Fussnote"
         en: Note about external resource
         es: Nota sobre recurso externo
+        pl: Uwaga o zasobie zewnętrznym
     u:
       label:
         it: Risorsa esterna
@@ -803,6 +913,7 @@ doc_edit_workflow:
         de: Uniform Resource Identifier
         en: External resource
         es: Recurso externo
+        pl: Zasób zewnętrzny
 "930":
   label:
     it: Opera correlata
@@ -810,6 +921,7 @@ doc_edit_workflow:
     de: zugehörige Werke
     en: Related work
     es: Obra relacionada
+    pl: Powiązane dzieło
   fields:
     a:
       label:
@@ -818,6 +930,7 @@ doc_edit_workflow:
         de:  Werk
         en:  WORK
         es:  Obra
+        pl: Dzieło
     i:
       label:
         it:  Relazione
@@ -825,6 +938,7 @@ doc_edit_workflow:
         de:  Beziehung
         en:  Type of relationship
         es:  "Tipo de relación"
+        pl: Rodzaj relacji
  
 main_work:
   label:
@@ -833,6 +947,7 @@ main_work:
     de: Haupteintragungen
     en: Main entry fields
     es: Campos principales
+    pl: Główne pola edycji
 codes:
   label:
     it: Numeri e codici
@@ -840,6 +955,7 @@ codes:
     de: Nummern und Codes
     en: Numbers and code fields
     es: "Números y códigos"
+    pl: Pola liczb i kodów
 control:
   label:
     fr: "Champs de contrôle"
@@ -847,6 +963,7 @@ control:
     it: Campi di controllo
     en: Control fields
     es: Campos de control
+    pl: Pola kontrolne
 notes:
   label:
     it: Note
@@ -854,6 +971,7 @@ notes:
     de: Bemerkungen
     en: Note fields
     es: Notas
+    pl: Pola uwag
 subject:
   label:
     it: Soggetti
@@ -861,6 +979,7 @@ subject:
     de: Schlagworteintragungen
     en: Subject access fields
     es: Campos de puntos de acceso
+    pl: Pola haseł tematycznych
 incipits: 
   label: 
     it: Incipit
@@ -868,6 +987,7 @@ incipits:
     de: Incipits
     en: Incipits
     es: "Íncipits"
+    pl: Incipity
 places:
   label:
     it: Luoghi
@@ -875,6 +995,7 @@ places:
     de: Länder und Orte
     en: Countries and Places
     es: "Países y lugares"
+    pl: Kraje i miejsca
 other:
   label:
     it: Varia
@@ -882,6 +1003,7 @@ other:
     de: Verschiedenes
     en: Miscellaneous
     es: Varios
+    pl: Pozostałe
 references:
   label:
     it: Riferimenti
@@ -889,6 +1011,7 @@ references:
     de: Literatur und Bemerkungen
     en: References and notes
     es: Notas y referencias
+    pl: Odniesienia i uwagi
 relations:
   label:
     it: Relazione
@@ -896,6 +1019,7 @@ relations:
     de: Beziehungen
     en: Relations
     es: Relaciones
+    pl: Relacje
 variants:
   label:
     it: Varianti
@@ -903,6 +1027,7 @@ variants:
     de: Namensvarianten
     en: Title variants
     es: "Variantes del título"
+    pl: Warianty tytułu
 administration:
   label:
     it: Amministrazione
@@ -910,6 +1035,7 @@ administration:
     de: Administration
     en: Administration
     es: Administración
+    pl: Administracja
 male:
   label:
     it: maschio
@@ -917,6 +1043,7 @@ male:
     de: männlich
     en: male
     es: masculino
+    pl: mężczyzna
 female:
   label:
     it: femmina
@@ -924,6 +1051,7 @@ female:
     de: weiblich
     en: female
     es: femenino
+    pl: kobieta
 unknown:
   label:
     it: sconosciuto
@@ -931,6 +1059,7 @@ unknown:
     de: unbekannt
     en: unknown
     es: desconocido
+    pl: płeć nieznana
 
 #########################
 go:
@@ -940,6 +1069,7 @@ go:
     de: Geburtsort
     en: Place of Birth
     es: Lugar de nacimiento
+    pl: Miejsce urodzenia
 ha:
   label:
     it: Luogo di origine
@@ -947,6 +1077,7 @@ ha:
     de: Herkunftsangabe
     en: Place of Origin
     es: Lugar de origen
+    pl: Miejsce pochodzenia
 po:
   label:
     it: Luogo postale
@@ -954,6 +1085,7 @@ po:
     de: postalischer Ort
     en: postal Place
     es: "Dirección postal"
+    pl: Rejon pocztowy
 so:
   label:
     it: Luogo di morte
@@ -961,6 +1093,7 @@ so:
     de: Sterbeort
     en: Place of Death
     es: Lugar de fallecimiento
+    pl: Miejsce śmierci
 wl:
   label:
     it: "Paese di attività"
@@ -968,6 +1101,7 @@ wl:
     de: Wirkungsland
     en: Country of activity
     es: "País de actividad"
+    pl: Kraj aktywności artystycznej
 wo:
   label:
     it: "Luogo di attività"
@@ -975,6 +1109,7 @@ wo:
     de: Wirkungsort
     en: Place of activity
     es: "Lugar de actividad"
+    pl: Miejsce aktywności artystycznej
 wr:
   label:
     it: "Regione di attività"
@@ -982,6 +1117,7 @@ wr:
     de: Wirkungsregion
     en: Region of activity
     es: "Región de actividad"
+    pl: Region aktywności artystycznej
 #Country Codes
 "XC-DZ":
   label:
@@ -990,6 +1126,7 @@ wr:
     de: "Algeria"
     en: "Algeria"
     es: "Argelia"
+    pl: Algieria
 "XD-AR":
   label:
     it: "Argentina"
@@ -997,6 +1134,7 @@ wr:
     de: "Argentina"
     en: "Argentina"
     es: "Argentina"
+    pl: Argentyna
 "XB-AM":
   label:
     it: "Armenia"
@@ -1004,6 +1142,7 @@ wr:
     de: "Armenia"
     en: "Armenia"
     es: "Armenia"
+    pl: Armenia
 "XE-AU":
   label:
     it: "Australia"
@@ -1011,6 +1150,7 @@ wr:
     de: "Australia"
     en: "Australia"
     es: "Australia"
+    pl: Australia
 "XA-AT":
   label:
     it: "Austria"
@@ -1018,6 +1158,7 @@ wr:
     de: "Austria"
     en: "Austria"
     es: "Austria"
+    pl: Austria
 "XA-AT-2":
   label:
     it: "Austria: Carinzia"
@@ -1025,6 +1166,7 @@ wr:
     de: "Austria: Carinthia"
     en: "Austria: Carinthia"
     es: "Austria: Carintia"
+    pl: Austria: Karyntia
 "XA-AT-3":
   label:
     it: "Austria: Austria Inferiore"
@@ -1032,6 +1174,7 @@ wr:
     de: "Austria: Lower Austria"
     en: "Austria: Lower Austria"
     es: "Austria: Baja Austria"
+    pl: Austria: Dolna Austria
 "XA-AT-5":
   label:
     it: "Austria: Salisburgo"
@@ -1039,6 +1182,7 @@ wr:
     de: "Austria: Salzburg"
     en: "Austria: Salzburg"
     es: "Austria: Salzburgo"
+    pl: Austria: Salzburg
 "XA-AT-6":
   label:
     it: "Austria: Stiria"
@@ -1046,6 +1190,7 @@ wr:
     de: "Austria: Styria"
     en: "Austria: Styria"
     es: "Austria: Estiria"
+    pl: Austria: Styria
 "XA-AT-7":
   label:
     it: "Austria: Tirolo"
@@ -1053,6 +1198,7 @@ wr:
     de: "Austria: Tyrol"
     en: "Austria: Tyrol"
     es: "Austria: Tirol"
+    pl: Austria: Tyrol
 "XA-AT-4":
   label:
     it: "Austria: Austria Superiore"
@@ -1060,6 +1206,7 @@ wr:
     de: "Austria: Upper Austria"
     en: "Austria: Upper Austria"
     es: "Austria: Alta Austria"
+    pl: Austria: Górna Austria
 "XA-AT-9":
   label:
     it: "Austria: Vienna"
@@ -1067,6 +1214,7 @@ wr:
     de: "Austria: Vienna"
     en: "Austria: Vienna"
     es: "Austria: Viena"
+    pl: Austria: Wiedeń
 "XA-BE":
   label:
     it: "Belgio"
@@ -1074,6 +1222,7 @@ wr:
     de: "Belgium"
     en: "Belgium"
     es: "Bélgica"
+    pl: Belgia
 "XC-BJ":
   label:
     it: "Benin"
@@ -1081,6 +1230,7 @@ wr:
     de: "Benin"
     en: "Benin"
     es: "Benín"
+    pl: Benin
 "XD-BR":
   label:
     it: "Brasile"
@@ -1088,6 +1238,7 @@ wr:
     de: "Brazil"
     en: "Brazil"
     es: "Brasil"
+    pl: Brazylia
 "XA-BG":
   label:
     it: "Bulgaria"
@@ -1095,6 +1246,7 @@ wr:
     de: "Bulgaria"
     en: "Bulgaria"
     es: "Bulgaria"
+    pl: Bułgaria
 "XB-KH":
   label:
     it: "Cambogia"
@@ -1102,6 +1254,7 @@ wr:
     de: "Cambodia"
     en: "Cambodia"
     es: "Camboya"
+    pl: Kambodża
 "XD-CA":
   label:
     it: "Canada"
@@ -1109,6 +1262,7 @@ wr:
     de: "Canada"
     en: "Canada"
     es: "Canadá"
+    pl: Kanada
 "XD-CL":
   label:
     it: "Cile"
@@ -1116,6 +1270,7 @@ wr:
     de: "Chile"
     en: "Chile"
     es: "Chile"
+    pl: Chile
 "XB-CN":
   label:
     it: "Cina"
@@ -1123,6 +1278,7 @@ wr:
     de: "China"
     en: "China"
     es: "China"
+    pl: Chiny
 "XD-CO":
   label:
     it: "Colombia"
@@ -1130,6 +1286,7 @@ wr:
     de: "Colombia"
     en: "Colombia"
     es: "Colombia"
+    pl: Kolumbia
 "XA-HR":
   label:
     it: "Croazia"
@@ -1137,6 +1294,7 @@ wr:
     de: "Croatia"
     en: "Croatia"
     es: "Croacia"
+    pl: Chorwacja
 
 "XD-CU":
   label:
@@ -1145,6 +1303,7 @@ wr:
     de: "Cuba"
     en: "Cuba"
     es: "Cuba"
+    pl: Kuba
 "XA-CZ":
   label:
     it: "Repubblica Ceca"
@@ -1152,6 +1311,7 @@ wr:
     de: "Czech Republic"
     en: "Czech Republic"
     es: "República Checa"
+    pl: Czechy
 "XA-DK":
   label:
     it: "Danimarca"
@@ -1159,6 +1319,7 @@ wr:
     de: "Denmark"
     en: "Denmark"
     es: "Dinamarca"
+    pl: Dania
 "XC-EG":
   label:
     it: "Egitto"
@@ -1166,6 +1327,7 @@ wr:
     de: "Egypt"
     en: "Egypt"
     es: "Egipto"
+    pl: Egipt
 "XA-EE":
   label:
     it: "Estonia"
@@ -1173,6 +1335,7 @@ wr:
     de: "Estonia"
     en: "Estonia"
     es: "Estonia"
+    pl: Estonia
 "XA-FI":
   label:
     it: "Finlandia"
@@ -1180,6 +1343,7 @@ wr:
     de: "Finland"
     en: "Finland"
     es: "Finlandia"
+    pl: Finlandia
 "XA-FR":
   label:
     it: "Francia"
@@ -1187,6 +1351,7 @@ wr:
     de: "France"
     en: "France"
     es: "Francia"
+    pl: Francja
 "XA-DE":
   label:
     it: "Germania"
@@ -1194,6 +1359,7 @@ wr:
     de: "Germany"
     en: "Germany"
     es: "Alemania"
+    pl: Niemcy
 "XA-DE-BY":
   label:
     it: "Germania: Baviera"
@@ -1201,6 +1367,7 @@ wr:
     de: "Germany: Bavaria"
     en: "Germany: Bavaria"
     es: "Alemania: Bavaria"
+    pl: Niemcy: Bawaria
 "XA-DE-SN":
   label:
     it: "Germania: Sassonia"
@@ -1208,6 +1375,7 @@ wr:
     de: "Germany: Saxony"
     en: "Germany: Saxony"
     es: "Alemania: Sajonia"
+    pl: Niemcy: Saksonia
 "XA-GR":
   label:
     it: "Grecia"
@@ -1215,6 +1383,7 @@ wr:
     de: "Greece"
     en: "Greece"
     es: "Grecia"
+    pl: Grecja
 "XA-VA":
   label:
     it: "Santa Sede"
@@ -1222,6 +1391,7 @@ wr:
     de: "Holy See"
     en: "Holy See"
     es: "Santa Sede"
+    pl: Watykan
 "XD-HN":
   label:
     it: "Honduras"
@@ -1229,6 +1399,7 @@ wr:
     de: "Honduras"
     en: "Honduras"
     es: "Honduras"
+    pl: Honduras
 "XA-HU":
   label:
     it: "Ungheria"
@@ -1236,6 +1407,7 @@ wr:
     de: "Hungary"
     en: "Hungary"
     es: "Hungría"
+    pl: Węgry
 "XA-IS":
   label:
     it: "Islanda"
@@ -1243,6 +1415,7 @@ wr:
     de: "Iceland"
     en: "Iceland"
     es: "Islandia"
+    pl: Islandia
 "XB-IN":
   label:
     it: "India"
@@ -1250,6 +1423,7 @@ wr:
     de: "India"
     en: "India"
     es: "India"
+    pl: Indie
 "XB-IR":
   label:
     it: "Iran, Repubblica Islamica dell'"
@@ -1257,6 +1431,7 @@ wr:
     de: "Iran, Islamic Republic of"
     en: "Iran, Islamic Republic of"
     es: "Irán, República Islámica de"
+    pl: Iran, Republika Islamska
 "XA-IE":
   label:
     it: "Irlanda"
@@ -1264,6 +1439,7 @@ wr:
     de: "Ireland"
     en: "Ireland"
     es: "Irlanda"
+    pl: Irlandia
 "XB-IL":
   label:
     it: "Israele"
@@ -1271,6 +1447,7 @@ wr:
     de: "Israel"
     en: "Israel"
     es: "Israel"
+    pl: Izrael
 "XA-IT-32":
   label:
     it: "Italia: Trentino-Alto Adige"
@@ -1278,6 +1455,7 @@ wr:
     de: "Italy: Trentino-Alto Adige"
     en: "Italy: Trentino-Alto Adige"
     es: "Italia: Trentino-Alto Adigio"
+    pl: Włochy: Trentino-Alto Adige
 "XA-IT":
   label:
     it: "Italia"
@@ -1285,6 +1463,7 @@ wr:
     de: "Italy"
     en: "Italy"
     es: "Italia"
+    pl: Włochy
 "XB-JP":
   label:
     it: "Giappone"
@@ -1292,6 +1471,7 @@ wr:
     de: "Japan"
     en: "Japan"
     es: "Japón"
+    pl: Japonia
 "XB-KR":
   label:
     it: "Corea, Repubblica di"
@@ -1299,6 +1479,7 @@ wr:
     de: "Korea, Republic of"
     en: "Korea, Republic of"
     es: "Corea, República de"
+    pl: Korea, Republika
 "XA-LV":
   label:
     it: "Lettonia"
@@ -1306,6 +1487,7 @@ wr:
     de: "Latvia"
     en: "Latvia"
     es: "Letonia"
+    pl: Łotwa
 "XA-LT":
   label:
     it: "Lituania"
@@ -1313,6 +1495,7 @@ wr:
     de: "Lithuania"
     en: "Lithuania"
     es: "Lituania"
+    pl: Litwa
 "XA-LU":
   label:
     it: "Lussemburgo"
@@ -1320,6 +1503,7 @@ wr:
     de: "Luxembourg"
     en: "Luxembourg"
     es: "Luxemburgo"
+    pl: Luksemburg
 "XA-MT":
   label:
     it: "Malta"
@@ -1327,6 +1511,7 @@ wr:
     de: "Malta"
     en: "Malta"
     es: "Malta"
+    pl: Malta
 "XD-MX":
   label:
     it: "Messico"
@@ -1334,6 +1519,7 @@ wr:
     de: "Mexico"
     en: "Mexico"
     es: "México"
+    pl: Meksyk
 "XA-ME":
   label:
     it: "Montenegro"
@@ -1341,6 +1527,7 @@ wr:
     de: "Montenegro"
     en: "Montenegro"
     es: "Montenegro"
+    pl: Czarnogóra
 "XA-NL":
   label:
     it: "Paesi Bassi"
@@ -1348,6 +1535,7 @@ wr:
     de: "Netherlands"
     en: "Netherlands"
     es: "Países Bajos"
+    pl: Niderlandy
 "XE-NZ":
   label:
     it: "Nuova Zelanda"
@@ -1355,6 +1543,7 @@ wr:
     de: "New Zealand"
     en: "New Zealand"
     es: "Nueva Zelanda"
+    pl: Nowa Zelandia
 "XA-NO":
   label:
     it: "Norvegia"
@@ -1362,6 +1551,7 @@ wr:
     de: "Norway"
     en: "Norway"
     es: "Noruega"
+    pl: Norwegia
 "XD-PY":
   label:
     it: "Paraguay"
@@ -1369,6 +1559,7 @@ wr:
     de: "Paraguay"
     en: "Paraguay"
     es: "Paraguay"
+    pl: Paragwaj
 "XA-PL":
   label:
     it: "Polonia"
@@ -1376,6 +1567,7 @@ wr:
     de: "Poland"
     en: "Poland"
     es: "Polonia"
+    pl: Polska
 "XA-PT":
   label:
     it: "Portogallo"
@@ -1383,6 +1575,7 @@ wr:
     de: "Portugal"
     en: "Portugal"
     es: "Portugal"
+    pl: Portugalia
 "XD-PR":
   label:
     it: "Puerto Rico"
@@ -1390,6 +1583,7 @@ wr:
     de: "Puerto Rico"
     en: "Puerto Rico"
     es: "Puerto Rico"
+    pl: Portoryko
 "XA-RO":
   label:
     it: "Romania"
@@ -1397,6 +1591,7 @@ wr:
     de: "Romania"
     en: "Romania"
     es: "Rumania"
+    pl: Rumunia
 "XA-RU":
   label:
     it: "Federazione Russa"
@@ -1404,6 +1599,7 @@ wr:
     de: "Russian Federation"
     en: "Russian Federation"
     es: "Federación Rusa"
+    pl: Federacja Rosyjska
 "XA-RS":
   label:
     it: "Serbia"
@@ -1411,6 +1607,7 @@ wr:
     de: "Serbia"
     en: "Serbia"
     es: "Serbia"
+    pl: Serbia
 "XA-SK":
   label:
     it: "Slovacchia"
@@ -1418,6 +1615,7 @@ wr:
     de: "Slovakia"
     en: "Slovakia"
     es: "Eslovaquia"
+    pl: Słowacja
 "XA-SI":
   label:
     it: "Slovenia"
@@ -1425,6 +1623,7 @@ wr:
     de: "Slovenia"
     en: "Slovenia"
     es: "Eslovenia"
+    pl: Słowenia
 "XC-ZA":
   label:
     it: "Sudafrica"
@@ -1432,6 +1631,7 @@ wr:
     de: "South Africa"
     en: "South Africa"
     es: "Sudáfrica"
+    pl: Republika Południowej Afryki
 "XA-ES":
   label:
     it: "Spagna"
@@ -1439,6 +1639,7 @@ wr:
     de: "Spain"
     en: "Spain"
     es: "España"
+    pl: Hiszpania
 "XA-SE":
   label:
     it: "Svezia"
@@ -1446,6 +1647,7 @@ wr:
     de: "Sweden"
     en: "Sweden"
     es: "Suecia"
+    pl: Szwecja
 "XA-CH-VD":
   label:
     it: "Svizzera: Vaud"
@@ -1453,6 +1655,7 @@ wr:
     de: "Switzerland: Vaud"
     en: "Switzerland: Vaud"
     es: "Suiza: cantón de Vaud"
+    pl: Szwajcaria: kanton Vaud
 "XA-CH":
   label:
     it: "Svizzera"
@@ -1460,6 +1663,7 @@ wr:
     de: "Switzerland"
     en: "Switzerland"
     es: "Suiza"
+    pl: Szwajcaria
 "XB-SY":
   label:
     it: "Repubblica Araba Siriana"
@@ -1467,6 +1671,7 @@ wr:
     de: "Syrian Arab Republic"
     en: "Syrian Arab Republic"
     es: "República Árabe Siria"
+    pl: Syryjska Republika Arabska
 "XD-TT":
   label:
     it: "Trinidad e Tobago"
@@ -1474,6 +1679,7 @@ wr:
     de: "Trinidad and Tobago"
     en: "Trinidad and Tobago"
     es: "Trinidad y Tobago"
+    pl: Trynidad i Tobago
 "XB-TR":
   label:
     it: "Turchia"
@@ -1481,6 +1687,7 @@ wr:
     de: "Turkey"
     en: "Turkey"
     es: "Turquía"
+    pl: Turcja
 "XA-UA":
   label:
     it: "Ucraina"
@@ -1488,6 +1695,7 @@ wr:
     de: "Ukraine"
     en: "Ukraine"
     es: "Ucrania"
+    pl: Ukraina
 "XA-GB":
   label:
     it: "Regno Unito"
@@ -1495,6 +1703,7 @@ wr:
     de: "United Kingdom"
     en: "United Kingdom"
     es: "Reino Unido"
+    pl: Zjednoczone Królestwo
 "XD-US":
   label:
     it: "Stati Uniti d'America"
@@ -1502,6 +1711,7 @@ wr:
     de: "United States of America"
     en: "United States of America"
     es: "Estados Unidos de América"
+    pl: Stany Zjednoczone AP
 "XD-UY":
   label:
     it: "Uruguay"
@@ -1509,6 +1719,7 @@ wr:
     de: "Uruguay"
     en: "Uruguay"
     es: "Uruguay"
+    pl: Urugwaj
 "XD-VE":
   label:
     it: "Venezuela, Repubblica Bolivariana del"
@@ -1516,6 +1727,7 @@ wr:
     de: "Venezuela, Bolivarian Republic of"
     en: "Venezuela, Bolivarian Republic of"
     es: "Venezuela, República Bolivariana de"
+    pl: Wenezuela, Republika Boliwariańska
 # Relationships
 brother of:
   label:
@@ -1524,6 +1736,7 @@ brother of:
     de: Bruder von
     en: brother of
     es: hermano de
+    pl: Brat …
 child of:
   label:
     it: Figlio/figlia di
@@ -1531,6 +1744,7 @@ child of:
     de: Kind von
     en: child of
     es: "hijo/a de"
+    pl: Potomek …
 mother of:
   label:
     it: Madre di
@@ -1538,6 +1752,7 @@ mother of:
     de: Mutter von
     en: mother of
     es: madre de
+    pl: Matka …
 confused with:
   label:
     it: Confuso/confusa con
@@ -1545,6 +1760,7 @@ confused with:
     de: Verwechselt mit
     en: confused with
     es: "Confundido/a con"
+    pl: Mylon(y/a) z …
 sister of:
   label:
     it: Sorella di
@@ -1552,6 +1768,7 @@ sister of:
     de: Schwester von
     en: sister of
     es: hermana de
+    pl: Siostra …
 married with:
   label:
     it: Sposato/sposata con
@@ -1559,6 +1776,7 @@ married with:
     de: Verheiratet mit
     en: married with
     es: "casado/a con"
+    pl: W małżeństwie z …
 father of:
   label:
     it: Padre di
@@ -1566,6 +1784,7 @@ father of:
     de: Vater von
     en: father of
     es: padre de
+    pl: Ojciec …
 related to:
   label:
     it: Parente di
@@ -1573,6 +1792,7 @@ related to:
     de: Verwandt mit
     en: related to
     es: relacionado/a con
+    pl: W pokrewieństwie z …
 other:
   label:
     it: Altro
@@ -1580,6 +1800,7 @@ other:
     de: Weiteres
     en: other
     es: otro
+    pl: Pozostałe
 
 # Name variant codes
 bn:
@@ -1589,6 +1810,7 @@ bn:
     de: Beiname
     en: Byname
     es: Apodo
+    pl: Przydomek
 da:
   label:
     it: Pseudonimo
@@ -1596,6 +1818,7 @@ da:
     de: Pseudonym
     en: Pseudonym
     es: Seudónimo
+    pl: Pseudonim
 do:
   label:
     it: Nome di religione
@@ -1603,6 +1826,7 @@ do:
     de: Ordensname
     en: Order Name
     es: Nombre religioso
+    pl: Imię zakonne
 dv:
   label:
     it: Altra forma di ricerca
@@ -1610,6 +1834,7 @@ dv:
     de: andere Suchform
     en: Other Searchform
     es: Otra variante
+    pl: Inna forma wyszukiwania
 ee:
   label:
     it: Nome da sposato
@@ -1617,6 +1842,7 @@ ee:
     de: Ehename
     en: Marriage Name
     es: Apellido de casado/a
+    pl: Nazwisko po mężu
 ef:
   label:
     it: Nome di famiglia
@@ -1624,6 +1850,7 @@ ef:
     de: Familienname
     en: Family Name
     es: Apellido
+    pl: Nazwisko rodowe
 ff:
   label:
     it: Nome di persona
@@ -1631,6 +1858,7 @@ ff:
     de: Personenname
     en: Person Name
     es: Nombre personal
+    pl: Imię i nazwisko
 gg:
   label:
     it: Nome da nubile/celibe
@@ -1638,6 +1866,7 @@ gg:
     de: Geburtsname
     en: Birthname
     es: Nombre de nacimiento
+    pl: Nazwisko rodowe
 in:
   label:
     it: Iniziali
@@ -1645,6 +1874,7 @@ in:
     de: Initiale
     en: Initial
     es: Iniciales
+    pl: Inicjały
 mo:
   label:
     it: Monogramma
@@ -1652,6 +1882,7 @@ mo:
     de: Monogramm
     en: Monogram
     es: Monograma
+    pl: Monogram
 tn:
   label:
     it: Nome di battesimo
@@ -1659,6 +1890,7 @@ tn:
     de: Taufname
     en: Baptsimal Name
     es: Nombre bautismal
+    pl: Imię z chrztu
 ub:
   label:
     it: Traduzione
@@ -1666,6 +1898,7 @@ ub:
     de: Übersetzung
     en: Translation
     es: "Traducción"
+    pl: Tłumaczenie
 z:
   label:
     it: Ortografia alternativa
@@ -1673,6 +1906,7 @@ z:
     de: Andere Schreibweise
     en: Other form
     es: "Ortografía alternativa"
+    pl: Inna forma
 xx:
   label:
     it: Sconosciuto
@@ -1680,6 +1914,7 @@ xx:
     de: Unbekannt
     en: Unknown
     es: Desconocido
+    pl: Nieznane
 cmp: 
   label: 
     it: Rimando ad altro compositore
@@ -1687,6 +1922,7 @@ cmp:
     de: Komponistenquerverweis
     en: Composer cross-reference
     es: Referencia cruzada de compositor
+    pl: Odniesienie do innego kompozytora
 dte: 
   label: 
     it: Dedicatario
@@ -1694,6 +1930,7 @@ dte:
     de: "Widmungsträger"
     en: Dedicatee
     es: Dedicatario
+    pl: Adresat dedykacji
 asn: 
   label: 
     it: Nome associato
@@ -1702,6 +1939,7 @@ asn:
     en: Associated name
     es: Nombre asociado
     pt: Nome associado
+    pl: Powiązana nazwa
 lbt: 
   label: 
     it: Librettista
@@ -1709,6 +1947,7 @@ lbt:
     de: Librettist
     en: Librettist
     es: Libretista
+    pl: Autor libretta
 lyr: 
   label: 
     it: Poeta
@@ -1716,6 +1955,7 @@ lyr:
     de: Textdichter
     en: Text author
     es: Autor(a) del texto
+    pl: Autor tekstu
 oth: 
   label: 
     it: Altra funzione
@@ -1723,6 +1963,7 @@ oth:
     de: Sonstige Funktion
     en: Other function
     es: Otra función
+    pl: Inna funkcja
 #Keys
 #Keys
 A:
@@ -1733,6 +1974,7 @@ A:
     en: "A major"
     pt: "Lá  maior"
     es: "La Mayor"
+    pl: A-dur
 a:
   label:
     it: "La minore"
@@ -1741,6 +1983,7 @@ a:
     en: "A minor"
     pt: "Lá menor"
     es: "La menor"
+    pl: a-moll
 A|x: 
   label:
     it: "La♯ maggiore"
@@ -1749,6 +1992,7 @@ A|x:
     en: "A♯ major"
     pt: "Lá sustenido maior"
     es: "La sostenido Mayor"
+    pl: Ais-dur
 a|x: 
   label:
     it: "La♯ minore"
@@ -1757,6 +2001,7 @@ a|x:
     en: "A♯ minor"
     pt: "Lá sustenido menor"
     es: "La sostenido menor"
+    pl: ais-moll
 A|b: 
   label:
     it: "La♭ maggiore"
@@ -1765,6 +2010,7 @@ A|b:
     en: "A♭ major"
     pt: "Lá bemol maior"
     es: "La bemol Mayor"
+    pl: As-dur
 a|b: 
   label:
     it: "La♭ minore"
@@ -1773,6 +2019,7 @@ a|b:
     en: "A♭ minor"
     pt: "Lá bemol menor"
     es: "La bemol menor"
+    pl: as-moll
 B:
   label:
     it: "Si maggiore"
@@ -1781,6 +2028,7 @@ B:
     en: "B major"
     pt: Si maior
     es: "Si Mayor"
+    pl: H-dur
 b:
   label:
     it: "Si minore"
@@ -1789,6 +2037,7 @@ b:
     en: "B minor"
     pt: Si menor
     es: "Si menor"
+    pl: h-moll
 B|b: 
   label:
     it: "Si♭ maggiore"
@@ -1797,6 +2046,7 @@ B|b:
     en: "B♭ major"
     pt: Si bemol maior
     es: "Si bemol Mayor"
+    pl: B-dur
 b|b: 
   label:
     it: "Si♭ minore"
@@ -1805,6 +2055,7 @@ b|b:
     en: "B♭ minor"
     pt: Si bemol menor
     es: "Si bemol menor"
+    pl: b-moll
 C:
   label:
     it: "Do maggiore"
@@ -1813,6 +2064,7 @@ C:
     en: "C major"
     pt: "Dó maior"
     es: "Do Mayor"
+    pl: C-dur
 c:
   label:
     it: "Do minore"
@@ -1821,6 +2073,7 @@ c:
     en: "C minor"
     pt: "Dó menor"
     es: "Do menor"
+    pl: c-moll
 C|x: 
   label:
     it: "Do♯ maggiore"
@@ -1829,6 +2082,7 @@ C|x:
     en: "C♯ major"
     pt: "Dó sustenido maior"
     es: "Do sostenido Mayor"
+    pl: Cis-dur
 c|x: 
   label:
     it: "Do♯ minore"
@@ -1837,6 +2091,7 @@ c|x:
     en: "C♯ minor"
     pt: "Dó sustenido menor"
     es: "Do sostenido menor"
+    pl: cis-moll
 C|b: 
   label:
     it: "Do♭ maggiore"
@@ -1845,6 +2100,7 @@ C|b:
     en: "C♭ major"
     pt: "Dó bemol maior"
     es: "Do bemol Mayor"
+    pl: Ces-dur
 c|b: 
   label:
     it: "Do♭ minore"
@@ -1853,6 +2109,7 @@ c|b:
     en: "C♭ minor"
     pt: "Dó bemol menor"
     es: "Do bemol menor"
+    pl: ces-moll
 D:
   label:
     it: "Re maggiore"
@@ -1861,6 +2118,7 @@ D:
     en: "D major"
     pt: "Ré maior"
     es: "Re Mayor"
+    pl: D-dur
 d:
   label:
     it: "Re minore"
@@ -1869,6 +2127,7 @@ d:
     en: "D minor"
     pt: "Ré menor"
     es: "Re menor"
+    pl: d-moll
 D|x: 
   label:
     it: "Re♯ maggiore"
@@ -1877,6 +2136,7 @@ D|x:
     en: "D♯ major"
     pt: "Ré sustenido maior"
     es: "Re sostenido Mayor"
+    pl: Dis-dur
 d|x: 
   label:
     it: "Re♯ minore"
@@ -1885,6 +2145,7 @@ d|x:
     en: "D♯ minor"
     pt: "Ré sustenido menor"
     es: "Re sostenido menor"
+    pl: dis-moll
 D|b: 
   label:
     it: "Re♭ maggiore"
@@ -1893,6 +2154,7 @@ D|b:
     en: "D♭ major"
     pt: "Ré bemol maior"
     es: "Re bemol Mayor"
+    pl: Des-dur
 d|b: 
   label:
     it: "Re♭ minore"
@@ -1901,6 +2163,7 @@ d|b:
     en: "D♭ minor"
     pt: "Ré bemol menor"
     es: "Re bemol menor"
+    pl: des-moll
 E:
   label:
     it: "Mi maggiore"
@@ -1909,6 +2172,7 @@ E:
     en: "E major"
     pt: "Mi maior"
     es: "Mi Mayor"
+    pl: E-dur
 e:
   label:
     it: "Mi minore"
@@ -1917,6 +2181,7 @@ e:
     en: "E minor"
     pt: "Mi menor"
     es: "Mi menor"
+    pl: e-moll
 E|b: 
   label:
     it: "Mi♭ maggiore"
@@ -1925,6 +2190,7 @@ E|b:
     en: "E♭ major"
     pt: "Mi bemol maior"
     es: "Mi bemol Mayor"
+    pl: Es-dur
 e|b: 
   label:
     it: "Mi♭ minore"
@@ -1933,6 +2199,7 @@ e|b:
     en: "E♭ minor"
     pt: "Mi bemol menor"
     es: "Mi bemol menor"
+    pl: es-moll
 F:
   label:
     it: "Fa maggiore"
@@ -1941,6 +2208,7 @@ F:
     en: "F major"
     pt: "Fá maior"
     es: "Fa Mayor"
+    pl: F-dur
 f:
   label:
     it: "Fa minore"
@@ -1949,6 +2217,7 @@ f:
     en: "F minor"
     pt: "Fá menor"
     es: "Fa menor"
+    pl: f-moll
 F|x: 
   label:
     it: "Fa♯ maggiore"
@@ -1957,6 +2226,7 @@ F|x:
     en: "F♯ major"
     pt: "Fá sustenido maior"
     es: "Fa sostenido menor"
+    pl: Fis-dur
 f|x: 
   label:
     it: "Fa♯ minore"
@@ -1965,6 +2235,7 @@ f|x:
     en: "F♯ minor"
     pt: "Fá sustenido menor"
     es: "Fa sostenido Mayor"
+    pl: fis-moll
 G:
   label:
     it: "Sol maggiore"
@@ -1973,6 +2244,7 @@ G:
     en: "G major"
     pt: "Sol maior"
     es: "Sol Mayor"
+    pl: G-dur
 g:
   label:
     it: "Sol minore"
@@ -1981,6 +2253,7 @@ g:
     en: "G minor"
     pt: "Sol menor"
     es: "Sol menor"
+    pl: g-moll
 G|x: 
   label:
     it: "Sol♯ maggiore"
@@ -1989,6 +2262,7 @@ G|x:
     en: "G♯ major"
     pt: "Sol sustenido maior"
     es: "Sol sostenido menor"
+    pl: Gis-dur
 g|x: 
   label:
     it: "Sol♯ minore"
@@ -1997,6 +2271,7 @@ g|x:
     en: "G♯ minor"
     pt: "Sol sustenido menor"
     es: "Sol sostenido menor"
+    pl: gis-moll
 G|b: 
   label:
     it: "Sol♭ maggiore"
@@ -2005,6 +2280,7 @@ G|b:
     en: "G♭ major"
     pt: "Sol bemol maior"
     es: "Sol bemol Mayor"
+    pl: Ges-dur
 g|b: 
   label:
     it: "Sol♭ minore"
@@ -2013,6 +2289,7 @@ g|b:
     en: "G♭ minor"
     pt: "Sol bemol menor"
     es: "Sol bemol menor"
+    pl: ges-moll
 # modes
 # modes
 1t:
@@ -2023,6 +2300,7 @@ g|b:
     en: "Mode:  1t – Dorian"
     pt: "Modo:  1º tom (Dórico)"
     es: "Modo: 1º tono (Dórico)"
+    pl: Skala: 1t – dorycka
 2t:
   label:
     it: "Mode:  2t – Hypodorian"
@@ -2031,6 +2309,7 @@ g|b:
     en: "Mode:  2t – Hypodorian"
     pt: "Modo:  2º tom (Hipodórico)"
     es: "Modo:  2º tono (Hipodórico)"
+    pl: Skala: 2t – hypodorycka
 3t:
   label:
     it: "Mode:  3t – Phrygian"
@@ -2039,6 +2318,7 @@ g|b:
     en: "Mode:  3t – Phrygian"
     pt: "Modo:  3º tom (Frígio)"
     es: "Modo:  3º tono (Frigio)"
+    pl: Skala: 3t – frygijska
 4t:
   label:
     it: "Mode:  4t – Hypophrygian"
@@ -2047,6 +2327,7 @@ g|b:
     en: "Mode:  4t – Hypophrygian"
     pt: "Modo:  4º tom (Hipofrígio)"
     es: "Modo:  4º tono (Hipofrigio)"
+    pl: Skala: 4t – hypofrygijska
 5t:
   label:
     it: "Mode:  5t – Lydian"
@@ -2055,6 +2336,7 @@ g|b:
     en: "Mode:  5t – Lydian"
     pt: "Modo:  5º tom (Lídio)"
     es: "Modo:  5º tono (Lidio)"
+    pl: Skala: 5t – lidyjska
 6t:
   label:
     it: "Mode:  6t – Hypolydian"
@@ -2063,6 +2345,7 @@ g|b:
     en: "Mode:  6t – Hypolydian"
     pt: "Modo:  6º tom (Hipolídio)"
     es: "Modo:  6º tono (Hipolidio)"
+    pl: Skala: 6t – hypolidyjska
 7t:
   label:
     it: "Mode:  7t – Mixolydian"
@@ -2071,6 +2354,7 @@ g|b:
     en: "Mode:  7t – Mixolydian"
     pt: "Modo:  7º tom (Mixolídio)"
     es: "Modo:  7º tono (Mixolidio)"
+    pl: Skala: 7t – miksolidyjska
 8t:
   label:
     it: "Mode:  8t – Hypomixolydian"
@@ -2079,6 +2363,7 @@ g|b:
     en: "Mode:  8t – Hypomixolydian"
     pt: "Modo:  8º tom (Hipomixolídio)"
     es: "Modo:  8º tono (Hipomixolidio)"
+    pl: Skala: 8t – hypomiksolidyjska
 9t:
   label:
     it: "Mode:  9t – Aeolian"
@@ -2087,6 +2372,7 @@ g|b:
     en: "Mode:  9t – Aeolian"
     pt: "Modo:  9º tom (Eólio)"
     es: "Modo:  9º tono (Eólico)"
+    pl: Skala: 9t – eolska
 10t:
   label:
     it: "Mode: 10t – Hypoaeolian"
@@ -2095,6 +2381,7 @@ g|b:
     en: "Mode: 10t – Hypoaeolian"
     pt: "Modo: 10º tom (Hipoeólio)"
     es: "Modo: 10º tono (Hipoeólico)"
+    pl: Skala: 10t – hypoeolska
 11t:
   label:
     it: "Mode: 11t – Ionian"
@@ -2103,6 +2390,7 @@ g|b:
     en: "Mode: 11t – Ionian"
     pt: "Modo:  11º tom (Jônio)"
     es: "Modo:  11º tono (Jónico)"
+    pl: Skala: 11t – jońska
 12t:
   label:
     it: "Mode: 12t – Hypoionian"
@@ -2111,6 +2399,7 @@ g|b:
     en: "Mode: 12t – Hypoionian"
     pt: "Modo:  12º modo (Hipojônio)"
     es: "Modo:  12º tono (Hipojónico)"
+    pl: Skala: 12t – hypojońska
 1tt:
   label:
     it: "Mode:  1tt – Dorian, transposed"
@@ -2119,6 +2408,7 @@ g|b:
     en: "Mode:  1tt – Dorian, transposed"
     pt: "Modo:  1º tom (Dórico), transposta"
     es: "Modo: 1º tono (Dórico), transpuesto"
+    pl: Skala: 1tt – dorycka, transponowana
 2tt:
   label:
     it: "Mode:  2tt – Hypodorian, transposed"
@@ -2127,6 +2417,7 @@ g|b:
     en: "Mode:  2tt – Hypodorian, transposed"
     pt: "Modo:  2º tom (Hipodórico), transposta"
     es: "Modo:  2º tono (Hipodórico), transpuesto"
+    pl: Skala: 2tt – hypodorycka, transponowana
 3tt:
   label:
     it: "Mode:  3tt – Phrygian, transposed"
@@ -2135,6 +2426,7 @@ g|b:
     en: "Mode:  3tt – Phrygian, transposed"
     pt: "Modo:  3º tom (Frígio), transposta"
     es: "Modo:  3º tono (Frigio), transpuesto"
+    pl: Skala: 3tt – frygijska, transponowana
 4tt:
   label:
     it: "Mode:  4tt – Hypophrygian, transposed"
@@ -2143,6 +2435,7 @@ g|b:
     en: "Mode:  4tt – Hypophrygian, transposed"
     pt: "Modo:  4º tom (Hipofrígio), transposta"
     es: "Modo:  4º tono (Hipofrigio), transpuesto"
+    pl: Skala: 4tt – hypofrygijska, transponowana
 5tt:
   label:
     it: "Mode:  5tt – Lydian, transposed"
@@ -2151,6 +2444,7 @@ g|b:
     en: "Mode:  5tt – Lydian, transposed"
     pt: "Modo:  5º tom (Lídio), transposta"
     es: "Modo:  5º tono (Lidio), transpuesto"
+    pl: Skala: 5tt – lidyjska, transponowana
 6tt:
   label:
     it: "Mode:  6tt – Hypolydian, transposed"
@@ -2159,6 +2453,7 @@ g|b:
     en: "Mode:  6tt – Hypolydian, transposed"
     pt: "Modo:  6º tom (Hipolídio), transposta"
     es: "Modo:  6º tono (Hipolidio), transpuesto"
+    pl: Skala: 6tt – hypolidyjska, transponowana
 7tt:
   label:
     it: "Mode:  7tt – Mixolydian, transposed"
@@ -2167,6 +2462,7 @@ g|b:
     en: "Mode:  7tt – Mixolydian, transposed"
     pt: "Modo:  7º tom (Mixolídio), transposta"
     es: "Modo:  7º tono (Mixolidio), transpuesto"
+    pl: Skala: 7tt – miksolidyjska, transponowana
 8tt:
   label:
     it: "Mode:  8tt – Hypomixolydian, transposed"
@@ -2175,6 +2471,7 @@ g|b:
     en: "Mode:  8tt – Hypomixolydian, transposed"
     pt: "Modo:  8º tom (Hipomixolídio), transposta"
     es: "Modo:  8º tono (Hipomixolidio), transpuesto"
+    pl: Skala: 8tt – hypomiksolidyjska, transponowana
 9tt:
   label:
     it: "Mode:  9tt – Aeolian, transposed"
@@ -2183,6 +2480,7 @@ g|b:
     en: "Mode:  9tt – Aeolian, transposed"
     pt: "Modo:  9º tom (Eólio), transposta"
     es: "Modo:  9º tono (Eólico), transpuesto"
+    pl: Skala: 9tt – eolska, transponowana
 10tt:
   label:
     it: "Mode: 10tt – Hypoaeolian, transposed"
@@ -2191,6 +2489,7 @@ g|b:
     en: "Mode: 10tt – Hypoaeolian, transposed"
     pt: "Modo: 10º tom (Hipoeólio), transposta"
     es: "Modo: 10º tono (Hipoeólico), transpuesto"
+    pl: Skala: 10tt – hypoeolska, transponowana
 11tt:
   label:
     it: "Mode: 11tt – Ionian, transposed"
@@ -2199,6 +2498,7 @@ g|b:
     en: "Mode: 11tt – Ionian, transposed"
     pt: "Modo:  11º tom (Jônio), transposta"
     es: "Modo:  11º tono (Jónico), transpuesto"
+    pl: Skala: 11tt – jońska, transponowana
 12tt:
   label:
     it: "Mode: 12tt – Hypoionian, transposed"
@@ -2207,6 +2507,7 @@ g|b:
     en: "Mode: 12tt – Hypoionian, transposed"
     pt: "Modo:  12º modo (Hipojônio), transposta"
     es: "Modo:  12º tono (Hipojónico), transpuesto"
+    pl: Skala: 12tt – hypojońska, transponowana
 1byz:
   label:
     it: "Octoechos 1: Ēchos prōtos (First mode of Byzantine music)"
@@ -2215,6 +2516,7 @@ g|b:
     en: "Octoechos 1: Ēchos prōtos (First mode of Byzantine music)"
     pt: "Octoechos 1: Ēchos prōtos (Primeiro modo bizantino)"
     es: "Octoechos 1: Ēchos prōtos (Primer modo bizantino)"
+    pl: Octoechos 1: Ēchos prōtos (pierwsza skala muzyki bizantyjskiej)
 2byz:
   label:
     it: "Octoechos 2: Ēchos deuteros (Second mode of Byzantine music)"
@@ -2223,6 +2525,7 @@ g|b:
     en: "Octoechos 2: Ēchos deuteros (Second mode of Byzantine music)"
     pt: "Octoechos 2: Ēchos deuteros (Segundo modo bizantino)"
     es: "Octoechos 2: Ēchos deuteros (Segundo modo bizantino)"
+    pl: Octoechos 2: Ēchos deuteros (druga skala muzyki bizantyjskiej)
 3byz:
   label:
     it: "Octoechos 3: Ēchos tritos (Third mode of Byzantine music)"
@@ -2231,6 +2534,7 @@ g|b:
     en: "Octoechos 3: Ēchos tritos (Third mode of Byzantine music)"
     pt: "Octoechos 3: Ēchos tritos (Terceiro modo bizantino)"
     es: "Octoechos 3: Ēchos tritos (Tercer modo bizantino)"
+    pl: Octoechos 3: Ēchos tritos (trzecia skala muzyki bizantyjskiej)
 4byz:
   label: 
     it: "Octoechos 4: Ēchos tetartos (Fourth mode of Byzantine music)"
@@ -2239,6 +2543,7 @@ g|b:
     en: "Octoechos 4: Ēchos tetartos (Fourth mode of Byzantine music)"
     pt: "Octoechos 4: Ēchos tetartos (Quarto modo bizantino)"
     pt: "Octoechos 4: Ēchos tetartos (Cuarto modo bizantino)"
+    pl: Octoechos 4: Ēchos tetartos (czwarta skala muzyki bizantyjskiej)
 5byz:
   label: 
     it: "Octoechos 5: Ēchos plagios prōtos (First plagal mode of Byzantine music)"
@@ -2247,6 +2552,7 @@ g|b:
     en: "Octoechos 5: Ēchos plagios prōtos (First plagal mode of Byzantine music)"
     pt: "Octoechos 5: Ēchos plagios prōtos (Primeiro modo bizantino plagal)"
     es: "Octoechos 5: Ēchos plagios prōtos (Primer modo bizantino plagal)"
+    pl: Octoechos 5: Ēchos plagios prōtos (pierwsza skala plagalna muzyki bizantyjskiej)
 6byz:
   label: 
     it: "Octoechos 6: Ēchos plagios deuteros (Second plagal mode of Byzantine music)"
@@ -2255,6 +2561,7 @@ g|b:
     en: "Octoechos 6: Ēchos plagios deuteros (Second plagal mode of Byzantine music)"
     pt: "Octoechos 6: Ēchos plagios deuteros (Segundo modo bizantino plagal)"
     es: "Octoechos 6: Ēchos plagios deuteros (Segundo modo bizantino plagal)"
+    pl: Octoechos 6: Ēchos plagios deuteros (druga skala plagalna muzyki bizantyjskiej)
 7byz:
   label: 
     it: "Octoechos 7: Ēchos barys (Third plagal mode of Byzantine music)"
@@ -2263,6 +2570,7 @@ g|b:
     en: "Octoechos 7: Ēchos barys (Third plagal mode of Byzantine music)"
     pt: "Octoechos 7: Ēchos barys (Terceiro modo bizantino plagal)"
     es: "Octoechos 7: Ēchos barys (Tercer modo bizantino plagal)"
+    pl: Octoechos 7: Ēchos barys (trzecia skala plagalna muzyki bizantyjskiej)
 8byz:
   label: 
     it: "Octoechos 8: Ēchos plagios tetartos (Fourth plagal mode of Byzantine music)"
@@ -2271,6 +2579,7 @@ g|b:
     en: "Octoechos 8: Ēchos plagios tetartos (Fourth plagal mode of Byzantine music)"
     pt: "Octoechos 8: Ēchos plagios tetartos (Quarto modo bizantino plagal)"
     es: "Octoechos 8: Ēchos plagios tetartos (Cuarto modo bizantino plagal)"
+    pl: Octoechos 8: Ēchos plagios tetartos (czwarta skala plagalna muzyki bizantyjskiej)
 #Clefs (031)
 01_modern_clefs:
   label:
@@ -2279,6 +2588,7 @@ g|b:
     de: "Common clefs"
     en: "Common clefs"
     es: Claves comunes
+    pl: Klucze współczesne
 C-1:
   label:
     it: "C-1"
@@ -2286,6 +2596,7 @@ C-1:
     de: "C-1"
     en: "C-1"
     es: "C-1"
+    pl: C-1
 C-2:
   label:
     it: "C-2"
@@ -2293,6 +2604,7 @@ C-2:
     de: "C-2"
     en: "C-2"
     es: "C-2"
+    pl: C-2
 C-3:
   label:
     it: "C-3"
@@ -2300,6 +2612,7 @@ C-3:
     de: "C-3"
     en: "C-3"
     es: "C-3"
+    pl: C-3
 C-4:
   label:
     it: "C-4"
@@ -2307,6 +2620,7 @@ C-4:
     de: "C-4"
     en: "C-4"
     es: "C-4"
+    pl: C-4
 C-5:
   label:
     it: "C-5"
@@ -2314,6 +2628,7 @@ C-5:
     de: "C-5"
     en: "C-5"
     es: "C-5"
+    pl: C-5
 F-1:
   label:
     it: "F-1"
@@ -2321,6 +2636,7 @@ F-1:
     de: "F-1"
     en: "F-1"
     es: "F-1"
+    pl: F-1
 F-2:
   label:
     it: "F-2"
@@ -2328,6 +2644,7 @@ F-2:
     de: "F-2"
     en: "F-2"
     es: "F-2"
+    pl: F-2
 F-3:
   label:
     it: "F-3"
@@ -2335,6 +2652,7 @@ F-3:
     de: "F-3"
     en: "F-3"
     es: "F-3"
+    pl: F-3
 F-4:
   label:
     it: "F-4 (chiave di basso)"
@@ -2342,6 +2660,7 @@ F-4:
     de: "F-4 (Baß-Schlüssel)"
     en: "F-4 (bass clef)"
     es: "F-4 (clave de bajo)"
+    pl: F-4 (klucz basowy)
 F-5:
   label:
     it: "F-5"
@@ -2349,6 +2668,7 @@ F-5:
     de: "F-5"
     en: "F-5"
     es: "F-5"
+    pl: F-5
 G-1:
   label:
     it: "G-1"
@@ -2356,6 +2676,7 @@ G-1:
     de: "G-1"
     en: "G-1"
     es: "G-1"
+    pl: G-1
 G-2:
   label:
     it: "G-2 (chiave di violino)"
@@ -2363,6 +2684,7 @@ G-2:
     de: "G-2 (Violin-Schlüssel)"
     en: "G-2 (treble clef)"
     es: "G-2(clave aguda estándar)"
+    pl: G-2 (klucz wiolinowy)
 G-3:
   label:
     it: "G-3"
@@ -2370,6 +2692,7 @@ G-3:
     de: "G-3"
     en: "G-3"
     es: "G-3"
+    pl: G-3
 G-4:
   label:
     it: "G-4"
@@ -2377,6 +2700,7 @@ G-4:
     de: "G-4"
     en: "G-4"
     es: "G-4"
+    pl: G-4
 G-5:
   label:
     it: "G-5"
@@ -2384,6 +2708,7 @@ G-5:
     de: "G-5"
     en: "G-5"
     es: "G-5"
+    pl: G-5
 g-2:
   label:
     it: "g-2 (Chiave di violino ottavizzata)"
@@ -2391,6 +2716,7 @@ g-2:
     de: "g-2 (oktavierenden Violinschlüssels)"
     en: "g-2 (octave treble clef)"
     es: "g-2 (clave de sol octava baja)"
+    pl: g-2 (oktawowy klucz wiolinowy) 
 02_mensural_clefs:
   label:
     it: "Chiavi mensurali"
@@ -2398,6 +2724,7 @@ g-2:
     de: "Mensural clefs"
     en: "Mensural clefs"
     es: "Claves mensurales"
+    pl: Klucze menzuralne
 C+1:
   label:
     it: "C+1"
@@ -2405,6 +2732,7 @@ C+1:
     de: "C+1"
     en: "C+1"
     es: "C+1"
+    pl: C+1
 C+2:
   label:
     it: "C+2"
@@ -2412,6 +2740,7 @@ C+2:
     de: "C+2"
     en: "C+2"
     es: "C+2"
+    pl: C+2
 C+3:
   label:
     it: "C+3"
@@ -2419,6 +2748,7 @@ C+3:
     de: "C+3"
     en: "C+3"
     es: "C+3"
+    pl: C+3
 C+4:
   label:
     it: "C+4"
@@ -2426,6 +2756,7 @@ C+4:
     de: "C+4"
     en: "C+4"
     es: "C+4"
+    pl: C+4
 C+5:
   label:
     it: "C+5"
@@ -2433,6 +2764,7 @@ C+5:
     de: "C+5"
     en: "C+5"
     es: "C+5"
+    pl: C+5
 F+1:
   label:
     it: "F+1"
@@ -2440,6 +2772,7 @@ F+1:
     de: "F+1"
     en: "F+1"
     es: "F+1"
+    pl: F+1
 F+2:
   label:
     it: "F+2"
@@ -2447,6 +2780,7 @@ F+2:
     de: "F+2"
     en: "F+2"
     es: "F+2"
+    pl: F+2
 F+3:
   label:
     it: "F+3"
@@ -2454,6 +2788,7 @@ F+3:
     de: "F+3"
     en: "F+3"
     es: "F+3"
+    pl: F+3
 F+4:
   label:
     it: "F+4"
@@ -2461,6 +2796,7 @@ F+4:
     de: "F+4"
     en: "F+4"
     es: "F+4"
+    pl: F+4
 F+5:
   label:
     it: "F+5"
@@ -2468,6 +2804,7 @@ F+5:
     de: "F+5"
     en: "F+5"
     es: "F+5"
+    pl: F+5
 G+1:
   label:
     it: "G+1"
@@ -2475,6 +2812,7 @@ G+1:
     de: "G+1"
     en: "G+1"
     es: "G+1"
+    pl: G+1
 G+2:
   label:
     it: "G+2"
@@ -2482,6 +2820,7 @@ G+2:
     de: "G+2"
     en: "G+2"
     es: "G+2"
+    pl: G+2
 G+3:
   label:
     it: "G+3"
@@ -2489,6 +2828,7 @@ G+3:
     de: "G+3"
     en: "G+3"
     es: "G+3"
+    pl: G+3
 G+4:
   label:
     it: "G+4"
@@ -2496,6 +2836,7 @@ G+4:
     de: "G+4"
     en: "G+4"
     es: "G+4"
+    pl: G+4
 G+5:
   label:
     it: "G+5"
@@ -2503,6 +2844,7 @@ G+5:
     de: "G+5"
     en: "G+5"
     es: "G+5"
+    pl: G+5
 #Attribution qualifier for 710$j
 "Verified":
   label:
@@ -2511,6 +2853,7 @@ G+5:
     de: Gesichert
     en: Verified
     es: Verificada
+    pl: Zweryfikowane
 "Ascertained":
   label:
     it: Accertato
@@ -2518,6 +2861,7 @@ G+5:
     de: Ermittelt
     en: Ascertained
     es: Certificada
+    pl: Stwierdzone
 "Alleged":
   label:
     it: Presunto
@@ -2525,6 +2869,7 @@ G+5:
     de: Angeblich
     en: Alleged
     es: Supuesta
+    pl: Domniemane
 "Doubtful":   
   label:
     it: Dubbio
@@ -2532,6 +2877,7 @@ G+5:
     de: Zweifelhaft
     en: Doubtful
     es: Dudosa
+    pl: Wątpliwe
 "Misattributed":   
   label:
     it: Attribuito erroneamente
@@ -2539,6 +2885,7 @@ G+5:
     de: Fälschlich
     en: Misattributed
     es: Mal atribuida
+    pl: Błędnie przypisane
 "Conjectural":   
   label:
     it: Congetturale
@@ -2546,4 +2893,5 @@ G+5:
     de: Mutmaßlich
     en: Conjectural
     es: Conjetural
+    pl: Spekulatywne
 

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -4,684 +4,755 @@ en:
 # Pad for italian, it has 2 missing items
 #
 #
-    dashboard: "Dashboard"
+    dashboard: Strona główna
     dashboard_welcome:
-      welcome: "Welcome to Active Admin. This is the default dashboard page."
-      call_to_action: "To add dashboard sections, checkout 'app/admin/dashboard.rb'"
-    view: "View"
-    edit: "Edit"
-    delete: "Delete"
-    delete_confirmation: "Are you sure you want to delete this?"
-    new_model: "New %{model}"
-    create_model: "New %{model}"
-    edit_model: "Edit %{model}"
-    update_model: "Edit %{model}"
-    delete_model: "Delete %{model}"
-    save_model: "Save"
-    details: "%{model} Details"
-    cancel: "Cancel"
-    empty: "Empty"
-    previous: "Previous"
-    next: "Next"
-    download: "Download:"
-    has_many_new: "Add New %{model}"
-    has_many_delete: "Delete"
-    has_many_remove: "Remove"
+      welcome: Witamy w części produkcyjnej. Domyślna strona panelu użytkownika.
+      call_to_action: W celu dodania sekcji w panelu użytkownika sprawdź plik 'app/admin/dashboard.rb'
+    view: Sprawdź
+    edit: Edytuj
+    delete: Usuń
+    delete_confirmation: Czy na pewno to usunąć?
+    new_model: Nowy %{model}
+    create_model: Nowy %{model}
+    edit_model: Edytuj %{model}
+    update_model: Edytuj %{model}
+    delete_model: Usuń %{model}
+    save_model: Zapisz
+    details: %{model} Szczegóły
+    cancel: Anuluj
+    empty: Pusty
+    previous: Poprzedni
+    next: Następny
+    download: Pobierz:
+    has_many_new: Dodaj nowy %{model}
+    has_many_delete: Usuń
+    has_many_remove: Opróżnij
     filters:
       buttons:
-        filter: "Filter"
-        clear: "Clear Filters"
+        filter: Filtruj
+        clear: Wyczyść filtry
       predicates:
-        contains: "Contains"
-        equals: "Equals"
-        starts_with: "Starts with"
-        ends_with: "Ends with"
-        greater_than: "Greater than"
-        less_than: "Less than"
-        with_integer: "Filter"
-        from: "Date from"
-        to: "Date to"
+        contains: Zawiera …
+        equals: Identyczne z …
+        starts_with: Zaczyna się od …
+        ends_with: Kończy się …
+        greater_than: Jest większe niż …
+        less_than: Jest mniejsze niż …
+        with_integer: Filtruj
+        from: Data od …
+        to: Data do …
     status_tag:
-      "yes": "Yes"
-      "no": "No"
-    main_content: "Please implement %{model}#main_content to display content."
-    logout: "Logout"
-    powered_by: "Powered by %{active_admin} %{version}"
+      "yes": Tak
+      "no": Nie
+    main_content: "Wprowadź %{model}#main_content, by wyświetlić zawartość."
+    logout: Wyloguj
+    powered_by: Powered by %{active_admin} %{version}
     sidebars:
-      filters: "Filters"
-      sections: "Sections and actions"
-      actions: "Actions"
-      toc: "Table of content"
+      filters: Filtry
+      sections: Sekcje i działania
+      actions: Działania
+      toc: Spis zawartości
     pagination:
-      empty: "No %{model} found"
-      one: "Displaying <b>1</b> %{model}"
-      one_page: "Displaying <b>all %{n}</b> %{model}"
-      multiple: "Displaying %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> of <b>%{total}</b> in total"
-      multiple_without_total: "Displaying %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>"
+      empty: Nie znaleziono %{model}
+      one: Wyświetlany <b>1</b> %{model}
+      one_page: Wyświetlane <b>wszystkie %{n}</b> %{model}
+      multiple: Wyświetlane %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> z <b>%{total}</b> łącznie
+      multiple_without_total: Wyświetlane %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>
+      per_page: Liczba elementów na stronie:
       entry:
-        one: "entry"
-        other: "entries"
-    any: "Any"
+        one: Wpis
+        other: Wpisy
+    any: Dowolne
     blank_slate:
-      content: "There are no %{resource_name} yet."
-      link: "Create one"
+      content: Jeszcze nie ma %{resource_name}.
+      link: Utwórz jeden
     dropdown_actions:
-      button_label: "Actions"
+      button_label: Działania
     batch_actions:
-      button_label: "Batch actions"
-      default_confirmation: "Are you sure you want to do this?"
-      delete_confirmation: "Are you sure you want to delete these %{plural_model}?"
+      button_label: Działania wsadowe
+      default_confirmation: Czy na pewno to zrobić?
+      delete_confirmation: Czy na pewno usunąć ? %{plural_model}?
       succesfully_destroyed:
-        one: "Successfully destroyed 1 %{model}"
-        other: "Successfully destroyed %{count} %{plural_model}"
-      selection_toggle_explanation: "(Toggle Selection)"
-      link: "Create one"
-      action_label: "%{title}"
+        one: Zniszczono 1 %{model}
+        other: Zniszczono %{count} %{plural_model} 
+      selection_toggle_explanation: (Przełącz wybór)
+      link: Utwórz jeden
+      action_label: %{title}
       labels:
-        destroy: "Delete"
-        folder: "Create folder with items"
-        add_to_folder: "Add items to existing folder"
-        merge: "Merge authority records"
+        destroy: Usuń
+        folder: Utwórz folder z pozycjami
+        add_to_folder: Dodaj pozycje do istniejącego folderu
+        merge: Scal rekordy haseł wzorcowych
+        change_template: Zmień szablon
 
     comments:
-      resource_type: "Resource Type"
-      author_type: "Author Type"
-      body: "Text"
-      author: "Author"
-      title: "Comment"
-      add: "Add Comment"
-      resource: "Resource"
-      no_comments_yet: "No comments yet."
-      author_missing: "Anonymous"
-      title_content: "Comments (%{count})"
+      resource_type: Rodzaj zasobu
+      author_type: Rodzaj autora
+      body: Tekst
+      author: Autor
+      title: Komentarz
+      add: Dodaj komentarz
+      resource: Zasób
+      no_comments_yet: Jeszcze nie ma komentarzy.
+      comments_help: "Wpisz @, by wspomnieć określonego użytkownika, który zostanie następnie powiadomiony e-mailem."
+      author_missing: Anonimowy
+      title_content: Liczba komentarzy: (%{count})
       errors:
-        empty_text: "Comment wasn't saved, text was empty."
+        empty_text: Komentarz nie został zapisany z powodu braku tekstu.
     devise:
       username:
-        title: "Username"
+        title: Nazwa użytkownika
       email:
-        title: "Email"
+        title: E-mail
       subdomain:
-        title: "Subdomain"
+        title: Poddomena
       password:
-        title: "Password"
+        title: Hasło
       sign_up:
-        title: "Sign up"
-        submit: "Sign up"
+        title: Zapisz się
+        submit: Zapisz się
       login:
-        title: "Login"
-        remember_me: "Remember me"
-        submit: "Login"
+        title: Zaloguj
+        remember_me: Zapamiętaj mnie
+        submit: Zaloguj
       reset_password:
-        title: "Forgot your password?"
-        submit: "Reset My Password"
+        title: Nie pamiętasz hasła?
+        submit: Zresetuj hasło
       change_password:
-        title: "Change your password"
-        submit: "Change my password"
+        title: Zmień hasło
+        submit: Zmień hasło
       unlock:
-        title: "Resend unlock instructions"
-        submit: "Resend unlock instructions"
+        title: Wyślij ponownie instrukcje odblokowania
+        submit: Wyślij ponownie instrukcje odblokowania
       resend_confirmation_instructions:
-        title: "Resend confirmation instructions"
-        submit: "Resend confirmation instructions"
+        title: Wyślij ponownie instrukcje potwierdzenia
+        submit: Wyślij ponownie instrukcje potwierdzenia
       links:
-        sign_in: "Sign in"
-        forgot_your_password: "Forgot your password?"
-        sign_in_with_omniauth_provider: "Sign in with %{provider}"
-        resend_unlock_instructions: "Re-send unlock instructions"
+        sign_in: Zaloguj
+        forgot_your_password: Nie pamiętasz hasła?
+        sign_in_with_omniauth_provider: Zaloguj się za pomocą %{provider}
+        resend_unlock_instructions: Wyślij ponownie instrukcje odblokowania
     unsupported_browser:
-      headline: "Please note that Muscat no longer supports Internet Explorer versions 8 or less."
-      recommendation: "We recommend upgrading to the latest <a href=\"http://windows.microsoft.com/ie\">Internet Explorer</a>, <a href=\"https://chrome.google.com/\">Google Chrome</a>, or <a href=\"https://mozilla.org/firefox/\">Firefox</a>."
-      turn_off_compatibility_view: "If you are using IE 9 or later, make sure you <a href=\"http://windows.microsoft.com/en-US/windows7/webpages-look-incorrect-in-Internet-Explorer\">turn off \"Compatibility View\"</a>."
+      headline: Muscat nie współpracuje już z wersjami 8 i starszymi Internet Explorera.
+      recommendation: "Zalecamy zainstalowanie najnowszej wersji programu <a href=\http://windows.microsoft.com/ie\">Internet Explorer</a>"
+      turn_off_compatibility_view: "Jeśli używasz IE 9 lub nowszy,  pamiętaj <a href=\http://windows.microsoft.com/en-US/windows7/webpages-look-incorrect-in-Internet-Explorer\">o wyłączeniu \"Compatibility View\"</a>."
     access_denied:
-      message: "You are not authorized to perform this action."
+      message: Nie masz uprawnienia do wykonania tego działania.
     index_list:
-      table: "Table"
-      block: "List"
-      grid: "Grid"
-      blog: "Blog"
-  switch_language: "Switch language" 
-  this_file_language: "English"
+      table: Tabela
+      block: Lista
+      grid: Siatka
+      blog: Blog
+  switch_language: Zmień język
+  this_file_language: Angielski
   
   time:
     formats:
-      default: "%H:%M"
-      short: "%H:%M"
-      long: "%Y-%m-%d %H:%M"
+      default: %H:%M
+      short: %H:%M
+      long: %R-%m-%d %H:%M
       
   #################### MODELS      
   activerecord:
     models:
       digital_object:
-        one: "Image"
-        other: "Images"
+        one: Obraz
+        other: Obrazy
       catalogue:
-        one: "Secondary literature"
-        other: "Secondary literature"
+        one: Literatura pomocnicza
+        other: Literatura pomocnicza
       folder:
-        one: "Folder"
-        other: "Folders"
+        one: Folder
+        other: Foldery
       workgroup:
-        one: "Group"
-        other: "Groups"
+        one: Grupa
+        other: Grupy
       holding:
-        one: "Holding"
-        other: "Holdings"
+        one: Egzemplarz
+        other: Egzemplarze
       institution:
-        one: "Institution"
-        other: "Institutions"
+        one: Instytucja
+        other: Instytucje
       liturgical_feast:
-        one: "Liturgical festivals"
-        other: "Liturgical festivals"
+        one: Święta liturgiczne
+        other: Święta liturgiczne
       person:
-        one: "Personal name"
-        other: "Personal names"
+        one: Osoba
+        other: Osoby
       source:
-        one: "Source"
-        other: "Sources"
+        one: Źródło
+        other: Źródła
       standard_term:
-        one: "Subject heading"
-        other: "Subject headings"
+        one: Słowo kluczowe
+        other: Słowa kluczowe
       standard_title:
-        one: "Standard title"
-        other: "Standard titles"
+        one: Standardowy tytuł
+        other: Standardowe tytuły
       user:
-        one: "User"
-        other: "Users"
+        one: Użytkownik
+        other: Użytkownicy
       work:
-        one: "Work"
-        other: "Work"
+        one: Dzieło
+        other: Dzieło
   
   #################### RECORD TYPES (TEMPLATES)
-  select_template: "Select new template"
-  available_templates: "Available templates"
-  from_existing_source: "Create from existing source"
-  create_from_existing: "Create"
+  select_template: Wybierz nowy szablon
+  available_templates: Dostępne szablony
+  from_existing_source: Utwórz z istniejącego źródła
+  create_from_existing: Utwórz
   record_types:
-    unspecified: "[Unknown template]"
-    collection: "Music manuscript, collection parent record"
-    source: "Music manuscript"
-    edition_content: "Printed music edition, item in collection"
-    libretto_source: "Libretto, handwritten"
-    libretto_edition_content: "Libretto, printed"
-    theoretica_source: "Treatise, handwritten"
-    theoretica_edition_content: "Treatise, printed"
-    edition: "Printed music edition, collection parent record or individual item"
+    unspecified: [Nieznany szablon]
+    collection: "Rekopis muzyczny, rekord macierzysty kolekcji"
+    source: Rękopis muzyczny
+    edition_content: "Druk muzyczny, pozycja w kolekcji"
+    libretto_source: Libretto rękopiśmienne
+    libretto_edition: Libretto drukowane
+    libretto_edition_content: "Libretto drukowane, pozycja w kolekcji"
+    theoretica_source: Traktat rękopiśmienny
+    theoretica_edition: Traktat drukowany
+    theoretica_edition_content: "Traktat drukowany, pozycja w kolekcji"
+    edition: "Druk muzyczny, rekord macierzysty kolekcji lub indywidalna pozycja"
+
+    composite_volumes: Klocki introligatorskie
+    composite_volume: Klocek introligatorski
+    
+    music_manuscripts: Rękopisy muzyczne
+    collection_record: Rekord kolekcji dla rękopisów muzycznych
+    individual_entry: Indywidualny wpis pozycji w kolekcji rękopisów
+    single_manuscript: Pojedynczy rękopis muzyczny
+    
+    printed_music: Druki muzyczne
+    collection_record_edition: Rekord kolekcji dla druków muzycznych
+    individual_entry_edition: Indywidualny wpis pozycji w kolekcji druków muzycznych
+    single_edition: Pojedynczy druk muzyczny
+
+    libretti_handwritten: Libretta rękopiśmienne
+    collection_record_libretti: Rekord kolekcji dla librett rękopiśmiennych
+    individual_entry_libretti: Indywidualny wpis pozycji w kolekcji librett rękopiśmiennych
+    single_libretto: Pojedyncze libretto rękopiśmienne
+    
+    libretti_printed: Libretta drukowane
+    collection_record_libretti_printed: Rekord kolekcji dla librett drukowanych
+    individual_entry_libretti_printed: Indywidualny wpis pozycji w kolekcji librett drukowanych
+    single_libretto_printed: Pojedyncze libretto drukowane
+    
+    threatise_handwritten: Traktaty rękopiśmienne
+    collection_record_threatise: Rekord kolekcji dla traktatów rękopiśmiennych
+    individual_entry_threatise: Indywidualny wpis pozycji w kolekcji traktatów rękopiśmiennych
+    single_threatise: Pojedynczy traktat rękopiśmienny
+    
+    threatise_printed: Traktaty drukowane
+    collection_record_threatise_printed: Rekord kolekcji dla traktatów drukowanych
+    individual_entry_threatise_printed: Indywidualny wpis w kolekcji traktatów drukowanych
+    single_threatise_printed: Pojedynczy traktat drukowany 
         
   #################### MENUS
-  menu_home: "Home"
-  menu_sources: "Sources"
-  menu_simple_search: "Simple search"
-  menu_advanced_search: "Advanced search"
-  menu_indexes: "Authorities"
-  menu_people: "Personal names"
-  menu_institutions: "Institutions"
-  menu_titles: "Titles / text incipits"
-  menu_subjects: "Subject headings"
-  menu_library_sigla: "Library siglum"
-  menu_catalogues: "Secondary literature"
-  menu_liturgical_feasts: "Liturgical festivals"
-  menu_latin: "Latin text"
-  menu_places: "Places"
-  menu_help: "Help"
-  menu_folders: "Folders"
-  menu_users: "Users"
-  menu_workgroups: "Workgroups"
-  menu_administration: "Administration"
-  menu_comments: "Comments"
-  menu_catalog: "Faceted search"
-  menu_languages: "Language"
-  menu_contact: "Contact"
-  menu_search_history: "Search history"
-  menu_guidelines: "Cataloguing guidelines"
-  menu_marc_documentation: "MARC configuration"
-  menu_guidelines_top: "Guidelines"
-  menu_cataloging: "Cataloguing"
-  menu_jobs: "Jobs"
-  menu_holdings: "Holdings"
-  menu_works: "Works"
+  menu_home: Strona główna
+  menu_sources: Źródła
+  menu_simple_search: Wyszukiwanie proste
+  menu_advanced_search: Wyszukiwanie zaawansowane
+  menu_indexes: Hasła wzorcowe
+  menu_people: Osoby
+  menu_institutions: Instytucje
+  menu_titles: Tytuły / incipity tekstowe
+  menu_subjects: Słowa kluczowe
+  menu_library_sigla: Siglum
+  menu_catalogues: Literatura pomocnicza
+  menu_liturgical_feasts: Święta liturgiczne
+  menu_latin: Tekst łaciński
+  menu_places: Miejsca
+  menu_help: Pomoc
+  menu_folders: Foldery
+  menu_users: Użytkownicy
+  menu_workgroups: Grupy robocze
+  menu_administration: Administracja
+  menu_comments: Komentarze
+  menu_catalog: Wyszukiwanie wieloaspektowe
+  menu_languages: Język
+  menu_contact: Kontakt
+  menu_search_history: Historia wyszukiwania
+  menu_guidelines: Wskazówki do katalogowania
+  menu_marc_documentation: Konfiguracja MARC
+  menu_guidelines_top: Wskazówki
+  menu_cataloging: Katalogowanie
+  menu_jobs: Zadania
+  menu_holdings: Egzemplarz
+  menu_works: Dzieła
   
   ### VARIOUS ELEMENTS
-  recent_changes: "Lastest modifications"
-  any_field_contains: "Any field contains"
-  title_contains: "Diplomatic title contains"
-  std_title_contains: "Standardized title contains"
-  composer_contains: "Composer contains"
-  library_sigla_contains: "Siglum contains"
-  is_in_folder: "Is in folder"
-  workgroups: "Workgroups"
-  roles: "Roles"
-  user_details: "User Details"
-  sections: "Sections"
-  edit: "Edit"
-  search_sources: "Search Sources"
-  created_at: "Created on"
-  updated_at: "Last modification"
-  status: "Status"
-  progress_stage: "Stage"
-  object: "Object"
-  queue: "Queue"
-  failed_at: "Failed At"
-  run_at: "Run At"
-  progress: "Progress"
-  failed: "Failed"
-  waiting: "Waiting"
-  running: "Running"
-  finished: "Finished"
-  lib_siglum: "Library Siglum"
-  holding_records: "Exemplar Information"
-  holding_no_siglum: "Holding without silgum"
-  new_holding: "Add holdings"
-  new_holding_page: "New holdings information"
-  new_digital_object: "Attach a new image"
-  record_actions: "Record Actions"
-  record_status: "Record Status"
-  record_owner: "Record Owner"
-  record_audit: "Record Origin"
-  basic_level: "Basic record"
-  full_level: "Full record"
+  recent_changes: Ostatnie modyfikacje
+  any_field_contains: Dowolne pole zawiera …
+  title_contains: Tytuł dyplomatyczny zawiera …
+  std_title_contains: Znormalizowany tytuł zawiera …
+  composer_contains: Kryterium kompozytora zawiera …
+  library_sigla_contains: Siglum zawiera …
+  is_in_folder: Jest w folderze …
+  workgroups: Grupy robocze
+  roles: Role
+  user_details: Dane użytkownika
+  sections: Sekcje
+  edit: Edytuj
+  search_sources: Przeszukuj źródła
+  created_at: Data utworzenia
+  updated_at: Ostatnia modyfikacja
+  status: Status
+  progress_stage: Scena
+  object: Obiekt
+  queue: Kolejka
+  failed_at: Niepowodzenie o godzinie …
+  run_at: Uruchom o godzinie …
+  progress: Postęp
+  failed: Niepowodzenie
+  waiting: Oczekiwanie
+  running: W toku
+  finished: Gotowe
+  lib_siglum: Siglum
+  holding_records: Informacje o egzemplarzu
+  holding_no_siglum: Egzemplarz bez siglum
+  new_holding: Dodaj egzemplarz
+  new_holding_page: Nowe informacje o egzemplarzu
+  new_digital_object: Dołącz nowy obraz
+  record_actions: Działania na rekordzie
+  record_status: Status rekordu
+  record_owner: Właściciel rekordu
+  record_audit: Pochodzenie rekordu
+  basic_level: Rekord podstawowy
+  full_level: Rekord pełny
   #full_level: "Full record, material examined"
-  abbreviated_level: "Brief record, material examined"
-  retro_level: "Retrocataloging"
-  imported_level: "Imported record"
-  link_type: "Linked object type"
-  linked_object: "Linked Object"
-  links: "Links"
-  link_remove: "Remove Link"
-  link_remove_confirm: "Are you sure you want to delete this link?"
-  unloadable_record: "This record experienced loading errors: it can be viewed but not edited. Please contact an administrator."
-  validation_level_error: "There are errors, please solve before saving"
-  validation_level_warning: "There are warnings, save again to override"
+  abbreviated_level: "Krótki rekord, zbadany materiał"
+  retro_level: Katalogowanie retrospektywne
+  imported_level: Rekord zaimportowany
+  link_type: Typ powiązanego obiektu
+  linked_object: Powiązany obiekt
+  links: Odsyłacze
+  link_remove: Usuń odsyłacz
+  link_remove_confirm: Czy na pewno usunąć ten odsyłacz?
+  unloadable_record: "Błędy wczytania rekordu: można go odczytywać, lecz nie edytować. Skontaktuj się z administratorem."
+  validation_level_error: Wystąpiły błędy. Napraw je przed zapisaniem.
+  validation_level_warning: "Wystąpiły ostrzeżenia. Zapisz ponownie, by je skasować."
   
   jobs:
-    not_set: "[No status set]"
-    ok: "Job ended successfully"
-    no_status: "There was an Error Reading job Status"
-    error: "ERROR: "
-    running_jobs: "Running Jobs Cannot be Deleted."
-    auto_delete: "Cannot Delete: Finished job was Automatically Deleted."
-    no_view: "Cannot View: Finished job was Automatically Deleted."
+    not_set: [Nie ustawiono statusu.]
+    ok: Zadanie ukończone pomyślnie
+    no_status: Błąd odczytu statusu zadania
+    error: BŁĄD:
+    running_jobs: Nie można usuwać bieżących zadań.
+    auto_delete: Nie można usunąć. Ukończone zadanie zostało usunięte automatycznie.
+    no_view: Nie można sprawdzić. Ukończone zadanie zostało usunięte automatycznie.
 
   # Sidebar
-  delete: "Delete"
-  to_the_list: "Return to the list"
-  edit: "Edit"
-  new: "Create"
-  duplicate: "Duplicate"
-  merge: "Merge"
-  no_action: "No action available"
-  reindex: "Reindex sources"
-  resave: "Resave sources"
-  publish: "Publish"
-  unpublish: "Unpublish"
-  select: "Select"
-  create_folder: "Add all to a new folder"
-  append_folder: "Add all to an existing folder"
-  add_institution: "Link Institution"
-  add_source: "Link Source"
-  add_person: "Link Person"
-  archive_unarchive: "Archive / un-archive"
-  archive: "Archive"
-  unarchive: "Un-archive"
+  delete: Usuń
+  to_the_list: Wróć do listy
+  edit: Edytuj
+  new: Utwórz
+  duplicate: Powiel
+  merge: Scal
+  no_action: Brak dostępnego działania
+  reindex: Zreindeksuj źródła
+  resave: Zapisz ponownie źródła
+  publish: Opublikuj
+  unpublish: Cofnij publikację
+  select: Wybierz
+  create_folder: Dodaj wszystko do nowego folderu
+  append_folder: Dodaj wszystko do istniejącego folderu
+  add_institution: Powiąż instytucję
+  add_source: Powiąż źródło
+  add_person: Powiąż osobę
+  archive_unarchive: Zarchiwizuj / cofnij archiwizację
+  archive: Zarchiwizuj
+  unarchive: Cofnij archiwizację
+  export_folder: Wyeksportuj folder jako MARCXML
+  export_folder_csv: Wyeksportuj folder jako CSV
+  validate_folder: Zatwierdź pozycje
+
   
   # Editor sidebar
-  show_all_groups: "Show all sections"
-  show_preview: "Show preview"
-  hide_preview: "Hide preview"
-  show_validate: "Validate"
-  show_history: "Show modification history"
-  show_viaf: "VIAF Search"
-  save_and_continue: "Save and continue editing"
-  save_and_exit: "Save and close"
-  cancel: "Cancel"
-  duplicate_confirm: "Are you sure you want to duplicate this record?"
+  show_all_groups: Pokaż wszystkie sekcje
+  show_preview: Pokaż podgląd
+  hide_preview: Ukryj podgląd
+  show_validate: Zatwierdź
+  show_history: Pokaż historię modyfikacji
+  show_viaf: Wyszukiwanie w VIAF
+  save_and_continue: Zapisz i kontynuuj edycję
+  save_and_exit: Zapisz i zamknij
+  cancel: Anuluj
+  duplicate_confirm: Czy na pewno powielić ten rekord?
   
   # Version history
-  history_date: "Date"
-  history_author: "Author"
-  history_event: "Event"
-  history_modification: "Modification"
-  history_view: "View"
-  history_diff: "Diff"
-  history_restore: "Restore"
-  history_delete: "Delete"
-  history_restore_confirm: "Do you want to restore this version?"
-  history_delete_confirm: "Do you want to delete this version?"
+  history_date: Data
+  history_author: Autor
+  history_event: Wydarzenie
+  history_modification: Modyfikacja
+  history_view: Sprawdź
+  history_diff: Różnica
+  history_restore: Przywróć
+  history_delete: Usuń
+  history_restore_confirm: Czy przywrócić tę wersję?
+  history_delete_confirm: Czy usunąć tę wersję?
   
   #### FOLDER MESSAGES
   folders:
-    save: "Save results to Folder"
-    success: "Folder %{name} created with %{count} items."
-    too_many: "Cannot add more than %{max} items (%{count} selected)."
-    added: "Added %{count} items to Folder %{name}."
-    added_bg: "Added items to folder, job %{job} enqueued."
-    success_bg: "Folder %{name} created, job %{job} enqueued."
+    save: Zapisz wyniki w folderze
+    success: Utworzono folder %{name} zawierający %{count} pozycji.
+    too_many: Nie można dodać więcej niż %{max} pozycji (wybrano %{count}).
+    added: Do foldera %{name} dodano %{count} pozycji.
+    added_bg: "Pozycje dodane do foldera, zadanie %{job} zakolejkowane."
+    success_bg: "Folder %{name} utworzony, zadanie %{job} zakolejkowane."
+    items: Pozycje
+    export_started: Na adres %{e-mail} zostanie wysłana wiadomość z odsyłaczem do pobrania (Export job id: %{job}).
+    export_limit: Można wyeksportować maks. %{max} pozycji. Ten folder zawiera %{count} pozycji.
+    folder_empty: Folder nie zawiera pozycji.
+    not_found: Folder %{id} nie istnieje.
+    publish_job: Opublikuj rozpoczęte zadanie (id: %{id})
+    unpublish_job: Cofnij publikację rozpoczętego zadania (id: %{id})
+    reindex_job: Zreindeksuj rozpoczęte zadanie (id: %{id})
+    validation_started: Na adres %{e-mail} zostanie wysłana wiadomość z informacją o zatwierdzeniu (Validation job id: %{job}).
+    folder_not_source: Można zatwierdzać tylko foldery zawierające źródła.
 
   ### Digital objects
-  digital_objects: "Images"
-  digital_object_new: "Add a new image"
-  digital_object_add: "Add"
+  digital_objects: Obrazy
+  digital_object_new: Dodaj nowy obraz
+  digital_object_add: Dodaj
   
   ############ filters
-  filter_address: "Address"
-  filter_alternate_dates: "Alternate dates"
-  filter_alternate_names: "Alternate names"
-  filter_alternate_terms: "Alternate terms"
-  filter_alternates: "Alternate names"
-  filter_any_field: "Any field"
-  filter_author: "Author"
-  filter_author_or_editor: "Author/Editor"
-  filter_autograph_of: "Autograph of"
-  filter_birth_place: "Birth place"
-  filter_catalog: "Catalog"
-  filter_category_type: "Category"
-  filter_collection: "Collection"
-  filter_comment: "Comment"
-  filter_composer: "Composer"
-  filter_connected_libraries: "Libraries"
-  filter_country: "Country"
-  filter_creation_date: "Creation date"
-  filter_date: "Date"
-  filter_date_from: "Date from"
-  filter_date_of_publication: "Year of publication"
-  filter_date_to: "Date to"
-  filter_description: "Description"
-  filter_digital_objects: "Digital Objects"
-  filter_district: "District"
-  filter_email: "E-mail"
-  filter_folder_type: "Folder Type"
-  filter_full_name: "Name"
-  filter_gender: "Gender"
-  filter_id: "ID"
-  filter_incipits: "Incipits"
-  filter_incipits_ng: "Incipits (ngrams)"
-  filter_incipits_tf: "Incipits (themefinder)"
-  filter_incipit_key: "Incipit key"
-  filter_institution: "Institution"
-  filter_institutions: "Institutions"
-  filter_key: "Key"
-  filter_language: "Language"
-  filter_last_updated: "Last updated"
-  filter_lib_siglum: "Library sigla"
-  filter_life_dates: "Life dates"
-  filter_links: "Links"
-  filter_liturgical_feast: "Liturgical feast"
-  filter_location_and_name: "Name and location"
-  filter_manuscript_no: "Manuscript No."
-  filter_male: "Male"
-  filter_female: "Female"
-  filter_unknown: "Unknown"
-  filter_shelf_mark: "Shelfmark"
-  filter_name: "Name"
-  filter_notes: "Notes"
-  filter_old_versions: "Old versions"
-  filter_owner: "Owner"
-  filter_pages: "Pages"
-  filter_pattern: "Siglum patterns"
-  filter_people: "People"
-  filter_person_100d: "Life Dates"
-  filter_person_550a: "Profession"
-  filter_person_375a: "Gender"
-  filter_person_043c: "Nationality"
-  filter_person_551a: "Places"
-  filter_person_100d_birthdate: "Year of Birth"
-  filter_person_100d_deathdate: "Year of Death"
-  filter_phone: "Phone"
-  filter_place: "Place"
-  filter_place_of_publication: "Place of publication"
-  filter_provenance: "Provenance"
-  filter_record_type: "Template Type"
-  filter_record_type_short: "Type"
-  filter_source_type: "Source Type"
-  filter_publisher: "Publisher"
-  filter_revue_title: "Revue title"
-  filter_id: "RISM ID"
-  filter_id_no: "RISM ID"
-  filter_images: "Images"
-  filter_scoring: "Scoring"
-  filter_series_items: "Series items"
-  filter_siglum: "Siglum"
-  filter_source: "Source"
-  filter_sources: "Sources"
-  filter_source_type: "Source Type"
-  filter_std_title: "Standardized title"
-  filter_subject: "Subject"
-  filter_subsequent_entries: "Subsequent Entries"
-  filter_term: "Term"
-  filter_textincipit: "Textincipit"
-  filter_thematic_opus: "Thematic cat. / Opus no."
-  filter_title: "Title"
-  filter_titles: "Titles"
-  filter_title_on_ms: "Title on source"
-  filter_title_short: "Short title"
-  filter_topic: "Topic"
-  filter_sub_topic: "Subtopic"
-  filter_url: "Internet address"
-  filter_variants: "Variants"
-  filter_versions: "Versions"
-  filter_volume: "Volume"
-  filter_image: "Image"
-  filter_file_name: "File name"
-  filter_file_size: "File size"
-  filter_content_type: "Type"
-  filter_wf: "WF"
-  filter_wf_audit: "Audit"
-  filter_wf_stage: "Status"
-  filter_distribution: "Scoring"
-  filter_dist_exclude: "Exclude"
-  filter_dist_594a: "Vocal parts (solo)"
-  filter_dist_594b: "Other vocal parts (solo)"
-  filter_dist_594c: "Vocal parts (coro)"
-  filter_dist_594d: "Other vocal parts (coro)"
-  filter_dist_594e: "Solo instrument"
-  filter_dist_594f: "Strings"
-  filter_dist_594g: "Woodwinds"
-  filter_dist_594h: "Brass instruments"
-  filter_dist_594i: "Plucked instruments"
-  filter_dist_594k: "Percussion instruments"
-  filter_dist_594l: "Keyboard instruments"
-  filter_dist_594m: "Other instruments"
-  filter_dist_594n: "Basso continuo instruments"
-  filter_source_name: "Source Name"
-  filter_source_composer: "Source Composer"
-  filter_printed_exemplars: "Number of printed copies"
+  filter_address: Adres
+  filter_alternate_dates: Inne daty
+  filter_alternate_names: Inne nazwy
+  filter_alternate_terms: Inne pojęcia
+  filter_alternates: Inne nazwy
+  filter_any_field: Dowolne pole
+  filter_author: Autor
+  filter_author_or_editor: Autor / Edytor
+  filter_autograph_of: Autograf autorstwa
+  filter_birth_place: Miejsce urodzenia
+  filter_catalog: Katalog
+  filter_category_type: Kategoria
+  filter_collection: Kolekcja
+  filter_comment: Komentarz
+  filter_composer: Kompozytor
+  filter_connected_libraries: Biblioteki
+  filter_country: Kraj
+  filter_creation_date: Data utworzenia
+  filter_date: Data
+  filter_date_from: Data od …
+  filter_date_of_publication: Rok publikacji
+  filter_date_to: Data do …
+  filter_description: Opis
+  filter_digital_objects: Obiekty cyfrowe
+  filter_district: Rejon
+  filter_email: E-mail
+  filter_folder_type: Rodzaj folderu
+  filter_full_name: Nazwa
+  filter_gender: Płeć społeczno-kulturowa
+  filter_id: ID
+  filter_incipits: Incipity
+  filter_incipits_ng: Incipity (ngrams)
+  filter_incipits_tf: Incipity (themefinder)
+  filter_incipit_key: Tonacja incipitu
+  filter_institution: Instytucja
+  filter_institutions: Instytucje
+  filter_key: Tonacja
+  filter_language: Język
+  filter_last_updated: Ostatnia aktualizacja
+  filter_lib_siglum: Siglum
+  filter_life_dates: Daty urodzenia i śmierci
+  filter_links: Odsyłacze
+  filter_liturgical_feast: Święto liturgiczne
+  filter_location_and_name: Nazwa i lokalizacja
+  filter_manuscript_no: Nr rękopisu
+  filter_male: Mężczyzna
+  filter_female: Kobieta
+  filter_unknown: Płeć nieznana
+  filter_shelf_mark: Sygnatura
+  filter_name: Nazwa
+  filter_notes: Uwagi
+  filter_old_versions: Stare wersje
+  filter_owner: Właściciel
+  filter_pages: Strony
+  filter_pattern: Wzory siglum
+  filter_people: Osoby
+  filter_person_100d: Daty urodzenia i śmierci
+  filter_person_550a: Zawód
+  filter_person_375a: Płeć społeczno-kulturowa
+  filter_person_043c: Narodowość
+  filter_person_551a: Miejsca
+  filter_person_100d_birthdate: Rok urodzenia
+  filter_person_100d_deathdate: Rok śmierci
+  filter_phone: Nr telefonu
+  filter_place: Miejsce
+  filter_place_of_publication: Miejsce publikacji
+  filter_plate_no: Numer wydawniczy
+  filter_provenance: Pochodzenie
+  filter_record_type: Rodzaj szablonu
+  filter_record_type_short: Rodzaj
+  filter_source_type: Rodzaj źródła
+  filter_publisher: Wydawca
+  filter_revue_title: Tytuł periodyku
+  filter_id: ID
+  filter_id_no: RISM ID
+  filter_images: Obrazy
+  filter_scoring: Obsada
+  filter_series_items: Pozycje seryjne
+  filter_siglum: Siglum
+  filter_source: Źródło
+  filter_sources: Źródła
+  filter_source_type: Rodzaj źródła
+  filter_std_title: Znormalizowany tytuł
+  filter_subject: Przedmiot
+  filter_subsequent_entries: Kolejne wpisy
+  filter_term: Określenie
+  filter_textincipit: Incipit tekstowy
+  filter_thematic_opus: Kategoria tematyczna / Nr opus
+  filter_title: Tytuł
+  filter_titles: Tytuły
+  filter_title_on_ms: Tytuł w źródle
+  filter_title_short: Skrócony tytuł
+  filter_topic: Temat
+  filter_sub_topic: Podtemat
+  filter_url: Adres internetowy
+  filter_variants: Warianty
+  filter_versions: Wersje
+  filter_volume: Wolumen
+  filter_image: Obraz
+  filter_file_name: Nazwa pliku
+  filter_file_size: Rozmiar pliku
+  filter_content_type: Rodzaj
+  filter_wf: WF
+  filter_wf_audit: Kontrola
+  filter_wf_stage: Status
+  filter_distribution: Obsada
+  filter_dist_exclude: Wyłącz
+  filter_dist_594a: Partie wokalne (solowe)
+  filter_dist_594b: Pozostałe partie wokalne (solowe)
+  filter_dist_594c: Partie wokalne (chóralne)
+  filter_dist_594d: Pozostałe partie wokalne (chóralne)
+  filter_dist_594e: Instrument solowy
+  filter_dist_594f: Instrumenty strunowe
+  filter_dist_594g: Instrumenty dęte drewniane
+  filter_dist_594h: Instrumenty dęte blaszane
+  filter_dist_594i: Instrumenty szarpane
+  filter_dist_594k: Instrumenty perkusyjne
+  filter_dist_594l: Instrumenty klawiszowe
+  filter_dist_594m: Pozostałe instrumenty
+  filter_dist_594n: Instrumenty realizujące basso continuo
+  filter_source_name: Nazwa źródła
+  filter_source_composer: Kompozytor źródła
+  filter_printed_exemplars: Liczba drukowanych egzemplarzy
  
   ## Referring lists for auth files
-  refers_to_this: "%{model_from} referring to this %{model_to}"
+  refers_to_this: %{model_from} odnosi się do %{model_to}
  
-  rism_any_key: "Any key"
-  rism_a_flat: "A flat major/minor"
-  rism_a: "A major/minor"
-  rism_b_flat: "B flat major/minor"
-  rism_b: "B major/minor"
-  rism_c: "C major/minor"
-  rism_c_sharp: "C sharp major/minor"
-  rism_d_flat: "D flat major/minor"
-  rism_d: "D major/minor"
-  rism_e_flat: "E flat major/minor"
-  rism_e: "E major/minor"
-  rism_f: "F major/minor"
-  rism_f_sharp: "F sharp major/minor"
-  rism_g: "G major/minor"
-  rism_g_sharp: "G sharp major/minor"
+  rism_any_key: Dowolny klucz
+  rism_a_flat: As-dur / as-moll
+  rism_a: A-dur / a-moll
+  rism_b_flat: B-dur / b-moll
+  rism_b: H-dur / h-moll
+  rism_c: C-dur / c-moll
+  rism_c_sharp: Cis-dur / cis-moll
+  rism_d_flat: Des-dur / des-moll
+  rism_d: D-dur / d-moll
+  rism_e_flat: Es-dur / es-moll
+  rism_e: E-dur / e-moll
+  rism_f: F-dur / f-moll
+  rism_f_sharp: Fis-dur / fis-moll
+  rism_g: G-dur / g-moll
+  rism_g_sharp: Gis-dur / gis-moll
   
   # Assorted error messages
-  error_not_found: "The resource you are trying to access does not exist or has been deleted."
-  error_saving: "The resource is not complete or generates a duplicate"
-  unknown_tags: "There are some unknown fields in this record"
-  ungrouped_tags: "There are ungrouped fields in this record"
-  cannot_update_source: "You are not authorized to edit this type of source"
-  cannot_create_source: "You are not authorized to create this type of source"
-  validate_name_uniqness: "Record not saved: Same short title '%{term}' already exists."
-  validates_parent_id: "Record not saved: Parent record (773) cannot be same as this record"
+  error_not_found: Poszukiwany zasób nie istnieje lub został usunięty.
+  error_saving: Zasób jest niekompletny lub generuje duplikat.
+  unknown_tags: Rekord zawiera pola nieznane.
+  ungrouped_tags: Rekord zawiera pola niezgrupowane.
+  cannot_update_source: Nie masz uprawnienia do edycji tego rodzaju źródła.
+  cannot_create_source: Nie masz uprawnienia do utworzenia tego rodzaju źródła.
+  validate_name_uniqness: Rekord nie zapisany. Ten skrócony tytuł (‘%{term}’) już istnieje.
+  validates_parent_id: "Rekord nie zapisany. Rekord macierzysty (773) nie może być taki sam, jak ten."
   
   #
   entry:
-    one: "entry"
-    other: "entries"
+    one: Wpis
+    other: Wpisy
   digital_object:
-    one: "digital object"
-    other: "digital objects"
+    one: Obiekt cyfrowy
+    other: Obiekty cyfrowe
   catalogue:
-    one: "catalogue"
-    other: "catalogues"
+    one: Katalog
+    other: Katalogi
   institution: 
-    one: "institution"
-    other: "institutions"
+    one: Instytucja
+    other: Instytucje
   library: 
-    one: "library"
-    other: "libraries"
+    one: Biblioteka
+    other: Biblioteki
   liturgicalfeast: 
-    one: "litrugical feast"
-    other: "liturgical feasts"
+    one: Święto liturgiczne
+    other: Święta liturgiczne
   source:
-    one: "source"
-    other: "sources"
+    one: Źródło
+    other: Źródła
   place:
-    one: "place"
-    other: "places"
+    one: Miejsce
+    other: Miejsca
   person: 
-    one: "person"
-    other: "poeple"
+    one: Osoba
+    other: Osoby
   standardterm:
-    one: "subject"
-    other: "subjects" 
+    one: Przedmiot
+    other: Przedmioty
   standardtitle:
-    one: "title or text incipit"
-    other: "titles or text incipits" 
+    one: Tytuł lub incipit tekstowy
+    other: Tytuły lub incipity tekstowe
 
   user:
-    one: "user"
-    other: "users" 
+    one: Użytkownik
+    other: Użytkownicy
   job:
-    one: "job"
-    other: "jobs"
+    one: Zadanie
+    other: Zadania
   folder:
-    one: "folder"
-    other: "folders"
+    one: Folder
+    other: Foldery
 
   will_paginate:
     page_entries_info:
       single_page_html:
-        zero: "No %{model} found" 
-        one: "Displaying <b>1</b> %{model}"
-        other: "Displaying <b>all %{count}</b> %{model}"
-      multi_page_html: "Displaying %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> of <b>%{count}</b> in total"
+        zero: Nie znaleziono %{model}
+        one: Wyświetlany <b>1</b> %{model}
+        other: Wyświetlane <b>wszystkie %{count}</b> %{model}
+      multi_page_html: Wyświetlane %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> z <b>%{total}</b> łącznie
   
     models:
       person: 
-        one: "Person"
-        other: "People"
+        one: Osoba
+        other: Osoby
 
   manuscript_links:
-     one: "1 source"
-     other: "%{count} sources" 
+     one: 1 źródło
+     other: Liczba źródeł: %{count}
      
   # themefinder
-  themefinder_c: "pitch refined contour"
-  themefinder_C: "pitch gross contour"
-  themefinder_d: "diatonic scale degree"
-  themefinder_i: "twelve-tone interval"
-  themefinder_I: "diatonic interval"
-  themefinder_p: "diatonic pitch class"
-  themefinder_P: "twelve-tone pitch class"
-  themefinder_p0: "no pitch search"
+  themefinder_c: Dokładny zapis linii melodycznej
+  themefinder_C: Zapis linii melodycznej zachowujący tylko interwały
+  themefinder_d: Stopień na skali diatonicznej
+  themefinder_i: Interwał dwunastotonowy
+  themefinder_I: Interwał diatoniczny
+  themefinder_p: Wysokość diatoniczna
+  themefinder_P: Wysokość chromatyczna
+  themefinder_p0: Bez wyszukiwania dźwięków
 
-  themefinder_u: "exact duration"
-  themefinder_r: "duration refined contour"
-  themefinder_R: "duration gross contour"
-  themefinder_d0: "no duration search"
+  themefinder_u: Dokładny czas trwania
+  themefinder_r: Dokładny zapis czasu trwania
+  themefinder_R: Zapis zachowujący tylko czas trwania
+  themefinder_d0: Bez wyszukiwania czasu trwania
   
-  themefinder_L: "metric level"
-  themefinder_l: "metric position"
-  themefinder_e: "metric refined contour"
-  themefinder_E: "metric gross contour"
-  themefinder_b: "beat level"
-  themefinder_m0: "no metric search"
+  themefinder_L: Poziom wartości rytmicznych
+  themefinder_l: Pozycja wartości rytmicznych
+  themefinder_e: Dokładny zapis wartości rytmicznych
+  themefinder_E: Zapis zachowujący tylko wartości rytmiczne
+  themefinder_b: Poziom rytmu
+  themefinder_m0: Bez wyszukiwania po metrum
   
-  tf_pitch_search: "Pitch"
-  tf_duration_search: "Duration"
-  tf_metric_search: "Metric"
-  tf_meter: "Meter"
-  tf_anchor: "Search only at the begining of the incipit"
+  tf_pitch_search: Wysokość dźwięku
+  tf_duration_search: Czas trwania
+  tf_metric_search: Wartość rytmiczna
+  tf_meter: Określenie tempa
+  tf_anchor: Wyszukaj tylko po początku incipitu
   
-  tf_pitch_help: "Tips for pitch search"
-  tf_duration_help: "Tips for duration search"
-  tf_metric_help: "Tips for metric help"
-  tf_anchor_help: "Anchored searching tips"
-  tf_timesig_help: "Time signature help"
-  btn_themefinder_reset: "Reset"
+  tf_pitch_help: Wskazówki do wyszukiwania po wysokościach dźwięku
+  tf_duration_help: Wskazówki do wyszukiwania po wartościach rytmicznych
+  tf_metric_help: Wskazówki do wyszukiwania po metrum
+  tf_anchor_help: Wskazówki do wyszukiwania początku lub końca terminu
+  tf_timesig_help: Wskazówki do wyszukiwania po metrum
+  btn_themefinder_reset: Wyzeruj
   
-  tf_acknowledgments: "Incipits search is performed with <a href=\"http://www.themefinder.org/\" target=\"_blank\">Themefinder</a> developed by the <a href=\"http://www.ccarh.org/\" target=\"_blank\">CCARH</a>."
+  tf_acknowledgments: "Incipity są wyszukiwane na stronie <a href=\http://www.themefinder.org/\" target=\"_blank\">Themefinder</a> opracowanej przez <a href=\"http://www.ccarh.org/\" target=\"_blank\">CCARH</a>."
 
-  hls_link_lang: "e"
-  hls_link_name: "HDS"
+  hls_link_lang: e
+  hls_link_name: HDS
   
-  do_link_lang: "eng"
-  do_media_files_title: "Multimedia files"
-  do_ext_res_link: "External resources:"
-  do_ext_link_not_avail: "(Audio files not available from this location)"
-  do_images_title: "Images"
-  connected_libraries: "Libraries"
-  view_source: "View Source"
+  do_link_lang: eng
+  do_media_files_title: Pliki multimedialne
+  do_ext_res_link: Zasoby zewnętrzne:
+  do_ext_link_not_avail: (Pliki audio niedostępne z tej lokalizacji)
+  do_images_title: Obrazy
+  connected_libraries: Biblioteki
+  view_source: Sprawdź źródło
 
   mei:
-    title: "MEI export for source %{source}"
-    parameters: "Parameters"
-    format: "Incipit output format:"
-    format_mei: "MEI"
-    format_pae: "PAE (no conversion)"
-    stylesheet: "Stylesheet"
-    default_stylesheet: "Default stylesheet"
-    custom_stylesheet: "Custom stylesheet:"
-    preview: "Preview"
-    download: "Download"
-    more: "More"
-    banner: 'Please click "Preview" to show the MEI-converted output.'
+    title: Eksport MEI dla źródła %{źródło}
+    parameters: Parametry
+    format: Format wyjściowy incipitu:
+    format_mei: MEI
+    format_pae: PAE (bez konwersji)
+    stylesheet: Styl szablonu
+    default_stylesheet: Domyślny styl szablonu
+    custom_stylesheet: Niestandardowy styl szbalonu
+    preview: Podgląd
+    download: Pobierz
+    more: Więcej
+    banner: "Kliknij przycisk „Podgląd”, by wyświetlić wynik konwersji na MEI.'"
 
   wf_stage:
-    inprogress: "Unpublished (UNP)"
-    published: "Published (PUB)"
-    deleted: "Deleted"
+    inprogress: Nieopublikowane (UNP)
+    published: Opublikowane (PUB)
+    deleted: Usunięte
+    deprecated: Nieaktualne
   
   dashboard:
-    selection: "Select recent activity"
-    type: "Change type"
-    type_created: "Recently created"
-    type_updated: "Recently updated"
-    owner: "Owner"
-    owner_user: "Myself"
-    owner_any: "Any"
-    quantity: "Display"
-    update: "Update"
-    no_items: "No elements to show with the current filters"
+    selection: Wybierz ostatnie działania
+    type: Zmień rodzaj
+    type_created: Ostatnio utworzone
+    type_updated: Ostatnio zaktualizowane
+    owner: Właściciel
+    owner_user: Ja
+    owner_any: Dowolny
+    quantity: Wyświetl
+    update: Zaktualizuj
+    no_items: Brak elementów do wyświetlenia przy aktualnych filtrach
+    message_silenced: Komunikat z wiadomościami został schowany.
+    got_it: Ok
+    got_it_explanation: Kliknięcie tego przycisku ukryje wiadomosci do momentu pojawianie się nowych.
+    news: Muscat News
   
   # editor validation 
   validation:
-    missing_message: "A value in this field is mandatory"
-    warning_message: "A value for this field should be provided"
-    insufficient_rights: "User has insufficient rights to create a record of this library"
-    name_uniqueness: "Short name of entry is already taken"
-    correct: "The record has no validation errors [200]"
+    missing_message: To pole jest obowiązkowe
+    warning_message: To pole powinno zawierać wartość
+    insufficient_rights: Użytkownik ma niewystarczające uprawnienia do utworzenia / zaktualizowania rekordu tej biblioteki
+    name_uniqueness: Skrócona nazwa wpisu została już pobrana
+    correct: Brak błędów zatwierdzenia rekordu [200]
+    begins_with_message: "Musi rozpoczynać się od \{0}\"
+    required_if_message: "Pole obowiązkowe, ponieważ pole {0} ${1} nie jest puste"
     
   incipit_search:
-    incipit_search: "Incipit Search"
-    query_type: "Query Type:"
-    exact_pitch: "Exact Pitch (Exact Match)"
-    interval: "Interval"
-    refined_pitch: "Refined Pitch Contour"
-    gross_pitch: "Gross Pitch Contour (Fuzziest match)"
-    anchor: "Search only beginning"
-    erase: "Erase one note"
+    incipit_search: Wyszukaj incipit
+    query_type: Rodzaj zapytania:
+    exact_pitch: Dokładna nazwa dźwięku
+    interval: Interwał
+    refined_pitch: Wyszukiwanie po linii melodycznej z wyłączeniem stosunków interwałowych
+    gross_pitch: Przybliżony zapis linii melodycznej
+    anchor: Wyszukaj tylko początek
+    erase: Wymaż jedną nutę
 
   # This is used for the "incipit" seach in the search history in BL
   # Note the capital 'I'
-  Incipit: "Incipit"
+  Incipit: Incipit
+  Images: Obrazy
+  "Standardized title": "Znormalizowany tytuł"
+  Composer: Kompozytor
+  "Source Type": "Rodzaj źródła"
+  Scoring: Obsada
+  Date: Data
+  "Library siglum": "Siglum"
+  Subject: Przedmiot
+  "Number of printed copies": "Liczba drukowanych egzemplarzy"
+  publisher: Wydawca
+
 
   cookies:
-    message: "Our website uses cookies to make your browsing experience better. By using our site you agree to our use of cookies."
-    dimiss: "Accept and Close"
-    link: 'Learn more'
+    message: "Strona wykorzystuje ciasteczka dla poprawy funkcjonalności. Korzystając z niej, zgadzasz się na to."
+    dimiss: Zaakceptuj i zamknij
+    link: Dowiedz się więcej'
 
   # date:
   # Empty lines for matching line numbers with other translation files  
@@ -716,26 +787,39 @@ en:
 # Blacklights overriden translations - the list can vary from one language to another
 
   blacklight:
-    application_name: 'Muscat'
+    application_name: Muscat'
     header_links:
-      logout: 'Logout'
+      logout: Wyloguj'
+    search:
+      start_over: Zacznij od nowa
+      facets:
+        title: Sprecyzuj wyszukiwanie
+    range_limit:
+      submit_limit: Sprecyzuj
+  blacklight_advanced_search:
+    form:
+      start_over: Zacznij od nowa
       
  
 ######################################################################################################
 # Record types, English only
       
   record_types_codes:
-    "0": "UNK"
-    "1": "COL"
-    "2": "MSR"
-    "3": "SUB"
-    "4": "LSR"
-    "5": "LEC"
-    "6": "TSR"
-    "7": "TEC"
-    "8": "EDT"
+    "0": UNK
+    "1": COL
+    "2": MSR
+    "3": SUB
+    "4": LSR
+    "5": LED
+    "6": TSR
+    "7": TED
+    "8": EDT
+    "9": LEC
+    "10": TEC
+    "11": CMP
     
   status_codes:
-    published: "PUB"
-    inprogress: "UNP"
+    published: PUB
+    inprogress: UNP
+    deprecated: DEP
 


### PR DESCRIPTION
This is a replacement pull request to [pull#979](https://github.com/rism-ch/muscat/pull/979).

Polish translation added in files listed below: 

- `config/editor_profiles/default/configurations/CatalogueLabels.yml`
- `config/editor_profiles/default/configurations/HoldingBasicLabels.yml`
- `config/editor_profiles/default/configurations/InstitutionLabels.yml`
- `config/editor_profiles/default/configurations/PersonLabels.yml`
- `config/editor_profiles/default/configurations/SourceLabels.yml`
- `config/editor_profiles/default/configurations/WorkLabels.yml`
- `config/locales/pl.yml`

This pull request can be merged automatically with `muscat/polish-version` branch.
