### PR TITLE
Fix default blacklight Solr settings

### DIFF
--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -18,4 +18,4 @@ test: &test
   url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:#{ENV['TEST_JETTY_PORT'] || 8983}/solr/default" %>
 production:
   adapter: solr
-  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/default" %>
+  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/production" %>


### PR DESCRIPTION
The Blacklight settings point to 'default' being the default core for Blacklight in production, but sunspot configures the default core to be 'production'. 

This PR aligns the two by changing the default setting for Blacklight to 'production'.