### PR TITLE
Allow different templates for secondary literature

### DIFF
--- a/app/views/admin/catalogues/select_new_template.html.erb
+++ b/app/views/admin/catalogues/select_new_template.html.erb
@@ -1,0 +1,42 @@
+<%- templates = EditorConfiguration.get_catalogue_templates %>
+
+<div class="panel">
+  <h3><%="#{I18n.t(:available_templates)}" %></h3>
+  <div class="panel_contents">
+    <div class="attributes_table">
+      <% templates.each do |toplevel, template_list| %>
+      <p><h5 style="margin-bottom: 0;"><%= I18n.t('record_types.' + toplevel) %></h5>
+        <ul class="template_ul">
+          <% template_list.each do |label, properties| %>
+
+          <li><%= link_to("#{I18n.t('record_types.' + label)}", new_resource_path(new_record_type: properties["record_type"])) %></li>
+
+          <% if properties.has_key? "sub_type" %>
+          <ul class="template_ul">
+            <% properties["sub_type"].each do |sub_label, sub_properties| %>
+              <li><%= link_to("#{I18n.t('record_types.' + sub_label)}", new_resource_path(new_record_type: sub_properties["record_type"])) %></li>
+            <%end %>
+          </ul>
+          <%end%>
+          <% end %>
+        </ul>
+      </p>
+      <% end %>
+    </div>
+  </div>
+</div>
+
+<%= form_tag(new_resource_path, {method: "get", :class => 'filter_form'}) do %>
+<div class="panel">
+  <h3><%="#{I18n.t(:from_existing_catalogue)}"%></h3>
+  <div class="panel_contents">
+    <div class="form-group">
+      <input name="existing_title" size="20" type="text"/>
+    </div>
+  </div>
+
+  <div class="buttons">
+    <%= submit_tag("#{I18n.t(:create_from_existing)}") %>
+  </div>
+</div>
+<%end%>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -199,6 +199,7 @@ en:
   select_template: "Select new template"
   available_templates: "Available templates"
   from_existing_source: "Create from existing source"
+  from_existing_catalogue: "Create from existing secondary literature"
   create_from_existing: "Create"
   record_types:
     unspecified: "[Unknown template]"
@@ -245,6 +246,9 @@ en:
     collection_record_threatise_printed: "Collection record for printed treatises"
     individual_entry_threatise_printed: "Individual entry in a printed treatise collection"
     single_threatise_printed: "Single printed treatise"
+
+    legacy_templates: "Legacy templates"
+    legacy_catalogue: "Secondary literature unified template"
         
   #################### MENUS
   menu_home: "Home page"

--- a/config/marc/default/catalogue/template_configuration.yml
+++ b/config/marc/default/catalogue/template_configuration.yml
@@ -1,0 +1,7 @@
+display:
+  legacy_templates:
+    legacy_catalogue:
+       record_type: default_catalogue
+
+default_mapping:
+  legacy_catalogue: "default"

--- a/lib/editor_configuration.rb
+++ b/lib/editor_configuration.rb
@@ -462,4 +462,16 @@ class EditorConfiguration
     conf["default_mapping"][record_type.to_s]
   end
   
+  def self.get_catalogue_templates
+    conf = YAML::load(IO.read(ConfigFilePath.get_marc_editor_profile_path("#{Rails.root}/config/marc/#{RISM::MARC}/catalogue/template_configuration.yml")))
+    return {} if !conf.has_key? "display"
+    conf["display"]
+  end
+
+  def self.get_catalogue_default_file(record_type)
+    conf = YAML::load(IO.read(ConfigFilePath.get_marc_editor_profile_path("#{Rails.root}/config/marc/#{RISM::MARC}/catalogue/template_configuration.yml")))
+    return nil if !conf.has_key? "default_mapping"
+    conf["default_mapping"][record_type.to_s]
+  end
+
 end


### PR DESCRIPTION
This patch is the first step towards having different templates for
secondary literature.  It synchronises some code and configuration files
from sources so now, when creating a new record, appears a menu with a
single choice, the legacy template.

There are yet no new fields (like record type) or tag changes.