### PR TITLE
Deprecate empty RISM::EDITOR_PROFILE

### DIFF
--- a/lib/editor_configuration.rb
+++ b/lib/editor_configuration.rb
@@ -38,23 +38,11 @@ class EditorConfiguration
     configs = list #YAML::load(yaml_list)
 
     settings = Settings.new(Hash.new())
-    
-    if RISM::EDITOR_PROFILE != ""
-      configs.each do |config|
-        file = "#{Rails.root}/config/editor_profiles/#{RISM::EDITOR_PROFILE}/configurations/#{config}.yml"
-        unless File.exists?(file)
-	  file = "#{Rails.root}/config/editor_profiles/default/configurations/#{config}.yml"
-	end
-        if File.exists?(file)
-          settings.squeeze(Settings.new(IO.read(file)))
-        end
-      end
-    else
-      configs.each do |config|
-        default_conf = "#{Rails.root}/config/editor_profiles/default/configurations/#{config}.yml"
-        if File.exists?(default_conf)
-          settings.squeeze(Settings.new(IO.read(default_conf)))
-        end
+
+    configs.each do |config|
+      file = ConfigFilePath.get_marc_editor_profile_path("#{Rails.root}/config/editor_profiles/#{RISM::EDITOR_PROFILE}/configurations/#{config}.yml")
+      if File.exists?(file)
+        settings.squeeze(Settings.new(IO.read(file)))
       end
     end
     

--- a/lib/editor_validation.rb
+++ b/lib/editor_validation.rb
@@ -11,9 +11,8 @@ class EditorValidation
   def squeeze(config)
     settings = Settings.new(Hash.new())
     
-    profile_name = RISM::EDITOR_PROFILE != "" ? RISM::EDITOR_PROFILE : "default"
-    file = "#{Rails.root}/config/editor_profiles/#{profile_name}/configurations/#{config}.yml"
-    settings.squeeze(Settings.new(IO.read(ConfigFilePath.get_marc_editor_profile_path(file))))
+    file = ConfigFilePath.get_marc_editor_profile_path("#{Rails.root}/config/editor_profiles/#{RISM::EDITOR_PROFILE}/configurations/#{config}.yml")
+    settings.squeeze(Settings.new(IO.read(file)))
 
     return settings
   end
@@ -113,16 +112,8 @@ class EditorValidation
       # load global configurations
       @squeezed_profiles = Array.new
     
-      profile_name = RISM::EDITOR_PROFILE != "" ? RISM::EDITOR_PROFILE : "default"
-    
       # Load local configurations
-      file = "#{Rails.root}/config/editor_profiles/#{profile_name}/profiles.yml"
-
-      # Fallback to default if no specific profile exist
-      unless File.exists?(file)
-        profile_name = "default"
-        file = "#{Rails.root}/config/editor_profiles/#{profile_name}/profiles.yml"
-      end
+      file = ConfigFilePath.get_marc_editor_profile_path("#{Rails.root}/config/editor_profiles/#{RISM::EDITOR_PROFILE}/profiles.yml")
 
       configurations = YAML::load(IO.read(file))
       configurations.each do |conf|


### PR DESCRIPTION
As RISM::EDITOR_PROFILE may no longer have an empty value, clean up the last
couple of obsolete traces where this condition was still taken into account.