### PR TITLE
New: Move to standard Rails translation mechanism

### DIFF
--- a/bin/muscat_execute_job
+++ b/bin/muscat_execute_job
@@ -15,7 +15,7 @@ fi
 JOB_NAME=$1
 
 if [ -z "$2" ]; then
-    RAILS_ENV=production
+    export RAILS_ENV=production
 else
     if [ $2 == "production" ] || [ $2 == "development" ] || [ $2 == "test" ]; then
         export RAILS_ENV=$2
@@ -32,7 +32,7 @@ start=$SECONDS
 
 echo "Running $JOB_NAME in $RAILS_ENV mode at $DATE" >> $LOGFILE 2>&1
 
-echo "$JOB_NAME.new.perform" | bundle exec rails c >> $MUSCAT_ROOT/log/"$JOB_NAME.log" 2>&1
+echo "$JOB_NAME.new.perform" | bundle exec rails c >> $MUSCAT_ROOT/log/"$JOB_NAME.log"
 
 end=$SECONDS
 duration=$(( end - start ))

--- a/bin/muscat_execute_job
+++ b/bin/muscat_execute_job
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+MUSCAT_ROOT=/var/muscat
+LOGFILE=$MUSCAT_ROOT/log/muscat_execute_job.log
+
+
+if [ $# -eq 0 ]; then
+    echo "muscat_execute_job <job> <env>"
+fi
+
+if [ -z "$1" ]; then
+    echo "No job supplied"
+fi
+
+JOB_NAME=$1
+
+if [ -z "$2" ]; then
+    RAILS_ENV=production
+else
+    if [ $2 == "production" ] || [ $2 == "development" ] || [ $2 == "test" ]; then
+        export RAILS_ENV=$2
+    else
+        echo "Invalid RAILS_ENV $2"
+        exit 1
+    fi
+fi
+
+cd $MUSCAT_ROOT
+
+DATE=`date`
+start=$SECONDS
+
+echo "Running $JOB_NAME in $RAILS_ENV mode at $DATE" >> $LOGFILE 2>&1
+
+echo "$JOB_NAME.new.perform" | bundle exec rails c >> $MUSCAT_ROOT/log/"$JOB_NAME.log" 2>&1
+
+end=$SECONDS
+duration=$(( end - start ))
+DATE=`date`
+echo "Finished $JOB_NAME mode at $DATE, duration $duration seconds" >> $LOGFILE 2>&1

--- a/config/editor_profiles/default/configurations/CatalogueLabels.yml
+++ b/config/editor_profiles/default/configurations/CatalogueLabels.yml
@@ -1,2127 +1,534 @@
---- !map:ActiveSupport::HashWithIndifferentAccess
-
-doc_abbreviations: 
-  label: 
-    it: Abbreviazioni
-    de: "Abkürzungen"
-    en: Abbreviations
-    es: Abreviaturas
-    pl: Skróty
-doc_aid: 
-  label: 
-    it: Aiuto
-    de: Arbeitshilfen
-    en: Aide
-    es: Asistencia
-    pl: Asystent
-doc_cataloguing_collections: 
-  label: 
-    it: Catalogazione di raccolte e volumi compositi
-    de: Erfassung von Sammlungen
-    en: Cataloging collection and convoluta
-    es: "Catalogación de colecciones y volúmenes compuestos"
-    pl: Katalogowanie kolekcji i klocka introligatorskiego
-doc_edit_functions: 
-  label: 
-    it: funzioni di base
-    de: "Grundätzliche Funktionen"
-    en: Basic functions
-    es: "Funciones básicas"
-    pl: Podstawowe funkcje
-doc_introduction: 
-  label: 
-    it: introduzione
-    de: Einleitung
-    en: Introduction
-    es: "Introducción"
-    pl: Wprowadzenie
-doc_masks: 
-  label: 
-    it: Formulari di catalogazione
-    de: Masken
-    en: Cataloging forms
-    es: "Formularios de catalogación"
-    pl: Formularze katalogowania
-doc_tag_index: 
-  label: 
-    it: Indice dei codici MARC
-    de: MARC Tag Index
-    en: MARC tag index
-    es: "Índice de etiquetas MARC"
-    pl: Indeks znaczników MARC
-doc_templates: 
-  label: 
-    it: Template
-    de: Templates
-    en: Templates
-    es: Plantillas
-    pl: Szablony
-"000": 
-  label: 
-    it: Leader
-    fr: Guide
-    de: Leader
-    en: Leader
-    es: "Líder"
-    pl: Leader
-"001": 
-  label: 
-    it: Numero documento RISM
-    fr: No. RISM
-    de: RISM Dokumentnummer
-    en: RISM ID No.
-    es: "Número de ID de RISM"
-    pl: RISM ID
-"003": 
-  label: 
-    it: Identificatore del numero di controllo
-    fr: "Identité du numéro de contrôle"
-    de: Kontrollnummer-Bezeichnung
-    en: Control number identifier
-    es: "Identificador de número de control"
-    pl: Identyfikator numeru kontrolnego
-"005": 
-  label: 
-    it: Data e ora dell'ultima transazione
-    fr: "Date/heure de la dernière transaction"
-    de: Datum und Zeit der letzten Transaktion
-    en: Date and time of last transaction
-    es: "Fecha y hora de la última transacción" 
-    pl: Data i godzina ostatniej operacji
-"020": 
-  label: 
-    it: ISBN
-    fr: ISBN
-    de: ISBN
-    en: ISBN
-    es: ISBN
-    pl: ISBN
-  fields: 
-    a: 
-      label: 
-        it: ISBN
-        fr: ISBN
-        de: ISBN
-        en: ISBN
-        es: ISBN
-        pl: ISBN
-
-"022": 
-  label: 
-    it: ISSN
-    fr: ISSN
-    de: ISSN
-    en: ISSN
-    es: ISSN
-    pl: ISSN
-  fields: 
-    a: 
-      label: 
-        it: ISSN
-        fr: ISSN
-        de: ISSN
-        en: ISSN
-        es: ISSN
-        pl: ISSN
-
-"024": 
-  label: 
-    it: ISMN
-    fr: ISMN
-    de: ISMN
-    en: ISMN
-    es: ISMN
-    pl: ISMN
-  fields: 
-    a: 
-      label: 
-        it: ISMN
-        fr: ISMN
-        de: ISMN
-        en: ISMN
-        es: ISMN
-        pl: ISMN
-
-"041": 
-  label: 
-    it: Codice lingua
-    fr: Code de langue
-    de: Sprache
-    en: Language Code
-    es: "Código de idioma"
-    pl: Kod języka
-  fields: 
-    a: 
-      label: 
-        it: Codice lingua
-        fr: Code de langue
-        de: Sprach-Code
-        en: Language Code
-        es: "Código de idioma"
-        pl: Kod języka
-"044": 
-  label: 
-    it: Paese
-    fr: Pays
-    de: Land
-    en: Country of publication
-    es: "País de publicación"
-    pl: Kraj publikacji
-  fields: 
-    a: 
-      label: 
-        it: Paese
-        fr: Pays
-        de: Land
-        en: Country of publication
-        es: "País de publicación"
-        pl: Kraj publikacji
-
-"100": 
-  label: 
-    it: Autore
-    fr: Auteur
-    de: Autor
-    en: Author
-    es: Autor
-    pl: Autor
-  accepts: 
-  - "710"
-  fields: 
-    a: 
-      label: 
-        it: Autore
-        fr: Auteur
-        de: Autor
-        en: Author
-        es: Autor
-        pl: Autor
-    d: 
-      label: 
-        it: Data di nascita e di morte
-        fr: Dates de vie
-        de: Geburts- und Todesdaten
-        en: Life dates
-        es: Fechas de nacimiento y muerte
-        pl: Daty urodzenia i śmierci
-"210": 
-  label: 
-    it: Abbreviazione
-    fr: Abbreviation
-    de: Kürzel
-    en: Short title
-    es: "Título breve"
-    pl: Skrócony tytuł
-  fields: 
-    a: 
-      label: 
-        it: Abbreviazione
-        fr: Abbreviation
-        de: Kürzel
-        en: Short title
-        es: "Título breve"
-        pl: Skrócony tytuł
-"240": 
-  label: 
-    it: Titolo 
-    fr: Title
-    de: Titel
-    en: Title
-    es: "Título"
-    pl: Tytuł
-  fields: 
-    a: 
-      label: 
-        it: Titolo
-        fr: Title
-        de: Titel
-        en: Title
-        es: "Título"
-        pl: Tytuł
-    g: 
-      label: 
-        it: Tipo
-        fr: Type
-        de: Art/Inhalt
-        en: Category
-        es: "Categoría"
-        pl: Kategoria
-    h: 
-      label: 
-        it: Tipo di pubblicazione
-        fr: Type de publication
-        de: Ausgabeform
-        en: Type of publication
-        es: "Tipo de publicación"
-        pl: Rodzaj publikacji
-"250": 
-  label: 
-    it: Edizione
-    fr: Édition
-    de: Ausgabe
-    en: Edition statement
-    es: "Declaración de edición"
-    pl: Wydanie
-  fields: 
-    a: 
-      label: 
-        it: Edizione
-        fr: Édition
-        de: Ausgabe
-        en: Edition statement
-        es: "Declaración de edición"
-        pl: Wydanie
-      comment: "NEW IN 2018"
-"260": 
-  label: 
-    it: Dati editoriali 
-    fr: Imprint
-    de: Imprint
-    en: Imprint
-    es: Datos editoriales
-    pl: Stopka wydawnicza
-  fields: 
-    a: 
-      label: 
-        it: Luogo
-        fr: Endroit
-        de: Verlagsort
-        en: Place of publication
-        es: Lugar de publicación
-        pl: Miejsce publikacji
-    b: 
-      label: 
-        it: Editore
-        fr: "éditeur"
-        de: Verlag
-        en: Publisher
-        es: Editor
-        pl: Wydawca
-    c: 
-      label: 
-        it: Anno
-        fr: Année
-        de: Jahr
-        en: Year
-        es: Año
-        pl: Rok
-"264": 
-  label: 
-    it: Produzione
-    fr: Production
-    de: Verlauf
-    en: Production
-    es: "Producción"
-    pl: Produkcja
-  fields: 
-    c: 
-      label: 
-        it: Produzione
-        fr: Production
-        de: Verlauf
-        en: Production
-        es: Producción
-        pl: Produkcja
-"700": 
-  label: 
-    it: Nome addizionale di persona
-    fr: "Nom supplémentaire de la personne"
-    de: Sonstige Person
-    en: Additional personal name
-    es: Nombre personal adicional
-    pl: Dodatkowa osoba
-  fields: 
-    a: 
-      label: 
-        it: Persona
-        fr: Personne
-        de: Person
-        en: Person
-        pl: Osoba
-    "4": 
-      label: 
-        it: Funzione
-        fr: Function
-        de: Funktionsbezeichnung
-        en: Function
-        pt: "Função"
-        es: Persona
-        pl: Funkcja
-"710": 
-  label: 
-    it: Nome di ente
-    fr: "Nom de la collectivité"
-    de: Nebeneintragung Körperschaften
-    en: Additional institution
-    es: "Institución adicional"
-    pl: Dodatkowa instytucja
-  fields: 
-    a: 
-      label: 
-        it: Nome di ente
-        fr: "Nom de la collectivité"
-        de: Körperschaftsname
-        en: Institution
-        es: "Institución"
-        pl: Instytucja
-    b: 
-      label: 
-        it: Ente subordinato
-        fr: "Collectivité subordonnée"
-        de: Untergeordnete Körperschaft
-        en: Department
-        es: Departamento
-        pl: Wydział
-    g: 
-      label: 
-        it: Qualificazione d'attribuzione
-        fr: Qualificatif d'attribution
-        de: Zuschreibungsvermerk
-        en: Attribution qualifier
-        es: "Calificador de atribución"
-        pl: Kwalifikator atrybucji
-      edit_label: 
-        it: Attribuzione
-        fr: Attribution
-        de: Zuschreibung
-        en: Attribution
-        es: Atribución
-        pl: Atrybucja
-
-    "4": 
-      label: 
-        it: Funzione
-        fr: Fonction
-        de: Funktionsbezeichnung
-        en: Function
-        es: Función
-        pl: Funkcja
-    "8": 
-      label: 
-        it: Gruppo di materiale
-        fr: Documents
-        de: Set
-        en: Set
-        es: "Grupo de materiales"
-        pl: Zbiór
-"730": 
-  label:
-    it: Titolo uniforme alternativo
-    fr: Titres uniformes additionnels
-    de: Zusätzlicher Titel
-    en: Additional title
-    es: Título adicional
-    pl: Dodatkowy tytuł
+'000':
+  label: records.leader
+'001':
+  label: records.rism_id_number
+'003':
+  label: records.control_number_identifier
+'005':
+  label: records.date_time_last_transaction
+01_codes_artistic:
+  label: records.artistic_production
+'020':
   fields:
-    a: 
-      label: 
-        it: Titolo uniforme alternativo
-        fr: Titres uniformes additionnels
-        de: Zusätzlicher Titel
-        en: Additional title
-        es: Título adicional
-        pl: Dodatkowy tytuł
-"760": 
-  label: 
-    it: Fa parte di
-    fr: Titre de la revue
-    de: In
-    en: Item part of
-    es: "Ítem integrante de"
-    pl: Jest częścią…
-  fields: 
-    g: 
-      label: 
-        it: Volume, anno, pagina
-        fr: Partie
-        de: Jahrgang, Seite
-        en: Volume, year, page
-        es: "Volumen, año, página"
-        pl: Wolumen, rok, strona
-    t: 
-      label: 
-        it: Titolo del periodico o della miscellanea
-        fr: Titre de la revue
-        de: "In: "
-        en: "Title of periodical, book, or series"
-        es: "Título del periódico, libro o serie"
-        pl: Tytuł czasopisma, książki lub serii
-"780": 
-  label: 
-    it: Titolo precedente
-    fr: Entrée précédente
-    de: Früherer Eintrag
-    en: Preceding entry
-    es: Entrada anterior
-    pl: Poprzedzający wpis
-  fields: 
-    t: 
-      label: 
-        it: Titolo precedente
-        fr: Entrée précédente
-        de: Früherer Eintrag
-        en: Preceding entry
-        es: Entrada anterior
-        pl: Poprzedzający wpis
-"785": 
-  label: 
-    it: Titolo successivo
-    fr: Entrée suivante
-    de: Folgeeintrag
-    en: Succeeding entry
-    es: Entrada siguiente
-    pl: Kolejny wpis
-  fields: 
-    t: 
-      label: 
-        it: Titolo successivo
-        fr: Entrée suivante
-        de: Folgeeintrag
-        en: Succeeding entry
-        es: Entrada siguiente
-        pl: Kolejny wpis
-main: 
-  label: 
-    it: Campi principali
-    fr: "Entrées principales"
-    de: Haupteintragungen
-    en: Main entry fields
-    es: Campos principales
-    pl: Główne pola edycji
-codes: 
-  label: 
-    it: Numeri e codici
-    fr: "Numéros et codes"
-    de: Nummern und Codes
-    en: Numbers and code fields
-    es: "Números y códigos"
-    pl: Pola liczb i kodów
-control: 
-  label: 
-    fr: "Champs de contrôle"
-    de: Kontrollfelder
-    it: Campi di controllo
-    en: Control Fields
-    es: Campos de control
-    pl: Pola kontrolne
-notes: 
-  label: 
-    it: Note
-    fr: Notes
-    de: Fussnoten
-    en: Note fields
-    es: Notas
-    pl: Pola uwag
-other: 
-  label: 
-    it: Varia
-    fr: Divers
-    de: Verschiedenes
-    en: Miscellaneous
-    es: Varios
-    pl: Pozostałe
-administration: 
-  label: 
-    it: Amministrazione
-    fr: Administration
-    de: Administration
-    en: Administration
-    es: Administración
-    pl: Administracja
-ed: 
-  label: 
-    it: Edizione
-    fr: "édition"
-    de: Edition
-    en: Edition
-    es: Edición
-    pl: Edycja
-H: 
-  label: 
-    it: Curatore
-    fr: Editeur
-    de: Herausgeber
-    en: Editor
-    es: Editor
-    pl: Edytor
-added_series: 
-  label: 
-    it: Note secondarie sul titolo sovraordinato
-    fr: "Entrées de collection"
-    de: Nebeneintragungen Gesamttitel
-    en: Series added entry fields
-    es: "Entradas adicionales de la serie"
-    pl: Dodatkowe wpisy tytułów
-administration: 
-  label: 
-    it: Amministrazione
-    fr: Administration
-    de: Administration
-    en: Administration
-    es: Administración
-    pl: Administracja
-arr: 
-  label: 
-    it: Arrangiatore
-    fr: Arrangeur
-    de: Bearbeiter
-    en: Arranger
-    es: Arreglador
-    pl: Aranżer
-art: 
-  label: 
-    it: Scenografo
-    fr: "Metteur en scène"
-    de: "Bühnenbildner"
-    en: Artist
-    es: Artista
-    pl: Artysta
-asn: 
-  label: 
-    it: Altro nome
-    fr: Autre nom
-    de: Behandelte Person
-    en: Associated name
-    es: Nombre asociado
-    pl: Powiązana osoba
-aut: 
-  label: 
-    it: "Autore addizionale"
-    fr: "Auteur supplémentaire"
-    de: "Zusätzlicher Autor"
-    en: "Additional author"
-    es: "Autor adicional"
-    pl: Dodatkowy autor
-bibliographical_reference: 
-  label: 
-    it: Bibliografia
-    fr: "Références"
-    de: Literatur
-    en: References
-    es: Referencias
-    pl: Odniesienia
-bnd: 
-  label: 
-    it: Rilegatore
-    fr: Relieur
-    de: Buchbinder
-    en: Binder
-    es: Encuadernador
-    pl: Introligator
-bsl: 
-  label: 
-    it: Libraio musicale
-    fr: Libraire
-    de: "Musikalienhändler"
-    en: Bookseller
-    es: Librero
-    pl: Księgarz
-ccp: 
-  label: 
-    it: Autore della fonte letteraria
-    fr: Auteur du texte
-    de: Autor der Textvorlage
-    en: Conceptor
-    es: Autor de la idea
-    pl: Autor koncepcji
-chr: 
-  label: 
-    it: Coreografo
-    fr: "Chorégraphe"
-    de: Choreograph
-    en: Choreographer
-    es: Coreógrafo
-    pl: Choreograf
-clb: 
-  label: 
-    it: Autore secondario
-    fr: Collabarateur
-    de: Mitverfasser
-    en: Collaborator
-    es: Colaborador
-    pl: Współtwórca
-cmp: 
-  label: 
-    it: Compositore / Compositore secondario
-    fr: Compositeur / Co-compositeur
-    de: Komponist / Mitkomponist
-    en: Composer
-    es: Compositor / Co-compositor
-    pl: Kompozytor
-cnd: 
-  label: 
-    it: Direttore d'orchestra
-    fr: Chef d'orchestre
-    de: Dirigent
-    en: Conductor
-    es: Director musical
-    pl: Dyrygent
-cns: 
-  label: 
-    it: Censore
-    fr: Censeur
-    de: Zensor
-    en: Censor
-    es: Censor
-    pl: Cenzor
-codes: 
-  label: 
-    it: Numeri e codici
-    fr: "Numéros et codes"
-    de: Nummern und Codes
-    en: Numbers and code fields
-    es: "Números y códigos"
-    pl: Pola liczb i kodów
-com: 
-  label: 
-    it: Compilatore
-    fr: Compilateur
-    de: Kompilator
-    en: Compiler
-    es: Compilador
-    pl: Kompilator
-content: 
-  label: 
-    it: Descrizione del contenuto
-    fr: Description du contenu
-    de: Inhaltsangaben
-    en: Content description
-    es: "Descripción del contenido"
-    pl: Opis źródła
-control: 
-  label: 
-    fr: "Champs de contrôle"
-    de: Kontrollfelder
-    it: Campi di controllo
-    en: Control Fields
-    es: Campos de control
-    pl: Pola kontrolne
-cst: 
-  label: 
-    it: Costumista
-    fr: Costumier
-    de: "Kostümbildner"
-    en: Costume designer
-    es: Vestuarista
-    pl: Projektant kostiumów
-date: 
-  label: 
-    it: Date
-    fr: Dates
-    de: Daten
-    en: Dates
-    es: Fechas
-    pl: Daty
-description: 
-  label: 
-    it: Campi per la descrizione fisica
-    fr: "Description matérielle"
-    de: "Felder für die physische Beschreibung"
-    en: Physical description, etc. fields
-    es: "Campos para la descripción Material"
-    pl: Opis fizyczny itp. pola
-diplomatic_title: 
-  label: 
-    it: Titolo diplomatico
-    fr: Titre diplomatique
-    de: Diplomatischer Titel
-    en: Diplomatic title
-    es: "Título diplomático"
-    pl: Tytuł dyplomatyczny
-dnc: 
-  label: 
-    it: Ballerino
-    fr: Danceur
-    de: "Tänzer"
-    en: Dancer
-    es: "Bailarín(a)"
-    pl: Tancerz
-dnr: 
-  label: 
-    it: Donatore
-    fr: Donateur
-    de: Donator
-    en: Donor
-    es: Donante
-    pl: Donator
-dte: 
-  label: 
-    it: Dedicatario
-    fr: "Dédicataire"
-    de: "Widmungsträger"
-    en: Dedicatee
-    es: Dedicatario
-    pl: Adresat dedykacji
-dub: 
-  label: 
-    it: Dubbio
-    fr: Douteux
-    de: Zweifelhaft
-    en: Dubious
-    es: Dudoso
-    pl: Wątpliwe
-edition: 
-  label: 
-    it: Campi per i dati editoriali
-    fr: Edition, adresse bibliographique, etc.
-    de: Ausgabe- und Impressumsfelder
-    en: Edition, imprint, etc. fields
-    es: "Campos para los datos editoriales"
-    pl: Edycja, stopka wydawnicza itp. pola
-edt: 
-  label: 
-    it: Curatore
-    fr: Editeur
-    de: Herausgeber
-    en: Editor
-    es: "Editor (curador)/Editorial"
-    pl: Edytor
-egr: 
-  label: 
-    it: Incisore
-    fr: Graveur
-    de: Stecher
-    en: Engraver
-    es: Grabador
-    pl: Rytownik
-fmo: 
-  label: 
-    it: Proprietario precedente
-    fr: "Propriétaire précédent"
-    de: Vorbesitzer
-    en: Former owner
-    es: Propietario anterior
-    pl: Poprzedni właściciel
-holding: 
-  label: 
-    it: Informazioni sul fondo
-    fr: "Données bibliographiques, fonds, etc."
-    de: Bestandsdaten
-    en: Holdings, location, etc. fields
-    es: "Campos de los ejemplares y su ubicación"
-    pl: Pola egzemplarza, lokalizacji itp.
-ill: 
-  label: 
-    it: Disegnatore
-    fr: Illustrateur
-    de: Illustrator
-    en: Illustrator
-    es: Ilustrador
-    pl: Ilustrator
-incipit: 
-  label: 
-    it: Incipit
-    fr: Incipits
-    de: Incipits
-    en: Incipits
-    es: Íncipits
-    pl: Incipity
-itr: 
-  label: 
-    it: Strumentista
-    fr: Instrumentiste
-    de: Instrumentalist
-    en: Instrumentalist
-    es: Instrumentista
-    pl: Instrumentalista
-lbt: 
-  label: 
-    it: Librettista
-    fr: Librettiste
-    de: Librettist
-    en: Librettist
-    es: Libretista
-    pl: Autor libretta
-library: 
-  label: 
-    it: Biblioteca
-    fr: "Bibliothèque"
-    de: Besitzerangaben
-    en: Library information
-    es: "Información del repositorio"
-    pl: Informacje o bibliotece
-linkage: 
-  label: 
-    it: Collegamento
-    fr: Liens
-    de: Verlinkung
-    en: Linkage
-    es: Vínculos
-    pl: Powiązanie
-linking: 
-  label: 
-    it: Note su collegamenti
-    fr: "Entrées de liens"
-    de: "Verknüpfungseintragungen"
-    en: Linking entry fields
-    es: "Campos de entrada de vínculos"
-    pl: Łączenie pól wpisów
-ltg: 
-  label: 
-    it: Litografo
-    fr: Litographe
-    de: Lithograph
-    en: Lithograph
-    es: Litógrafo
-    pl: Litograf
-lyr: 
-  label: 
-    it: Poeta
-    fr: Parolier
-    de: Textdichter
-    en: Lyricist
-    es: Letrista
-    pl: Autor słów
-main: 
-  label: 
-    it: Campi principali
-    fr: "Entrées principales"
-    de: Haupteintragungen
-    en: Main entry fields
-    es: Campos principales
-    pl: Główne pola edycji
-notes: 
-  label: 
-    it: Note
-    fr: Notes
-    de: Fussnoten
-    en: Note fields
-    es: Notas
-    pl: Pola uwag
-other: 
-  label: 
-    it: Varia
-    fr: Divers
-    de: Verschiedenes
-    en: Miscellaneous
-    es: Varios
-    pl: Pozostałe
-oth: 
-  label: 
-    it: Altra funzione
-    fr: Autre function
-    de: Sonstige Funktion
-    en: Other function
-    es: "Otra función"
-    pl: Inna funkcja
-otm: 
-  label: 
-    it: Organizzatore
-    fr: Organisateur
-    de: Veranstalter
-    en: Event organizer
-    es: "Organizador del evento"
-    pl: Organizator wydarzenia
-pat: 
-  label: 
-    it: Committente
-    fr: "Mécène"
-    de: "Mäzen/Auftraggeber"
-    en: Patron
-    es: Comitente
-    pl: Sponsor
-pbl: 
-  label: 
-    it: Editore
-    fr: Editeur
-    de: Verleger
-    en: Publisher
-    es: "Editor (publicador)/Editorial (publicadora)"
-    pl: Wydawca
-performance: 
-  label: 
-    it: Rappresentazioni
-    fr: Performances
-    de: "Aufführungen"
-    en: Performances
-    es: Interpretaciones
-    pl: Wykonania
-physical_description: 
-  label: 
-    it: Descrizione fisica
-    fr: "Description matérielle"
-    de: Physische Beschreibung
-    en: Physical description
-    es: "Descripción física"
-    pl: Opis fizyczny
-ppm: 
-  label: 
-    it: Fabbricante di carta
-    fr: Papetier
-    de: Papierhersteller
-    en: Paper maker
-    es: "Fabricante de papel"
-    pl: Producent papieru
-prd: 
-  label: 
-    it: Personale alla produzione
-    fr: "Personnel de réalisation"
-    de: Produktionspersonal
-    en: Production personnel
-    es: "Personal de producción"
-    pl: Personel produkcyjny
-prf: 
-  label: 
-    it: Interprete
-    fr: "Interprète"
-    de: Interpret
-    en: Performer
-    es: "Intérprete"
-    pl: Wykonawca
-provenance: 
-  label: 
-    it: Provenienza
-    fr: Provenance
-    de: Provenienz
-    en: Provenance
-    es: Procedencia
-    pl: Pochodzenie
-prt: 
-  label: 
-    it: Stampatore
-    fr: Imprimeur
-    de: Drucker
-    en: Printer
-    es: Impresor
-    pl: Drukarnia
-scr: 
-  label: 
-    it: Copista
-    fr: Scribe
-    de: Schreiber
-    en: Scribe
-    es: Copista
-    pl: Kopista
-series: 
-  label: 
-    it: Informazioni sul titolo sovraordinato
-    fr: Mentions de collection
-    de: Gesamttitelangaben
-    en: Series statement fields
-    es: "Información de serie"
-    pl: Pola uwag do serii
-show_admin: 
-  label: 
-    it: Amministrazione
-    fr: Administration
-    de: Administration
-    en: Administration
-    es: Administración
-    pl: Administracja
-show_content: 
-  label: 
-    it: Contenuto
-    fr: Contenu
-    de: Inhalt
-    en: Content
-    es: Contenido
-    pl: Zawartość
-show_details: 
-  label: 
-    it: Descrizione fisica
-    fr: "Détail de la source"
-    de: Physische Beschreibung
-    en: Source details
-    es: "Detalles de la fuente"
-    pl: Dane źródła
-show_distribution: 
-  label: 
-    it: Organico
-    fr: Formation
-    de: Besetzung
-    en: Distribution
-    es: "Distribución"
-    pl: Dystrybucja
-show_information: 
-  label: 
-    it: Note
-    fr: "Information supplémentaire"
-    de: Anmerkungen
-    en: Further information
-    es: "Más información"
-    pl: Dalsze informacje
-show_library: 
-  label: 
-    it: Biblioteca
-    fr: "Bibliothèque"
-    de: Besitzerangaben
-    en: Library information
-    es: "Información del repositorio"
-    pl: Informacje o bibliotece
-show_links: 
-  label: 
-    it: Titoli connessi
-    fr: Titres connexes
-    de: Verlinkungen
-    en: Related Titles
-    es: "Títulos relacionados"
-    pl: Powiązane tytuły
-show_references: 
-  label: 
-    it: Bibliografia
-    fr: "Références"
-    de: Literatur
-    en: References
-    es: "Bibliografía"
-    pl: Odniesienia
-show_resources: 
-  label: 
-    it: Collegamenti
-    fr: Liens
-    de: Links
-    en: Related resources
-    es: Recursos relacionados
-    pl: Powiązane zasoby
-show_summary: 
-  label: 
-    it: Riassunto
-    fr: "Résumé"
-    de: Zusammenfassung
-    en: Summary
-    es: Resumen
-    pl: Podsumowanie
-show_terms: 
-  label: 
-    it: Descrittori
-    fr: Termes
-    de: Deskriptoren
-    en: Index terms
-    es: "Términos de indexación"
-    pl: Pojęcia indeksowane
-subject: 
-  label: 
-    it: Note sul titolo uniforme
-    fr: "Entrées de sujets"
-    de: Schlagworteintragungen
-    en: Subject access fields
-    es: "Campos de los puntos de acceso"
-    pl: Pola haseł tematycznych
-title: 
-  label: 
-    it: Titolo e campi correlati
-    fr: "Titre et champs associés"
-    de: Titel- und damit verbundene Felder
-    en: Title and title-related fields
-    es: "Título y campos relacionados"
-    pl: Tytuł i pola związane z tytułem
-trl: 
-  label: 
-    it: Traduttore
-    fr: Traducteur
-    de: "Übersetzer"
-    en: Translator
-    es: Traductor
-    pl: Tłumacz
-voc: 
-  label: 
-    it: Cantante
-    fr: Vocaliste
-    de: "Sänger"
-    en: Vocalist
-    es: Cantante
-    pl: Wokalista
-01_codes_artistic: 
-  label: 
-    it: Autore
-    fr: Auteur
-    de: Verfasser
-    en: Artistic production
-    es: Producción artística
-    pl: Autor produkcji artystycznej
-02_codes_performing: 
-  label: 
-    it: Partecipanti
-    fr: Performance
-    de: Mitwirkende
-    en: Performance
-    es: Interpretación
-    pl: Wykonanie
-03_codes_technical: 
-  label: 
-    it: Produttore
-    fr: "Création"
-    de: Hersteller
-    en: Technical production
-    es: "Producción técnica"
-    pl: Produkcja techniczna
-04_codes_other: 
-  label: 
-    it: Altri
-    fr: Autre
-    de: Weitere
-    en: Other
-    es: Otro
-    pl: Pozostałe
-"300": 
-  label: 
-    it: Materiale
-    fr: "Matériel"
-    de: Material
-    en: Physical Description
-    es: "Descripción física"
-    pl: Opis fizyczny
-  fields: 
-    a: 
-      label: 
-        it: Estensione
-        fr: Extension
-        de: Umfang
-        en: Extent
-        es: "Extensión"
-        pl: Zakres
-"337": 
-  label: 
-    it: Mezzo fisico
-    fr: Moyen physique 
-    de: Physisches Medium 
-    en: Media type
-    es: "Tipo de medio físico"
-    pl: Rodzaj nośnika
-  fields: 
-    a: 
-      label: 
-        it: Mezzo fisico 
-        fr: Moyen physique 
-        de: Physisches Medium 
-        en: Media type
-        es: "Tipo de medio físico"
-        pl: Rodzaj nośnika
-"500": 
-  label: 
-    it: Osservazioni
-    fr: "Remarque générale"
-    de: Bemerkungen
-    en: General note
-    es: Nota general
-    pl: Uwaga ogólna
-  fields: 
-    a: 
-      label: 
-        it: Osservazioni
-        fr: "Remarque générale"
-        de: Bemerkungen
-        en: General note
-        es: Nota general
-        pl: Uwaga ogólna
-      edit_label: 
-      en: ""
-"502": 
-  label: 
-    it: Nota alla dissertazione
-    fr: Note à la thèse
-    de: Hinweis zur Dissertation
-    en: Dissertation note
-    es: "Nota de disertación"
-    pl: Uwaga do dysertacji
-  fields: 
-    a: 
-      label: 
-        it: Nota alla dissertazione
-        fr: Note à la thèse
-        de: Hinweis zur Dissertation
-        en: Dissertation note
-        es: "Nota de disertación"
-        pl: Uwaga do dysertacji
-      comment: "NEW IN 2018"
-"520": 
-  label: 
-    it: Indicazione di contenuto
-    fr: Indication de copie
-    de: Bestandsangabe
-    en: Contents note
-    es: "Nota sobre el contenido"
-    pl: Uwaga do zawartości
-  fields: 
-    a: 
-      label: 
-        it: Indicazione di contenuto
-        fr: Indication de copie
-        de: Bestandsangabe
-        en: Contents note
-        es: "Nota sobre el contenido"
-        pl: Uwaga do zawartości
-      edit_label: 
-        en: ""
-"599": 
-  label: 
-    it: Commenti interni
-    fr: Commentaires internes
-    de: Interne Fussnoten
-    en: Internal note
-    es: Nota interna
-    pl: Uwaga wewnętrzna
-  fields: 
-    a: 
-      label: 
-        it: Commenti interni
-        fr: Commentaires internes
-        de: Interne Fussnoten
-        en: Internal note
-        es: Nota interna
-        pl: Uwaga wewnętrzna
-      edit_label: 
-        en: ""
-"650": 
-  label: 
-    it: Parola chiave
-    fr: Sujets
-    de: Schlagworteintragung
-    en: Subject heading
-    es: Descriptor
-    pl: Słowo kluczowe
-  fields: 
-    v: 
-      label: 
-        it: Suddivisione formale
-        fr: Subdivision de forme
-        de: Unterteilung nach der Form
-        en: Form subdivision
-        es: "Subdivisión de forma"
-        pl: Dalszy podział formularza
-    a: 
-      label: 
-        it: Parola chiave
-        de: Sachschlagwort
-        fr: Sujet
-        en: Subject heading
-        es: Decriptor
-        pl: Słowo kluczowe
-    x: 
-      label: 
-        it: Suddivisione generale
-        fr: "Subdivision générale"
-        de: Allgemeine Unterteilung
-        en: Subheading General subdivision
-        es: "Subdivisión general"
-        pl: Ogólny dalszy podział podnagłówków
-    y: 
-      label: 
-        it: Suddivisione cronologica
-        fr: Subdivision chronologique
-        de: Chronologische Unterteilung
-        en: Chronological subdivision
-        es: "Subdivisión cronológica"
-        pl: Dalszy podział chronologiczny
-    z: 
-      label: 
-        it: Suddivisione geografica
-        fr: "Subdivision géographique"
-        de: Geographische Unterteilung
-        en: Geographic subdivision
-        es: "Subdivisión geográfica"
-        pl: Dalszy podział geograficzny
-"651": 
-  label: 
-    it: Luogo
-    fr: "Lieu"
-    de: "Ort"
-    en: Related place
-    es: Lugar relacionado
-    pl: Powiązane miejsce
-  fields: 
-    a: 
-      label: 
-        it: Luogo
-        fr: "Lieu"
-        de: "Ort"
-        en: Place
-        es: Lugar
-        pl: Miejsce
-      edit_label: 
-        en: ""
-"856": 
-  label: 
-    it: Localizzazione e accesso elettronico
-    fr: "Ressource électronique externe"
-    de: Elektronische Lokalisierung und Zugriff
-    en: External resource
-    es: Recurso externo
-    pl: Zasób zewnętrzny
-  fields: 
-    z: 
-      label: 
-        it: Nota destinata al pubblico
-        fr: Remarque sur la ressource externe
-        de: "Für das Publikum bestimmte Fussnote"
-        en: Note about external resource
-        es: Nota sobre recurso externo
-        pl: Uwaga o zasobie zewnętrznym
-    u: 
-      label: 
-        it: Risorsa esterna URL
-        fr: Ressource externe URL
-        de: Uniform Resource Identifier URL
-        en: External resource URL
-        es: URL del recurso externo
-        pl: URL zasobu zewnętrznego
-# Marc Language codes
-cat: 
-  label: 
-    it: Catalano
-    fr: Catalan
-    de: Katalanisch
-    en: Catalan 
-    es: Catalán
-    pl: Kataloński
-cze: 
-  label: 
-    it: Ceco
-    fr: Tchèque
-    de: Tschechisch
-    en: Czech
-    es: Checo
-    pl: Czeski
-dan: 
-  label: 
-    it: Danese
-    fr: Danois
-    de: Dänisch
-    en: Danish
-    es: "Danés"
-    pl: Duński
-dut: 
-  label: 
-    it: Olandese
-    fr: Néerlandais
-    de: Niederländisch
-    en: Dutch
-    es: "Holandés"
-    pl: Holenderski
-eng: 
-  label: 
-    it: Inglese
-    fr: Anglais
-    de: Englisch
-    en: English
-    es: "Inglés"
-    pl: Angielski
-fre: 
-  label: 
-    it: Francese
-    fr: Français
-    de: Französisch
-    en: French
-    es: "Francés"
-    pl: Francuski
-ger: 
-  label: 
-    it: Tedesco
-    fr: Allemand
-    de: Deutsch
-    en: German
-    es: "Alemán"
-    pl: Niemiecki
-grc: 
-  label: 
-    it: Greco, antico (fino al 1453)
-    fr: Grec, ancien (TO 1453)
-    de: Altgriechisch (bis 1453)
-    en: Greek, Ancient (to 1453)
-    es: Griego, Antiguo (hasta 1453)
-    pl: Grecki, historyczny (do 1453 r.)
-gre:  
-  label: 
-    it: Greco, moderno (1453-)
-    fr: Grec, moderne (1453-)
-    de: Neugriechisch (1453-)
-    en: Greek, Modern (1453-)
-    es: Griego, Moderno (1453-)
-    pl: Grecki, współczesny (1453-)
-gsw: 
-  label: 
-    it: Svizzero tedesco 
-    fr: Suisse allemand
-    de: Schweizerdeutsch
-    en: Swiss German
-    es: "Suizo alemán"
-    pl: Niemiecki szwajcarski
-heb: 
-  label: 
-    it: Ebreo
-    fr: "Hébraïque"
-    de: Hebräisch
-    en: Hebrew
-    es: "Hebreo"
-    pl: Hebrajski
-hrv: 
-  label: 
-    it: Croato
-    fr: Croate
-    de: Kroatisch
-    en: Croatian
-    es: "Croata"
-    pl: Chorwacki
-hun: 
-  label: 
-    it: Ungherese
-    fr: Hongrois
-    de: Ungarisch
-    en: Hungarian
-    es: "Húngaro"
-    pl: Węgierski
-ita: 
-  label: 
-    it: Italiano
-    fr: Italien
-    de: Italienisch
-    en: Italian
-    es: "Italiano"
-    pl: Włoski
-jpn: 
-  label: 
-    it: Giapponese
-    fr: Japonais
-    de: Japanisch
-    en: Japanese
-    es: "Japonés"
-    pl: Japoński
-kor: 
-  label: 
-    it: Coreano
-    fr: "Coréen"
-    de: Koreanisch
-    en: Korean
-    es: "Coreano"
-    pl: Koreański
-lat: 
-  label: 
-    it: Latino
-    fr: Latin
-    de: Lateinisch
-    en: Latin
-    es: "Latín"
-    pl: Łaciński
-pol: 
-  label: 
-    it: Polacco
-    fr: Polonais
-    de: Polnisch
-    en: Polish
-    es: Polaco
-    pl: Polski
-por: 
-  label: 
-    it: Portoghese
-    fr: Portugais
-    de: Portugisisch
-    en: Portuguese
-    es: "Portugués"
-    pl: Portugalski
-rus: 
-  label: 
-    it: Russo
-    fr: Russe
-    de: Russisch
-    en: Russian
-    es: Ruso
-    pl: Rosyjski
-slo: 
-  label: 
-    it: Slovacco
-    fr: Slovaque
-    de: Slowakisch
-    en: Slovak
-    es: Eslovaco
-    pl: Słowacki
-slv: 
-  label: 
-    it: Sloveno
-    fr: "Slovène"
-    de: Slowenisch
-    en: Slovenian
-    es: Eslovenio
-    pl: Słoweński
-spa: 
-  label: 
-    it: Spagnolo
-    fr: Espanol
-    de: Spanisch
-    en: Spanish
-    es: "Español"
-    pl: Hiszpański
-srp: 
-  label: 
-    it: Serbo
-    fr: Serbe
-    de: Serbisch
-    en: Serbian
-    es: Serbio
-    pl: Serbski
-swe: 
-  label: 
-    it: Svedese
-    fr: "Suédois"
-    de: Schwedisch
-    en: Swedish
-    es: Sueco
-    pl: Szwedzki
+    a:
+      label: records.isbn
+  label: records.isbn
+'022':
+  fields:
+    a:
+      label: records.issn
+  label: records.issn
+'024':
+  fields:
+    a:
+      label: records.ismn
+  label: records.ismn
+02_codes_performing:
+  label: records.performance
+03_codes_technical:
+  label: records.technical_production
+'041':
+  fields:
+    a:
+      label: records.language_code
+  label: records.language_code
+'044':
+  fields:
+    a:
+      label: records.country_of_publication
+  label: records.country_of_publication
+04_codes_other:
+  label: records.other
+'100':
+  fields:
+    a:
+      label: records.author
+    d:
+      label: records.life_dates
+  label: records.author
+'210':
+  fields:
+    a:
+      label: records.short_title
+  label: records.short_title
+'240':
+  fields:
+    a:
+      label: records.title
+    g:
+      label: records.category
+    h:
+      label: records.type_publication
+  label: records.title
+'250':
+  fields:
+    a:
+      label: records.edition_statement
+  label: records.edition_statement
+'260':
+  fields:
+    a:
+      label: records.place_publication
+    b:
+      label: records.publisher
+    c:
+      label: records.year
+  label: records.imprint
+'264':
+  fields:
+    c:
+      label: records.production
+  label: records.production
+'300':
+  fields:
+    a:
+      label: records.extent
+  label: records.physical_description
+'337':
+  fields:
+    a:
+      label: records.media_type
+  label: records.media_type
+'500':
+  fields:
+    a:
+      label: records.general_note
+  label: records.general_note
+'502':
+  fields:
+    a:
+      label: records.dissertation_note
+  label: records.dissertation_note
+'520':
+  fields:
+    a:
+      label: records.contents_note
+  label: records.contents_note
+'599':
+  fields:
+    a:
+      label: records.internal_note
+  label: records.internal_note
+'650':
+  fields:
+    a:
+      label: records.subject_heading
+    v:
+      label: records.form_subdivision
+    x:
+      label: records.subheading_general
+    y:
+      label: records.chronological_subdivision
+    z:
+      label: records.geographic_subdivision
+  label: records.subject_heading
+'651':
+  fields:
+    a:
+      label: records.place
+  label: records.related_place
+'700':
+  fields:
+    '4':
+      label: records.function
+    a:
+      label: records.person
+  label: records.additional_personal_name_lit
+'710':
+  fields:
+    '4':
+      label: records.function
+    '8':
+      label: records.set
+    a:
+      label: records.institution
+    b:
+      label: records.department
+    g:
+      label: records.attribution_qualifier
+  label: records.additional_institution
+'730':
+  fields:
+    a:
+      label: records.additional_title_lit
+  label: records.additional_title_lit
+'760':
+  fields:
+    g:
+      label: records.volume_year_page
+    t:
+      label: records.title_periodical_book_series
+  label: records.item_part_of
+'780':
+  fields:
+    t:
+      label: records.preceding_entry
+  label: records.preceding_entry
+'785':
+  fields:
+    t:
+      label: records.succeeding_entry
+  label: records.succeeding_entry
+'856':
+  fields:
+    u:
+      label: records.external_resource_url
+    z:
+      label: records.note_external_resource
+  label: records.external_resource
+H:
+  label: records.editor
+XA-AD:
+  label: places.andorra
+XA-AT:
+  label: places.austria
+XA-BE:
+  label: places.belgium
+XA-BG:
+  label: places.bulgaria
+XA-CH:
+  label: places.switzerland
+XA-CH-VD:
+  label: places.switzerland_vaud
+XA-CZ:
+  label: places.czech_republic
+XA-DE:
+  label: places.germany
+XA-DK:
+  label: places.denmark
+XA-EE:
+  label: places.estonia
+XA-ES:
+  label: places.spain
+XA-FI:
+  label: places.finland
+XA-FR:
+  label: places.france
+XA-GB:
+  label: places.uk
+XA-GR:
+  label: places.greece
+XA-HR:
+  label: places.croatia
+XA-HU:
+  label: places.hungary
+XA-IE:
+  label: places.ireland
+XA-IS:
+  label: places.iceland
+XA-IT:
+  label: places.italy
+XA-LT:
+  label: places.lithuania
+XA-LU:
+  label: places.luxembourg
+XA-LV:
+  label: places.latvia
+XA-ME:
+  label: places.montenegro
+XA-MT:
+  label: places.malta
+XA-NL:
+  label: places.netherlands
+XA-NO:
+  label: places.norway
+XA-PL:
+  label: places.poland
+XA-PT:
+  label: places.portugal
+XA-RO:
+  label: places.romania
+XA-RS:
+  label: places.serbia
+XA-RU:
+  label: places.russian_federation
+XA-SE:
+  label: places.sweden
+XA-SI:
+  label: places.slovenia
+XA-SK:
+  label: places.slovakia
+XA-UA:
+  label: places.ukraine
+XA-VA:
+  label: places.holy_see
+XB-AM:
+  label: places.armenia
+XB-CN:
+  label: places.china
+XB-IL:
+  label: places.israel
+XB-IN:
+  label: places.india
+XB-IR:
+  label: places.iran
+XB-JP:
+  label: places.japan
+XB-KH:
+  label: places.cambodia
+XB-KR:
+  label: places.korea
+XB-SY:
+  label: places.syrian_arab_republic
+XB-TR:
+  label: places.turkey
+XB-TW:
+  label: places.taiwan
+XC-BJ:
+  label: languages.benin
+XC-DZ:
+  label: places.algeria
+XC-EG:
+  label: places.egypt
+XC-ZA:
+  label: places.south_africa
+XD-AR:
+  label: places.argentina
+XD-BR:
+  label: places.brazil
+XD-CA:
+  label: places.canada
+XD-CL:
+  label: places.chile
+XD-CO:
+  label: places.colombia
+XD-CU:
+  label: places.cuba
+XD-EC:
+  label: places.ecuador
+XD-HN:
+  label: places.honduras
+XD-MX:
+  label: places.mexico
+XD-PR:
+  label: places.puerto_rico
+XD-PY:
+  label: places.paraguay
+XD-TT:
+  label: places.trinidad_tobego
+XD-US:
+  label: places.usa
+XD-UY:
+  label: places.uruguay
+XD-VE:
+  label: places.venezuela
+XE-AU:
+  label: places.australia
+XE-NZ:
+  label: places.new_zealand
+added_series:
+  label: records.series_added_entry
+administration:
+  label: records.administration
+arr:
+  label: records.arranger
+art:
+  label: records.artist
+asn:
+  label: records.associated_name_lit
+aut:
+  label: records.additional_author
+bibliographical_reference:
+  label: records.references
+bnd:
+  label: records.binder
+bsl:
+  label: records.bookseller
+cat:
+  label: languages.catalan
+ccp:
+  label: records.conceptor
+chr:
+  label: records.choreographer
+clb:
+  label: records.collaborator
+cmp:
+  label: records.composer
+cnd:
+  label: records.conductor
+cns:
+  label: records.censor
+codes:
+  label: records.numbers_code_fields
+com:
+  label: records.compiler
+content:
+  label: records.content_description
+control:
+  label: records.control_fields
+cst:
+  label: records.costume_designer
+cze:
+  label: languages.czech
+dan:
+  label: languages.danish
+date:
+  label: records.dates
+description:
+  label: records.physical_description_fields
+diplomatic_title:
+  label: records.diplomatic_title
+dnc:
+  label: records.dancer
+dnr:
+  label: records.donor
+doc_abbreviations:
+  label: records.abbreviations
+doc_aid:
+  label: records.aide
+doc_cataloguing_collections:
+  label: records.cataloging_collection_convoluta
+doc_edit_functions:
+  label: records.basic_functions
+doc_introduction:
+  label: records.introduction
+doc_masks:
+  label: records.cataloging_forms
+doc_tag_index:
+  label: general.marc_tag_index
+doc_templates:
+  label: records.templates
+dte:
+  label: records.dedicatee
+dub:
+  label: records.dubious
+dut:
+  label: languages.dutch
+ed:
+  label: records.edition
+edition:
+  label: records.edition_imprint_fields
+edt:
+  label: records.editor
+egr:
+  label: records.engraver
+eng:
+  label: languages.english
+fmo:
+  label: records.former_owner
+fre:
+  label: languages.french
+ger:
+  label: languages.german
+grc:
+  label: languages.greek_ancient
+gre:
+  label: languages.greek_modern
+gsw:
+  label: languages.swiss_german
+heb:
+  label: languages.hebrew
+holding:
+  label: records.holdings_location
+hrv:
+  label: languages.croatian
+hun:
+  label: languages.hungarian
+ill:
+  label: records.illustrator
+incipit:
+  label: records.incipits
+ita:
+  label: languages.italian
+itr:
+  label: records.instrumentalist
+jpn:
+  label: records.japanese
+kor:
+  label: languages.korean
+lat:
+  label: languages.latin
+lbt:
+  label: records.librettist
+library:
+  label: records.library_information
+linkage:
+  label: records.linkage
+linking:
+  label: records.linking_entry_fields
+ltg:
+  label: records.lithograph
+lyr:
+  label: records.lyricist
+main:
+  label: records.main_entry_fields
+notes:
+  label: records.note_fields
+oth:
+  label: records.other_function
+other:
+  label: records.miscellaneous
+otm:
+  label: records.event_organizer
+pat:
+  label: records.patron
+pbl:
+  label: records.publisher
+performance:
+  label: records.performances
+physical_description:
+  label: records.physical_description
+pol:
+  label: languages.polish
+por:
+  label: languages.portugese
+ppm:
+  label: records.paper_maker
+prd:
+  label: records.production_personnel
+prf:
+  label: records.performer
+provenance:
+  label: records.provenance
+prt:
+  label: records.printer
+rus:
+  label: languages.russian
+scr:
+  label: records.scribe
+series:
+  label: records.series_statement
+show_admin:
+  label: records.administration
+show_content:
+  label: records.content
+show_details:
+  label: records.source_details
+show_distribution:
+  label: records.distribution
+show_information:
+  label: records.further_information
+show_library:
+  label: records.library_information
+show_links:
+  label: records.related_titles
+show_references:
+  label: records.references
+show_resources:
+  label: records.related_resources
+show_summary:
+  label: records.summary
+show_terms:
+  label: records.index_terms
+slo:
+  label: languages.slovak
+slv:
+  label: languages.slovenian
+spa:
+  label: languages.spanish
+srp:
+  label: languages.serbian
+subject:
+  label: records.subject_access_fields
+swe:
+  label: languages.swedish
+title:
+  label: records.title_related_fields
+trl:
+  label: records.translator
+voc:
+  label: records.vocalist
 zho:
-  label:
-    it: Cinese
-    fr: Chinois
-    de: Chinesisch
-    en: Chinese
-    es: Chino
-    pl: Chiński
-zxx: 
-  label: 
-    it: Nessun contesto linguistico
-    fr: Sans contenu linguistique
-    de: ohne Sprache
-    en: No linguistic content
-    es: "Sin contenido lingüístico"
-    pl: Brak zawartości językowej
-#Country Codes
-"XC-DZ":
-  label:
-    it: "Algeria"
-    fr: "Algeria"
-    de: "Algeria"
-    en: "Algeria"
-    es: "Argelia"
-    pl: Algieria
-"XA-AD":
-  label:
-    it: "ANDORRA"
-    fr: "ANDORRA"
-    de: "Andorra"
-    en: "Andorra"
-    es: "ANDORRA"
-    pl: Andora
-"XD-AR":
-  label:
-    it: "Argentina"
-    fr: "Argentina"
-    de: "Argentina"
-    en: "Argentina"
-    es: "Argentina"
-    pl: Argentyna
-"XB-AM":
-  label:
-    it: "Armenia"
-    fr: "Armenia"
-    de: "Armenia"
-    en: "Armenia"
-    es: "Armenia"
-    pl: Armenia
-"XE-AU":
-  label:
-    it: "Australia"
-    fr: "Australia"
-    de: "Australia"
-    en: "Australia"
-    es: "Australia"
-    pl: Australia
-"XA-AT":
-  label:
-    it: "Austria"
-    fr: "Austria"
-    de: "Austria"
-    en: "Austria"
-    es: "Austria"
-    pl: Austria
-"XA-BE":
-  label:
-    it: "Belgio"
-    fr: "Belgium"
-    de: "Belgium"
-    en: "Belgium"
-    es: "Bélgica"
-    pl: Belgia
-"XC-BJ":
-  label:
-    it: "Benin"
-    fr: "Benin"
-    de: "Benin"
-    en: "Benin"
-    es: "Benín"
-    pl: Benin
-"XD-BR":
-  label:
-    it: "Brasile"
-    fr: "Brazil"
-    de: "Brazil"
-    en: "Brazil"
-    es: "Brasil"
-    pl: Brazylia
-"XA-BG":
-  label:
-    it: "Bulgaria"
-    fr: "Bulgaria"
-    de: "Bulgaria"
-    en: "Bulgaria"
-    es: "Bulgaria"
-    pl: Bułgaria
-"XB-KH":
-  label:
-    it: "Cambogia"
-    fr: "Cambodia"
-    de: "Cambodia"
-    en: "Cambodia"
-    es: "Camboya"
-    pl: Kambodża
-"XD-CA":
-  label:
-    it: "Canada"
-    fr: "Canada"
-    de: "Canada"
-    en: "Canada"
-    es: "Canadá"
-    pl: Kanada
-"XD-CL":
-  label:
-    it: "Chile"
-    fr: "Chile"
-    de: "Chile"
-    en: "Chile"
-    es: "Chile"
-    pl: Chile
-"XB-CN":
-  label:
-    it: "Cina"
-    fr: "China"
-    de: "China"
-    en: "China"
-    es: "China"
-    pl: Chiny
-"XD-CO":
-  label:
-    it: "Colombia"
-    fr: "Colombia"
-    de: "Colombia"
-    en: "Colombia"
-    es: "Colombia"
-    pl: Kolumbia
-"XA-HR":
-  label:
-    it: "Croazia"
-    fr: "Croatia"
-    de: "Croatia"
-    en: "Croatia"
-    es: "Croacia"
-    pl: Chorwacja
-
-"XD-CU":
-  label:
-    it: "Cuba"
-    fr: "Cuba"
-    de: "Cuba"
-    en: "Cuba"
-    es: "Cuba"
-    pl: Kuba
-"XA-CZ":
-  label:
-    it: "Repubblica ceca"
-    fr: "Czech Republic"
-    de: "Czech Republic"
-    en: "Czech Republic"
-    es: "República Checa"
-    pl: Czechy
-"XA-DK":
-  label:
-    it: "Danimarca"
-    fr: "Denmark"
-    de: "Denmark"
-    en: "Denmark"
-    es: "Dinamarca"
-    pl: Dania
-"XC-EG":
-  label:
-    it: "Egitto"
-    fr: "Egypt"
-    de: "Egypt"
-    en: "Egypt"
-    es: "Egipto"
-    pl: Egipt
-"XA-EE":
-  label:
-    it: "Estonia"
-    fr: "Estonia"
-    de: "Estonia"
-    en: "Estonia"
-    es: "Estonia"
-    pl: Estonia
-"XA-FI":
-  label:
-    it: "Finlandia"
-    fr: "Finland"
-    de: "Finland"
-    en: "Finland"
-    es: "Finlandia"
-    pl: Finlandia
-"XA-FR":
-  label:
-    it: "Francia"
-    fr: "France"
-    de: "France"
-    en: "France"
-    es: "Francia"
-    pl: Francja
-"XA-DE":
-  label:
-    it: "Germania"
-    fr: "Germany"
-    de: "Germany"
-    en: "Germany"
-    es: "Alemania"
-    pl: Niemcy
-"XA-GR":
-  label:
-    it: "Grecia"
-    fr: "Greece"
-    de: "Greece"
-    en: "Greece"
-    es: "Grecia"
-    pl: Grecja
-"XA-VA":
-  label:
-    it: "Santa Sede"
-    fr: "Holy See"
-    de: "Holy See"
-    en: "Holy See"
-    es: "Santa Sede"
-    pl: Watykan
-"XD-HN":
-  label:
-    it: "Honduras"
-    fr: "Honduras"
-    de: "Honduras"
-    en: "Honduras"
-    es: "Honduras"
-    pl: Honduras
-"XA-HU":
-  label:
-    it: "Ungheria"
-    fr: "Hungary"
-    de: "Hungary"
-    en: "Hungary"
-    es: "Hungría"
-    pl: Węgry
-"XA-IS":
-  label:
-    it: "Islanda"
-    fr: "Iceland"
-    de: "Iceland"
-    en: "Iceland"
-    es: "Islandia"
-    pl: Islandia
-"XB-IN":
-  label:
-    it: "India"
-    fr: "India"
-    de: "India"
-    en: "India"
-    es: "India"
-    pl: Indie
-"XB-IR":
-  label:
-    it: "Iran, Repubblica Islamica dell'"
-    fr: "Iran, Islamic Republic of"
-    de: "Iran, Islamic Republic of"
-    en: "Iran, Islamic Republic of"
-    es: "Irán, República Islámica de"
-    pl: Iran, Republika Islamska
-"XA-IE":
-  label:
-    it: "Irlanda"
-    fr: "Ireland"
-    de: "Ireland"
-    en: "Ireland"
-    es: "Irlanda"
-    pl: Irlandia
-"XB-IL":
-  label:
-    it: "Israele"
-    fr: "Israel"
-    de: "Israel"
-    en: "Israel"
-    es: "Israel"
-    pl: Izrael
-"XA-IT":
-  label:
-    it: "Italia"
-    fr: "Italy"
-    de: "Italy"
-    en: "Italy"
-    es: "Italia"
-    pl: Włochy
-"XB-JP":
-  label:
-    it: "Giappone"
-    fr: "Japan"
-    de: "Japan"
-    en: "Japan"
-    es: "Japón"
-    pl: Japonia
-"XB-KR":
-  label:
-    it: "Corea, Repubblica di"
-    fr: "Korea, Republic of"
-    de: "Korea, Republic of"
-    en: "Korea, Republic of"
-    es: "Corea, República de"
-    pl: Korea, Republika
-"XA-LV":
-  label:
-    it: "Lettonia"
-    fr: "Latvia"
-    de: "Latvia"
-    en: "Latvia"
-    es: "Letonia"
-    pl: Łotwa
-"XA-LT":
-  label:
-    it: "Lituania"
-    fr: "Lithuania"
-    de: "Lithuania"
-    en: "Lithuania"
-    es: "Lituania"
-    pl: Litwa
-"XA-LU":
-  label:
-    it: "Lussemburgo"
-    fr: "Luxembourg"
-    de: "Luxembourg"
-    en: "Luxembourg"
-    es: "Luxemburgo"
-    pl: Luksemburg
-"XA-MT":
-  label:
-    it: "Malta"
-    fr: "Malta"
-    de: "Malta"
-    en: "Malta"
-    es: "Malta"
-    pl: Malta
-"XD-MX":
-  label:
-    it: "Messico"
-    fr: "Mexico"
-    de: "Mexico"
-    en: "Mexico"
-    es: "México"
-    pl: Meksyk
-"XA-ME":
-  label:
-    it: "Montenegro"
-    fr: "Montenegro"
-    de: "Montenegro"
-    en: "Montenegro"
-    es: "Montenegro"
-    pl: Czarnogóra
-"XA-NL":
-  label:
-    it: "Paesi Bassi"
-    fr: "Netherlands"
-    de: "Netherlands"
-    en: "Netherlands"
-    es: "Países Bajos"
-    pl: Niderlandy
-"XE-NZ":
-  label:
-    it: "Nuova Zelanda"
-    fr: "New Zealand"
-    de: "New Zealand"
-    en: "New Zealand"
-    es: "Nueva Zelanda"
-    pl: Nowa Zelandia
-"XA-NO":
-  label:
-    it: "Norvegia"
-    fr: "Norway"
-    de: "Norway"
-    en: "Norway"
-    es: "Noruega"
-    pl: Norwegia
-"XD-PY":
-  label:
-    it: "Paraguay"
-    fr: "Paraguay"
-    de: "Paraguay"
-    en: "Paraguay"
-    es: "Paraguay"
-    pl: Paragwaj
-"XA-PL":
-  label:
-    it: "Polonia"
-    fr: "Poland"
-    de: "Poland"
-    en: "Poland"
-    es: "Polonia"
-    pl: Polska
-"XA-PT":
-  label:
-    it: "Portogallo"
-    fr: "Portugal"
-    de: "Portugal"
-    en: "Portugal"
-    es: "Portugal"
-    pl: Portugalia
-"XD-PR":
-  label:
-    it: "Puerto Rico"
-    fr: "Puerto Rico"
-    de: "Puerto Rico"
-    en: "Puerto Rico"
-    es: "Puerto Rico"
-    pl: Portoryko
-"XA-RO":
-  label:
-    it: "Romania"
-    fr: "Romania"
-    de: "Romania"
-    en: "Romania"
-    es: "Rumania"
-    pl: Rumunia
-"XA-RU":
-  label:
-    it: "Federazione Russa"
-    fr: "Russian Federation"
-    de: "Russian Federation"
-    en: "Russian Federation"
-    es: "Federación Rusa"
-    pl: Federacja Rosyjska
-"XA-RS":
-  label:
-    it: "Serbia"
-    fr: "Serbia"
-    de: "Serbia"
-    en: "Serbia"
-    es: "Serbia"
-    pl: Serbia
-"XA-SK":
-  label:
-    it: "Slovacchia"
-    fr: "Slovakia"
-    de: "Slovakia"
-    en: "Slovakia"
-    es: "Eslovaquia"
-    pl: Słowacja
-"XA-SI":
-  label:
-    it: "Slovenia"
-    fr: "Slovenia"
-    de: "Slovenia"
-    en: "Slovenia"
-    es: "Eslovenia"
-    pl: Słowenia
-"XC-ZA":
-  label:
-    it: "Sudafrica"
-    fr: "South Africa"
-    de: "South Africa"
-    en: "South Africa"
-    es: "Sudáfrica"
-    pl: Republika Południowej Afryki
-"XA-ES":
-  label:
-    it: "Spagna"
-    fr: "Spain"
-    de: "Spain"
-    en: "Spain"
-    es: "España"
-    pl: Hiszpania
-"XA-SE":
-  label:
-    it: "Svezia"
-    fr: "Sweden"
-    de: "Sweden"
-    en: "Sweden"
-    es: "Suecia"
-    pl: Szwecja
-"XA-CH-VD":
-  label:
-    it: "Svizzera: Vaud"
-    fr: "Switzerland: Vaud"
-    de: "Switzerland: Vaud"
-    en: "Switzerland: Vaud"
-    es: "Suiza: cantón de Vaud"
-    pl: "Szwajcaria: kanton Vaud"
-"XA-CH":
-  label:
-    it: "Svizzera"
-    fr: "Switzerland"
-    de: "Switzerland"
-    en: "Switzerland"
-    es: "Suiza"
-    pl: Szwajcaria
-"XB-SY":
-  label:
-    it: "Repubblica Araba Siriana"
-    fr: "Syrian Arab Republic"
-    de: "Syrian Arab Republic"
-    en: "Syrian Arab Republic"
-    es: "República Árabe Siria"
-    pl: Syryjska Republika Arabska
-"XB-TW":
-  label:
-    it: "Taiwan (provincia della Ciina)"
-    fr: "Taiwan (Province of China)"
-    de: "Taiwan (Province of China)"
-    en: "Taiwan (Province of China)"
-    es: "Taiwán (Provincia de China)"
-    pl: Tajwan (prowincja Chin)
-"XD-TT":
-  label:
-    it: "Trinidad e Tobago"
-    fr: "Trinidad and Tobago"
-    de: "Trinidad and Tobago"
-    en: "Trinidad and Tobago"
-    es: "Trinidad y Tobago"
-    pl: Trynidad i Tobago
-"XB-TR":
-  label:
-    it: "Turchia"
-    fr: "Turkey"
-    de: "Turkey"
-    en: "Turkey"
-    es: "Turquía"
-    pl: Turcja
-"XA-UA":
-  label:
-    it: "Ucraina"
-    fr: "Ukraine"
-    de: "Ukraine"
-    en: "Ukraine"
-    es: "Ucrania"
-    pl: Ukraina
-"XA-GB":
-  label:
-    it: "Regno Unito"
-    fr: "United Kingdom"
-    de: "United Kingdom"
-    en: "United Kingdom"
-    es: "Reino Unido"
-    pl: Zjednoczone Królestwo
-"XD-US":
-  label:
-    it: "Stati Uniti d'America"
-    fr: "United States of America"
-    de: "United States of America"
-    en: "United States of America"
-    es: "Estados Unidos de América"
-    pl: Stany Zjednoczone AP
-"XD-UY":
-  label:
-    it: "Uruguay"
-    fr: "Uruguay"
-    de: "Uruguay"
-    en: "Uruguay"
-    es: "Uruguay"
-    pl: Urugwaj
-"XD-VE":
-  label:
-    it: "Venezuela, Repubblica Bolivariana del"
-    fr: "Venezuela, Bolivarian Republic of"
-    de: "Venezuela, Bolivarian Republic of"
-    en: "Venezuela, Bolivarian Republic of"
-    es: "Venezuela, República Bolivariana de"
-    pl: Wenezuela, Republika Boliwariańska
-"XD-EC":
-  label:
-    it: "Ecuador"
-    fr: "Ecuador"
-    de: "Ecuador"
-    en: "Ecuador"
-    es: "Ecuador"
-    pl: Ekwador
+  label: languages.chinese
+zxx:
+  label: records.no_linguistic_content

--- a/config/editor_profiles/default/configurations/HoldingBasicLabels.yml
+++ b/config/editor_profiles/default/configurations/HoldingBasicLabels.yml
@@ -1,1609 +1,412 @@
---- !map:ActiveSupport::HashWithIndifferentAccess 
-
-doc_introduction: 
-  label: 
-    de: Einleitung
-    en: Introduction
-    it: Introduzione
-    es: "Introducción"
-    pl: Wprowadzenie
-doc_masks: 
-  label: 
-    de: Katalogisierung von Musikquellen
-    en: Cataloging musical sources
-    it: Catalogazione delle fonti musicali
-    es: "Catalogación de fuentes musicales"
-    pl: Katalogowanie źródeł muzycznych
-doc_tag_index: 
-  label: 
-    de: MARC Tag Index
-    en: Index of MARC fields
-    it: Indice dei campi MARC
-    es: "Índice de campos MARC"
-    pl: Indeks pól MARC
-
-################
-
-doc_abbreviations: 
-  label: 
-    de: "Abkürzungen und Bezeichnungen"
-    en: "Abbreviations and terminology"
-    it: "Abbreviazioni e terminologia"
-    es: "Abreviaturas y terminología"
-    pl: Skróty i pojęcia
-doc_abbr_dates: 
-  label: 
-    de: "Datierung"
-    en: "Dates"
-    it: "Date"
-    es: "Fechas"
-    pl: Daty
-doc_abbr_general: 
-  label: 
-    de: "Allgemeine Abkürzungen und Begriffe"
-    en: "General abbreviations and terms"
-    it: "Abbreviazioni generali e terminologia"
-    es: "Abreviaturas y términos generales"
-    pl: Ogólne skróty i pojęcia
-doc_abbr_keys: 
-  label: 
-    de: "Tonarten"
-    en: "Keys"
-    it: "Tasti"
-    es: "Tonalidades"
-    pl: Tonacje
-doc_abbr_lang: 
-  label: 
-    de: "Sprachcodes"
-    en: "Language codes"
-    it: "Codice lingua"
-    es: "Códigos de idioma"
-    pl: Kody języków
-doc_abbr_modes:
-  label: 
-    de: "Kirchentonarten"
-    en: "Ecclesiastical modes"
-    it: "Modi ecclesiastici"
-    es: "Modos eclesiásticos"
-    pl: Skale kościelne
-doc_abbr_voices_instr: 
-  label: 
-    de: "Stimmen- und Instrumentenbezeichnungen"
-    en: "Terms for voices and instruments"
-    it: "Terminologia per voci e strumenti"
-    es: "Terminología para voces e instrumentos"
-    pl: Określenia głosów i instrumentów
-doc_abbr_voices_instr2: 
-  label: 
-    de: "Stimmen- und Instrumentenbezeichnungen tabellarisch"
-    en: "RISM instrument abbreviations"
-    it: "Abbreviazioni RISM per gli strumenti"
-    pt: "Abreviaturas de instrumentos de RISM"
-    pl: Skróty instrumentów wg RISM
-
-###############
-
-doc_aid: 
-  label: 
-    de: Arbeitshilfen
-    en: Aids
-    it: Aiuti
-    pl: Pomoce
-doc_aid_liturgical_feasts: 
-  label: 
-    de: "Liturgische Feste"
-    en: "Liturgical festivals"
-    it: "Feste liturgiche"
-    es: "Festividades litúrgicas"
-    pl: Święta liturgiczne
-doc_aid_locations: 
-  label: 
-    de: "Fundorte auf Quellen"
-    en: "Locations on the source"
-    it: "Luogo sulla fonte"
-    es: "Ubicaciones en la fuente"
-    pl: Lokalizacje w źródle
-doc_aid_texts_sacred_works: 
-  label: 
-    de: "Standardtexte Sakralwerke"
-    en: "Standard texts of sacred works"
-    it: "Testo standard dei brani musicali sacri"
-    es: "Textos estándar de obras sacras"
-    pl: Standardowe teksty utworów sakralnych
-doc_aid_titles_keywords: 
-  label: 
-    de: "Einordnungstitel - Schlagworte"
-    en: "Standardized titles - Subject headings"
-    it: "Titolo standard - intestazione del soggetto"
-    es: "Títulos uniformes – Descriptores"
-    pl: Znormalizowane tytuły – słowa kluczowe
-doc_aid_transposing_instruments: 
-  label: 
-    de: "Hilfe zur Transponierung von Instrumenten"
-    en: "Help for transposing instruments"
-    it: "Aiuto agli strumenti traspositori"
-    es: Ayuda para instrumentos transpositores
-    pl: Pomoc przy transpozycji instrumentów
-
-################
-
-doc_cataloguing: 
-  label: 
-    de: Allgemeine Erfassung Hilfe
-    en: General cataloging guidelines
-    it: Regole di catalogazione generali
-    es: "Lineamientos generales para la catalogación"
-    pl: Ogólne wskazówki do katalogowania
-doc_cat_collections: 
-  label: 
-    de: Erfassung von Sammlungen
-    en: Cataloging collection and convoluta
-    it: Catalogazione delle collezioni e dei volumi compositi
-    es: "Catalogación de colecciones y volúmenes compuestos"
-    pl: Katalogowanie kolekcji i klocka introligatorskiego
-doc_cat_templates: 
-  label: 
-    de: Templates
-    en: Templates
-    it: Template
-    es: Plantillas
-    pl: Szablony
-doc_cat_authorities: 
-  label: 
-    de: Normdaten
-    en: Authorities
-    it: Autorità
-    es: Autoridades
-    pl: Hasła wzorcowe
-
-################
-
-doc_editor: 
-  label: 
-    de: "Editor Hilfe"
-    en: Using Muscat
-    it: Guida all'editor
-    es: Uso de Muscat
-    pl: Korzystanie z Muscatu
-doc_edit_functions: 
-  label: 
-    de: "Grundsätzliche Funktionen"
-    en: Basic functions
-    it: Funzioni base
-    es: "Funciones básicas"
-    pl: Podstawowe funkcje
-doc_edit_workflow: 
-  label: 
-    de: "Workflow"
-    en: Workflow
-    it: Workflow
-    pl: Przepływ pracy
-doc_edit_searching:
-  label:
-    de: "Suche"
-    en: "Searching"
-    it: "Ricerca"
-    es: "Búsqueda"
-    pl: Wyszukiwanie
-
-
-   
-################
-
-doc_library: 
-  label: 
-    de: Besitzerangaben
-    en: Library information
-    it: Informazioni sulla biblioteca
-    es: "Información del repositorio"
-    pl: Informacje o bibliotece
-doc_provenance: 
-  label: 
-    de: Provenienz
-    en: Provenance
-    it: Provenienza
-    es: Procedencia
-    pl: Pochodzenie
-doc_linkage: 
-  label: 
-    de: Verlinkung
-    en: Linkage
-    it: Collegamenti
-    es: "Vínculos"
-    pl: Powiązanie
-doc_diplomatic_title: 
-  label: 
-    de: Diplomatischer Titel
-    en: Diplomatic title
-    it: Titolo diplomatico
-    es: "Título diplomático"
-    pl: Tytuł dyplomatyczny
-doc_physical_description: 
-  label: 
-    de: Materialbeschreibung
-    en: Material description
-    it: Descrizione del materiale
-    es: "Descripción del material"
-    pl: Opis materiału
-doc_content: 
-  label: 
-    de: Inhalt
-    en: Content
-    it: Contenuto
-    es: Contenido
-    pl: Zawartość
-doc_incipit: 
-  label: 
-    de: Incipits
-    en: Incipits
-    it: Incipit
-    es: "Íncipits"
-    pl: Incipity
-doc_bibliographical_reference: 
-  label: 
-    de: Literatur
-    en: References
-    it: Riferimenti
-    es: Referencias
-    pl: Odniesienia
-doc_added_entries: 
-  label: 
-    de: Nebeneintragungen
-    en: Added entry name
-    it: Nome di entità aggiunto
-    pl: Dodana nazwa wpisu
-doc_performance: 
-  label: 
-    de: "Aufführungen"
-    en: Performances
-    it: Esecuzioni
-    es: "Interpretaciones"
-    pl: Wykonania
-doc_date: 
-  label: 
-    de: Daten
-    en: Dates
-    it: Date
-    es: Fechas
-    pl: Daty
-doc_administration: 
-  label: 
-    de: Administration
-    en: Administration
-    it: Amministrazione
-    es: "Administración"
-    pl: Administracja
-doc_personal_names:
-  label:
-    de: "Personen"
-    en: "Personal names"
-    it: "Nomi di persona"
-    es: "Nombres personales"
-    pl: Osoby
-doc_images:
-  label:
-    de: "Bilder"
-    en: "Images"
-    it: "Immagini"
-    es: "Imágenes"
-    pl: Obrazy
-doc_institutions:
-  label:
-    de: "Körperschaften"
-    en: "Institutions"
-    it: "Istituzioni"
-    es: "Instituciones"
-    pl: Instytucje
-doc_title:
-  label:
-    de: "Titel und Inhaltsangaben"
-    en: "Title and content description"
-    it: "Titolo e descrizione del contenuto"
-    es: "Título y descripción del contenido"
-    pl: Tytuł i opis źródła
-doc_people:
-  label:
-    de: "Personen und Körperschaften"
-    en: "People and institutions"
-    it: "Persone ed istituzioni"
-    es: "Personas e instituciones"
-    pl: Osoby i instytucje
-doc_main_entry_fields:
-  label:
-    de: "Haupteintragungen"
-    en: "Main entry fields"
-    it: "Campi principali"
-    es: "Campos principales"
-    pl: Główne pola edycji
-doc_numbers:
-  label:
-    de: "Nummern und Codes"
-    en: "Numbers and code fields"
-    it: "Campi numerici e codici"
-    es: "Números y campos de código"
-    pl: Pola liczb i kodów
-doc_name_variants:
-  label:
-    de: "Namensvarianten"
-    en: "Name variants"
-    it: "Varianti del nome"
-    es: Variantes del nombre
-    pl: Alternatywne nazwy osoby
-doc_relations:
-  label:
-    de: "Beziehungen"
-    en: "Relations"
-    it: "Relazioni"
-    es: "Relaciones"
-    pl: Relacje
-doc_references:
-  label:
-    de: "Literatur und Bemerkungen"
-    en: "References"
-    it: "Riferimenti"
-    es: "Referencias"
-    pl: Odniesienia
-
-################
-
-01_codes_artistic: 
-  label: 
-    it: Autore
-    fr: Auteur
-    de: Verfasser
-    en: Artistic production
-    pl: Autor produkcji artystycznej
-02_codes_performing: 
-  label: 
-    it: Partecipanti
-    fr: Exécuteurs
-    de: Mitwirkende
-    en: Performance
-    pl: Wykonanie
-03_codes_technical: 
-  label: 
-    it: Produttore
-    fr: "Création"
-    de: Hersteller
-    en: Technical production  
-    pl: Produkcja techniczna
-04_codes_other: 
-  label: 
-    it: Altri
-    fr: Autre
-    de: Weitere
-    en: Other 
-    pl: Pozostałe
-
-################
-
-"000": 
-  label: 
-    it: Leader
-    fr: Guide
-    de: Leader
-    en: Leader
-    es: "Líder"
-    pl: Leader
-"001": 
-  label: 
-    it: Numero documento RISM
-    fr: No. RISM
-    de: RISM Dokumentnummer
-    en: RISM ID No.
-    es: "Número de ID de RISM"
-    pl: RISM ID
-"035": 
-  label: 
-    it: Num. locale
-    fr: No. local
-    de: Lokale Nummer
-    en: Local Number
-    es: "Número local"
-    pl: Numer kontrolny
-  fields: 
-    a: 
-      label: 
-        it: Num. locale
-        fr: No. local
-        de: Lokale Nummer
-        en: Local ID no.
-        pl: Numer kontrolny
-      edit_label:
-        en: ""
-"300": 
-  label: 
-    it: Materiale
-    fr: "Matériel"
-    de: Material
-    en: Physical description
-    es: "Descripción física"
-    pl: Opis fizyczny
-  fields: 
-    a: 
-      label: 
-        it: Categoria di fonte, estensione
-        fr: Type de source
-        de: Quellenart, Umfang
-        en: Format, extent
-        es: "Formato, extensión"
-        pl: Rodzaj źródła, objętość
-    b: 
-      label: 
-        it: Altri dettagli sul materiale
-        fr: Autres détails du matériau
-        de: Zusätzliche Materialbeschreibung
-        en: Other physical details
-        es: "Otros detalles físicos"
-        pl: Pozostałe dane fizyczne
-    c: 
-      label: 
-        it: Dimensioni
-        fr: Dimension
-        de: Format
-        en: Dimensions
-        es: Dimensiones
-        pl: Wymiary
-    "8": 
-      label: 
-        it: Gruppo di materiale
-        fr: Documents
-        de: Set
-        en: Set
-        es: Set
-        pl: Zbiór
-"500": 
-  label: 
-    it: Osservazioni
-    fr: "Remarque générale"
-    de: Bemerkungen
-    en: General note
-    es: Nota general
-    pl: Uwaga ogólna
-  fields: 
-    a: 
-      label: 
-        it: Osservazioni
-        fr: "Remarque générale"
-        de: Bemerkungen
-        en: General note
-        es: Nota general
-        pl: Uwaga ogólna
-      edit_label: 
-        en: ""
-    "8": 
-      label: 
-        it: Gruppo di materiale
-        fr: Documents
-        de: Set
-        en: Set
-        es: Set
-        pl: Zbiór
-"506": 
-  label: 
-    it: Restrizioni all'accesso
-    fr: Restriction d'accès
-    de: "Zugangsbeschränkungen"
-    en: Access restrictions
-    es: Restricciones de acceso
-    pl: Ograniczenia dostępu
-  fields: 
-    a: 
-      label: 
-        it: Restrizioni all'accesso
-        fr: Restriction d'accès
-        de: "Zugangsbeschränkungen"
-        en: Access restriction
-        es: Restricciones de acceso
-        pl: Ograniczenia dostępu
-      edit_label: 
-        en: ""
-"518": 
-  label: 
-    it: Nota sull'esecuzione
-    fr: "Remarque sur les interprètes"
-    de: "Bemerkungen zu den Aufführungen"
-    en: Note on performance
-    es: "Nota sobre ocasión de interpretación"
-    pl: Uwaga o wykonaniu
-  fields: 
-    a: 
-      label: 
-        it: Nota sull'esecuzione
-        fr: "Remarque sur les interprètes"
-        de: "Bemerkungen zu den Aufführungen"
-        es: "Nota sobre ocasión de interpretación"
-        en: Performer note
-        pl: Uwaga o wykonaniu
-      edit_label: 
-        en: ""
-"541": 
-  label: 
-    it: Fonte immediata d'acquisto
-    fr: Source d'acquisition
-    de: Unmittelbare Beschaffungsquelle
-    en: Source of acquisition
-    es: "Fuente de adquisición"
-    pl: Źródło nabycia
-  fields: 
-    a: 
-      label: 
-        it: Nota sulla fonte d'acquisto
-        fr: Source d'acquisition
-        de: Beschaffungsquelle
-        en: Source of acquisition note
-        es: "Nota sobre la fuente de adquisición"
-        pl: Uwaga o źródle nabycia
-    c: 
-      label: 
-        it: Metodo d'acquisto
-        fr: "Méthode d'acquisition"
-        de: Beschaffungsart
-        en: Method of acquisition
-        es: "Método de adquisición"
-        pl: Sposób nabycia
-    d: 
-      label: 
-        it: Data d'acquisto
-        fr: Date d'acquisition
-        de: Beschaffungsdatum
-        en: Date of acquisition
-        es: "Fecha de adquisición"
-        pl: Data nabycia
-    e: 
-      label: 
-        it: Numero di acquisizione
-        fr: Numéro d'acquisition
-        de: Akzessionsnumer
-        en: Accession number
-        es: "Número de adquisición"
-        pl: Numer akcesji
-"561": 
-  label: 
-    it: Provenienza
-    fr: Provenance
-    de: Provenienzvermerke
-    en: Provenance note
-    es: Nota de procedencia
-    pl: Uwaga o pochodzeniu
-  fields: 
-    a: 
-      label: 
-        it: Provenienza
-        fr: Provenance
-        de: Provenienzvermerke
-        en: Provenance notes
-        es: Notas de procedencia
-        pl: Uwaga o pochodzeniu
-      edit_label: 
-        en: ""
-"563": 
-  label: 
-    it: Nota sulla rilegatura
-    fr: Reliure note
-    de: Einband note
-    en: Binding note
-    es: "Nota de encuadernación"
-    pl: Uwaga o oprawie
-  fields: 
-    a: 
-      label: 
-        it: Nota sulla rilegatura
-        fr: Reliure note
-        de: Einband note
-        en: Binding note
-        pl: Uwaga o oprawie
-      edit_label: 
-        en: ""
-"591": 
-  label: 
-    it: Altra segnatura
-    fr: Autre cote
-    de: Weitere Signatur
-    en: Other shelfmark
-    es: Otra signatura
-    pl: Inna sygnatura
-  fields: 
-    a: 
-      label: 
-        it: Altra segnatura
-        fr: Autre cote
-        de: Weitere Signatur
-        en: Other shelfmark
-        es: Otra signatura
-        pl: Inna sygnatura
-"592": 
-  label: 
-    it: Filigrana
-    fr: Filigrane
-    de: Wasserzeichen
-    en: Watermark description
-    es: "Descripción de la marca de agua"
-    pl: Opis znaku wodnego
-  fields: 
-    a: 
-      label: 
-        it: Filigrana
-        fr: Filigrane
-        de: Wasserzeichen
-        en: Watermark description
-        es: "Descripción de la marca de agua"
-        pl: Opis znaku wodnego
-    "8": 
-      label: 
-        it: Gruppo di materiale
-        fr: Documents
-        de: Set
-        en: Set
-        es: Set
-        pl: Zbiór
-"593": 
-  label: 
-    it: Categoria di fonte
-    fr: Type de source
-    de: Quellentyp
-    en: Source type
-    es: Tipo de fuente
-    pl: Rodzaj źródła
-  fields: 
-    a: 
-      label: 
-        it: Categoria
-        fr: Type
-        de: Typ
-        en: Type
-        es: Tipo
-        pl: Rodzaj
-"599": 
-  label: 
-    it: Commenti interni
-    fr: Commentaires internes
-    de: Interne Fussnoten
-    en: Local notes field
-    es: Campo de notas locales
-    pl: Pole uwag wewnętrznych
-  fields: 
-    a: 
-      label: 
-        it: Commenti interni
-        fr: Commentaires internes
-        de: Interne Fussnoten
-        en: Local notes field
-        es: Campo de notas locales
-        pl: Pole uwag wewnętrznych
-      edit_label: 
-        en: ""
-"651": 
-  label: 
-    it: Luogo di un evento
-    fr: "Lieu d'un événement"
-    de: "Aufführungsort"
-    en: Location of performance
-    es: "Lugar de interpretación"
-    pl: Lokalizacja wykonania
-  fields: 
-    a: 
-      label: 
-        it: Luogo di un evento
-        fr: "Lieu d'un événement"
-        de: "Aufführungsort"
-        en: Location of performance
-        es: "Lugar de interpretación"
-        pl: Lokalizacja wykonania
-      edit_label: 
-        en: ""
-"691": 
-  label: 
-    it: Riferimenti bibliografici
-    fr: "Référence bibliographique"
-    de: Literaturverweis
-    en: Bibliographic reference
-    es: "Referencia bibliográfica"
-    pl: Odniesienie bibliograficzne
-  fields: 
-    a: 
-      label: 
-        it: Bibliografia
-        fr: "Référence bibliographique"
-        de: Literatur
-        en: Bibliographic reference
-        es: "Referencia Bibliográfica"
-        pl: Odniesienie bibliograficzne
-    n: 
-      label: 
-        it: Numero/pagina
-        fr: "Numéro/page"
-        de: Fundstelle
-        en: Number/page
-        es: "Número/página"
-        pl: Numer / strona
-"700": 
-  label: 
-    it: Nomi di persone aggiuntivi
-    fr: Noms de personnes additionnels
-    de: Nebeneintragung Personen
-    en: Additional personal name
-    es: Nombre personal adicional
-    pl: Dodatkowa osoba
-  fields: 
-    a: 
-      label: 
-        it: Nome
-        fr: Nom
-        de: Personenname
-        en: Name
-        es: Nombre
-        pl: Imię i nazwisko
-    d: 
-      label: 
-        it: Date di nascita e di morte
-        fr: Dates de vie
-        de: Geburts- und Todesdaten
-        en: Life dates
-        es: Fechas de nacimiento y muerte
-        pl: Daty urodzenia i śmierci
-    j: 
-      label: 
-        it: Qualificazione d'attribuzione
-        fr: Qualificatif d'attribution
-        de: Zuschreibungsvermerk
-        en: Attribution qualifier
-        es: "Calificador de atribución"
-        pl: Kwalifikator atrybucji
-      edit_label: 
-        it: Attribuzione
-        fr: Attribution
-        de: Zuschreibung
-        en: Attribution
-        es: "Atribución"
-        pl: Atrybucja
-    "4": 
-      label: 
-        it: Funzione
-        fr: Function
-        de: Funktionsbezeichnung
-        en: Function
-        es: "Función"
-        pl: Funkcja
-    "8": 
-      label: 
-        it: Gruppo di materiale
-        fr: Documents
-        de: Set
-        en: Set
-        es: Set
-        pl: Zbiór
-"710": 
-  label: 
-    it: Nome di ente
-    fr: "Nom de la collectivité"
-    de: Nebeneintragung Körperschaften
-    en: Additional institution
-    es: "Institución adicional"
-    pl: Dodatkowa instytucja
-  fields: 
-    a: 
-      label: 
-        it: Nome di ente
-        fr: "Nom de la collectivité"
-        de: Körperschaftsname
-        en: Institution
-        es: "Institución"
-        pl: Instytucja
-    b: 
-      label: 
-        it: Ente subordinato
-        fr: "Collectivité subordonnée"
-        de: Untergeordnete Körperschaft
-        en: Department
-        es: Departamento
-        pl: Wydział
-    g: 
-      label: 
-        it: Qualificazione d'attribuzione
-        fr: Qualificatif d'attribution
-        de: Zuschreibungsvermerk
-        en: Attribution qualifier
-        es: "Calificador de atribución"
-        pl: Kwalifikator atrybucji
-      edit_label: 
-        it: Attribuzione
-        fr: Attribution
-        de: Zuschreibung
-        en: Attribution
-        es: "Atribución"
-        pl: Atrybucja
-
-    "4": 
-      label: 
-        it: Funzione
-        fr: Fonction
-        de: Funktionsbezeichnung
-        en: Function
-        es: "Función"
-        pl: Funkcja
-    "8": 
-      label: 
-        it: Gruppo di materiale
-        fr: Documents
-        de: Set
-        en: Set
-        es: Set
-        pl: Zbiór
-"852": 
-  label: 
-    it: Sigla della biblioteca
-    fr: "Sigle de bibliothèque"
-    de: Bibliothekssigel
-    en: Library siglum
-    es: Sigla del repositorio
-    pl: Siglum
-  fields: 
-    a: 
-      label: 
-        it: Sigla della biblioteca
-        fr: "Sigle de bibliothèque"
-        de: Bibliothekssigel
-        en: Library siglum
-        es: Sigla del repositorio
-        pl: Siglum
-    b: 
-      label: 
-        it: Dipartimento
-        fr: Section
-        de: Abteilung
-        en: Department
-        es: Departamento
-        pl: Wydział
-    c: 
-      label: 
-        it: Segnatura
-        fr: Cote
-        de: Signatur
-        en: Shelfmark
-        es: Signatura
-        pl: Sygnatura
-    d: 
-      label: 
-        it: Segnatura vecchia (olim)
-        fr: Ancienne cote (olim)
-        de: Alte Signatur (olim)
-        en: Shelfmark (olim)
-        es: Signatura antigua (olim)
-        pl: Sygnatura (wcześniejsza)
-    e: 
-      label: 
-        it: Biblioteca
-        fr: "Bibliothèque"
-        de: Bibliothek
-        en: Library
-        es: "Repositorio"
-        pl: Biblioteka
-    q: 
-      label: 
-        it: Materiale conservato
-        fr: Matériaux préservées
-        de: Erhaltenes Material
-        en: Material held
-        es: Material conservado
-        pl: Posiadany materiał
-    u: 
-      label: 
-        it: URI
-        fr: URI
-        de: URI
-        en: URI
-        es: URI
-        pl: URI
-    z: 
-      label: 
-        it: Nome del fondo
-        fr: Fonds
-        de: Bestandsname
-        en: Provenance
-        es: Procedencia
-        pl: Pochodzenie
-"856": 
-  label: 
-    it: Localizzazione e accesso elettronico
-    fr: "Ressource électronique externe"
-    de: Elektronische Lokalisierung und Zugriff
-    en: External resource URI
-    es: URI de recurso externo
-    pl: URI zasobu zewnętrznego
-  fields: 
-    z: 
-      label: 
-        it: Nota destinata al pubblico
-        fr: Remarque sur la ressource externe
-        de: "Für das Publikum bestimmte Fussnote"
-        en: Note about external resource
-        es: Nota sobre recurso externo
-        pl: Uwaga o zasobie zewnętrznym
-    u: 
-      label: 
-        it: Risorsa esterna
-        fr: Ressource externe
-        de: Uniform Resource Identifier
-        en: External resource
-        es: Recurso externo
-        pl: Zasób zewnętrzny
-    x: 
-      label: 
-        it: Tipo di collegamento
-        fr: Type de lien
-        de: Linktyp
-        en: Link type
-        es: Tipo de enlace
-        pl: Typ odsyłacza
-"963": 
-  label: 
-    it: Non-migrated bound with value from 563 
-    fr: Non-migrated bound with value from 563
-    de: Non-migrated bound with value from 563
-    en: Non-migrated bound with value from 563
-    es: Non-migrated bound with value from 563
-    pl: Non-migrated bound with value from 563 
-  fields: 
-    u: 
-      label: 
-        it: Temp val
-        fr: Temp val
-        de: Temp val
-        en: Temp val
-        es: Temp val
-        pl: Temp val
-"973": 
-  label: 
-    it: Rilegato con
-    fr: Relié en
-    de: Eingesprungen
-    en: Bound with
-    es: Encuadernado con
-    pl: Współoprawne z
-  fields: 
-    u: 
-      label: 
-        it: Rilegato con
-        fr: Relié en
-        de: Eingesprungen
-        en: Bound with
-        es: Encuadernado con
-        pl: Współoprawne z
-      comment: "NEW IN 2018!"
-################
-
-show_admin: 
-  label: 
-    it: Amministrazione
-    fr: Administration
-    de: Administration
-    en: Administration
-    es: "Administración"
-    pl: Administracja
-show_content: 
-  label: 
-    it: Contenuto
-    fr: Contenu
-    de: Inhalt
-    en: Content
-    es: Contenido
-    pl: Zawartość
-show_distribution: 
-  label: 
-    it: Organico
-    fr: Distribution
-    de: Besetzung
-    en: Distribution
-    es: "Distribución"
-    pl: Dystrybucja
-show_information: 
-  label: 
-    it: Note
-    fr: "Information supplémentaire"
-    de: Anmerkungen
-    en: Further information
-    es: "Información suplementaria"
-    pl: Dalsze informacje
-show_library: 
-  label: 
-    it: Biblioteca
-    fr: "Bibliothèque"
-    de: Besitzerangaben
-    en: Library information
-    es: "Información del repositorio"
-    pl: Informacje o bibliotece
-show_links: 
-  label: 
-    it: Titoli connessi
-    fr: Titres connexes
-    de: Verlinkungen
-    en: Related Titles
-    es: "Títulos relacionados"
-    pl: Powiązane tytuły
-show_material: 
-  label: 
-    it: Descrizione del materiale
-    fr: "Description du matériel"
-    de: Materialbeschreibung
-    en: Material description
-    es: "Descripción material"   
-    pl: Opis materiału
-show_references: 
-  label: 
-    it: Bibliografia
-    fr: "Références"
-    de: Literatur
-    en: References
-    es: "Referencias"
-    pl: Odniesienia
-show_resources: 
-  label: 
-    it: Collegamenti
-    fr: Liens
-    de: Links
-    en: Related resources
-    es: Recursos relacionados
-    pl: Powiązane zasoby
-show_summary: 
-  label: 
-    it: Riassunto
-    fr: "Résumé"
-    de: Zusammenfassung
-    en: Summary
-    es: Resumen
-    pl: Podsumowanie
-show_terms: 
-  label: 
-    it: Descrittori
-    fr: Termes
-    de: Deskriptoren
-    en: Index terms
-    es: "Términos de indexación"
-    pl: Pojęcia indeksowane
-        
-################
-        
-edit_administration: 
-  label: 
-    it: Amministrazione
-    fr: Administration
-    de: Administration
-    en: Administration
-    es: Administración
-    pl: Administracja
-edit_library: 
-  label: 
-    it: Biblioteca e relazione
-    fr: "Bibliothèque et relations"
-    de: Besitzerangaben und Verlinkung
-    en: Library information and relations
-    es: "Información del repositorio y sus relaciones"
-    pl: Informacje i relacje bibliotekarskie
-edit_material: 
-  label: 
-    it: Descrizione del materiale
-    fr: "Description du matériel"
-    de: Materialbeschreibung
-    en: Material description
-    es: "Descripción del material" 
-    pl: Opis materiału
-edit_names: 
-  label: 
-    it: Persone e istituzione
-    fr: Personnes et institutions
-    de: Personen und Körperschaften
-    en: People and institutions
-    es: Personas e instituciones
-    pl: Osoby i instytucje
-edit_references: 
-  label: 
-    it: Bibliografia e note
-    fr: "Références et notes"
-    de: Literatur und Fussnoten
-    en: References and notes
-    es: Referencias y notas
-    pl: Odniesienia i uwagi
-
-unmatched: 
-  label: 
-    it: Campi sconoscuti
-    fr: Champs non reconnus
-    de: Unbekannte Felder
-    en: Unknown fields
-    es: Campos desconocidos
-    pl: Pola nieznane
-
-################
-
-arr: 
-  label: 
-    it: Arrangiatore
-    fr: Arrangeur
-    de: Bearbeiter
-    en: Arranger
-    es: Arreglador
-    pl: Aranżer
-art: 
-  label: 
-    it: Scenografo
-    fr: "Metteur en scène"
-    de: "Bühnenbildner"
-    en: Artist
-    es: Puestista
-    pl: Artysta
-asn: 
-  label: 
-    it: Altro nome
-    fr: Autre nom
-    de: Weiterer Name
-    en: Other
-    es: Otro nombre
-    pl: Pozostałe
-aut: 
-  label: 
-    it: Autore
-    fr: Auteur
-    de: Autor
-    en: Author
-    es: Autor
-    pl: Autor
-bnd: 
-  label: 
-    it: Rilegatore
-    fr: Relieur
-    de: Buchbinder
-    en: Binder
-    es: Encuadernador
-    pl: Introligator
-bsl: 
-  label: 
-    it: Libraio musicale
-    fr: Libraire
-    de: "Musikalienhändler"
-    en: Bookseller
-    es: Librero
-    pl: Księgarz
-ccp: 
-  label: 
-    it: Autore della fonte letteraria
-    fr: Auteur du texte
-    de: Autor der Textvorlage
-    en: Conceptor
-    es: "Autor del concepto"
-    pl: Autor koncepcji
-chr: 
-  label: 
-    it: Coreografo
-    fr: "Chorégraphe"
-    de: Choreograph
-    en: Choreographer
-    es: "Coreógrafo"
-    pl: Choreograf
-clb: 
-  label: 
-    it: Autore secondario
-    fr: Collabarateur
-    de: Mitverfasser
-    en: Contributer
-    es: Colaborador
-    pl: Kontrybutor
-cmp: 
-  label: 
-    it: Rimando ad altro compositore
-    fr: Compositeur / Co-compositeur
-    de: Komponistenquerverweis
-    en: Composer cross-reference
-    es: Referencia cruzada de compositor
-    pl: Odniesienie do innego kompozytora
-cnd: 
-  label: 
-    it: Direttore d'orchestra
-    fr: Chef d'orchestre
-    de: Dirigent
-    en: Conductor
-    es: Director musical
-    pl: Dyrygent
-cns: 
-  label: 
-    it: Censore
-    fr: Censeur
-    de: Zensor
-    en: Censor
-    es: Censor
-    pl: Cenzor
-com: 
-  label: 
-    it: Compilatore
-    fr: Compilateur
-    de: Kompilator
-    en: Compiler
-    es: Compilador
-    pl: Kompilator
-cst: 
-  label: 
-    it: Costumista
-    fr: Costumier
-    de: "Kostümbildner"
-    en: Costume designer
-    es: Vestuarista
-    pl: Projektant kostiumów
-ctb: 
-  label: 
-    it: Compositore secondario
-    fr: Contributeur
-    de: Mitkomponist
-    en: Co-composer
-    es: Co-compositor
-    pl: Współkompozytor
-dnc: 
-  label: 
-    it: Ballerino
-    fr: Danceur
-    de: "Tänzer"
-    en: Dancer
-    es: "Bailarín(a)"
-    pl: Tancerz
-dnr: 
-  label: 
-    it: Donatore
-    fr: Donateur
-    de: Donator
-    en: Donor
-    es: Donante
-    pl: Donator
-dpt: 
-  label: 
-    it: Depositante
-    fr: Dépositeur
-    de: Depositor
-    en: Depositor
-    es: Depositante
-    pl: Deponent
-dsr: 
-  label: 
-    it: Progettista
-    fr: Décorateur
-    de: Designer
-    en: Designer
-    es: "Diseñador"
-    pl: Projektant
-dte: 
-  label: 
-    it: Dedicatario
-    fr: "Dédicataire"
-    de: "Widmungsträger"
-    en: Dedicatee
-    es: "Dedicatario(a)"
-    pl: Adresat dedykacji
-asn: 
-  label: 
-    it: Nome associato
-    fr: Nom associé
-    de: Zugehöriger Name
-    en: Associated name
-    es: Nombre asociado
-    pt: Nome associado
-    pl: Niepewne
-edt: 
-  label: 
-    it: Curatore
-    fr: Editeur
-    de: Herausgeber
-    en: Editor
-    es: Incierto
-    pl: Edytor
-egr: 
-  label: 
-    it: Incisore
-    fr: Graveur
-    de: Stecher
-    en: Engraver
-    es: Editor
-    pl: Rytownik
-evp:
-  label: 
-    it: "Luogo dell’evento"
-    fr: "Lieu de l'énénement"
-    de: Veranstaltungsort
-    en: Event place
-    es: Lugar del evento
-    pl: Miejsce wydarzenia
-fmo: 
-  label: 
-    it: Proprietario precedente
-    fr: "Propriétaire précédent"
-    de: Vorbesitzer
-    en: Former owner
-    es: Propietario anterior
-    pl: Poprzedni właściciel
-ill: 
-  label: 
-    it: Disegnatore
-    fr: Illustrateur
-    de: Illustrator
-    en: Illustrator
-    es: Ilustrador
-    pl: Ilustrator
-itr: 
-  label: 
-    it: Strumentista
-    fr: Instrumentiste
-    de: Instrumentalist
-    en: Instrumentalist
-    es: Instrumentista
-    pl: Instrumentalista
-lbt: 
-  label: 
-    it: Librettista
-    fr: Librettiste
-    de: Librettist
-    en: Librettist
-    es: Libretista
-    pl: Autor libretta
-ltg: 
-  label: 
-    it: Litografo
-    fr: Litographe
-    de: Lithograph
-    en: Lithographer
-    es: "Litógrafo"
-    pl: Litograf
-lyr: 
-  label: 
-    it: Poeta
-    fr: Parolier
-    de: Textdichter
-    en: Text author
-    es: Autor del texto
-    pl: Autor tekstu
-oth: 
-  label: 
-    it: Altra funzione
-    fr: Autre function
-    de: Sonstige Funktion
-    en: Other
-    es: "Otra función"
-    pl: Pozostałe
-otm: 
-  label: 
-    it: Organizzatore
-    fr: Organisateur
-    de: Veranstalter
-    en: Event organizer
-    es: Organizador de evento
-    pl: Organizator wydarzenia
-pat: 
-  label: 
-    it: Committente
-    fr: "Mécène"
-    de: "Mäzen/Auftraggeber"
-    en: Patron
-    es: Comitente
-    pl: Sponsor
-pbl: 
-  label: 
-    it: Editore
-    fr: Editeur
-    de: Verleger
-    en: Publisher
-    es: Editor
-    pl: Wydawca
-ppm: 
-  label: 
-    it: Fabbricante di carta
-    fr: Papetier
-    de: Papierhersteller
-    en: Papermaker
-    es: Fabricante de papel
-    pl: Producent papieru
-prd: 
-  label: 
-    it: Personale alla produzione
-    fr: "Personnel de réalisation"
-    de: Produktionspersonal
-    en: Production personnel
-    es: "Personal de producción"
-    pl: Personel produkcyjny
-prf: 
-  label: 
-    it: Interprete
-    fr: "Interprète"
-    de: Interpret
-    en: Performer
-    es: "Intérprete"
-    pl: Wykonawca
-prt: 
-  label: 
-    it: Stampatore
-    fr: Imprimeur
-    de: Drucker
-    en: Printer
-    es: Impresor
-    pl: Drukarnia
-pub: 
-  label: 
-    it: Editore
-    fr: Editeur
-    de: Verleger
-    en: Publisher
-    es: Editor
-    pl: Wydawca
-scr: 
-  label: 
-    it: Copista
-    fr: Copiste / Scribe
-    de: Schreiber
-    en: Copyist
-    es: Copista
-    pl: Kopista
-trl: 
-  label: 
-    it: Traduttore
-    fr: Traducteur
-    de: "Übersetzer"
-    en: Translator
-    es: Traductor
-    pl: Tłumacz
-voc: 
-  label: 
-    it: Cantante
-    fr: Vocaliste
-    de: "Sänger"
-    en: Vocalist
-    es: Cantante
-    pl: Wokalista
-#Attribution qualifier for 100/700$j
-"Verified":
-  label:
-    it: Verificato
-    fr: "Vérifié"
-    de: Gesichert
-    en: Verified
-    es: Verificada
-    pl: Zweryfikowane
-"Ascertained":   
-  label:
-    it: Accertato
-    fr: "Authentifié"
-    de: Ermittelt
-    en: Ascertained
-    es: Certificada
-    pl: Stwierdzone
-"Alleged":   
-  label:
-    it: Presunto
-    fr: "Présumé"
-    de: Angeblich
-    en: Alleged
-    es: Supuesta
-    pl: Domniemane
-"Doubtful":   
-  label:
-    it: Dubbio
-    fr: "Douteux"
-    de: Zweifelhaft
-    en: Doubtful
-    es: Dudosa
-    pl: Wątpliwe
-"Misattributed":   
-  label:
-    it: Attribuito erroneamente
-    fr: "Erroné"
-    de: Fälschlich
-    en: Misattributed
-    es: Mal atribuida
-    pl: Błędnie przypisane
-"Conjectural":   
-  label:
-    it: Congetturale
-    fr: Conjectural
-    de: Mutmaßlich
-    en: Conjectural
-    es: Conjetural
-    pl: Spekulatywne
-#Physical medium (340 $a) - currently not used by the partial
+'000':
+  label: records.leader
+'001':
+  label: records.rism_id_number
+01_codes_artistic:
+  label: records.artistic_production
+02_codes_performing:
+  label: records.performance
+'035':
+  fields:
+    a:
+      label: records.local_id_number
+  label: records.local_id_number
+03_codes_technical:
+  label: records.technical_production
+04_codes_other:
+  label: records.other
+'300':
+  fields:
+    '8':
+      label: records.set
+    a:
+      label: records.format_extent
+    b:
+      label: records.other_physical_details
+    c:
+      label: records.dimensions
+  label: records.physical_description
+'500':
+  fields:
+    '8':
+      label: records.set
+    a:
+      label: records.general_note_institution
+  label: records.general_note_institution
+'506':
+  fields:
+    a:
+      label: records.access_restrictions
+  label: records.access_restrictions
+'518':
+  fields:
+    a:
+      label: records.performer_note
+  label: records.note_on_performance
+'541':
+  fields:
+    a:
+      label: records.source_of_acquisition_note
+    c:
+      label: records.method_of_acquisition
+    d:
+      label: records.date_of_acquisition
+    e:
+      label: records.accession_number
+  label: records.source_of_acquisition_note
+'561':
+  fields:
+    a:
+      label: records.provenance_notes
+  label: records.provenance_notes
+'563':
+  fields:
+    a:
+      label: records.binding_note
+  label: records.binding_note
+'591':
+  fields:
+    a:
+      label: records.other_shelfmark
+  label: records.other_shelfmark
+'592':
+  fields:
+    '8':
+      label: records.set
+    a:
+      label: records.watermark_description
+  label: records.watermark_description
+'593':
+  fields:
+    a:
+      label: records.type
+  label: records.source_type
+'599':
+  fields:
+    a:
+      label: records.local_notes_field
+  label: records.local_notes_field
+'651':
+  fields:
+    a:
+      label: records.location_performance
+  label: records.location_performance
+'691':
+  fields:
+    a:
+      label: records.bibliographic_reference
+    n:
+      label: records.number_page
+  label: records.bibliographic_reference
+'700':
+  fields:
+    '4':
+      label: records.function
+    '8':
+      label: records.set
+    a:
+      label: records.name
+    d:
+      label: records.life_dates
+    j:
+      label: records.attribution_qualifier
+  label: records.additional_personal_name
+'710':
+  fields:
+    '4':
+      label: records.function
+    '8':
+      label: records.set
+    a:
+      label: records.institution
+    b:
+      label: records.department
+    g:
+      label: records.attribution_qualifier
+  label: records.additional_institution
+'852':
+  fields:
+    a:
+      label: records.library_siglum
+    b:
+      label: records.department
+    c:
+      label: records.shelfmark
+    d:
+      label: records.shelfmark_olim
+    e:
+      label: records.library
+    q:
+      label: records.material_held
+    u:
+      label: general.uri
+    z:
+      label: records.provenance
+  label: records.library_siglum
+'856':
+  fields:
+    u:
+      label: records.external_resource
+    x:
+      label: records.link_type
+    z:
+      label: records.note_external_resource
+  label: records.external_resource_uri
+'963':
+  fields:
+    u:
+      label: records.temp_val
+  label: records.non_migrated_bound
+'973':
+  fields:
+    u:
+      label: records.bound_with
+  label: records.bound_with
+Alleged:
+  label: records.alleged
+Ascertained:
+  label: records.ascertained
 Autography:
-  label:
-    it: "Autografia"
-    fr: "Autographie"
-    de: "Autographie"
-    en: "Autography"
-    es: "Autógrafo"
-    pl: Autografia
-"Computer printout":
-  label:
-    it: "Stampata da computer"
-    fr: "Impression informatique"
-    de: "Computerausdruck"
-    en: "Computer printout"
-    es: "Impreso de computadora"
-    pl: Wydruk komputerowy
+  label: records.autography
+Computer printout:
+  label: records.computer_printout
+Conjectural:
+  label: records.conjectural
+Digitalization:
+  label: records.digitized_music
+Doubtful:
+  label: records.doubtful
 Engraving:
-  label:
-    it: "Incisione"
-    fr: "Gravure"
-    de: "Stich"
-    en: "Engraving"
-    es: "Grabado"
-    pl: Sztych
+  label: records.engraving
 Facsimile:
-  label:
-    it: "Facsimile"
-    fr: "Facsimile"
-    de: "Faksimile"
-    en: "Facsimile"
-    es: "Facsímil"
-    pl: Faksymile
+  label: records.facsimile
+IIIF:
+  label: records.iiif_manifest
 Lithography:
-  label:
-    it: "Litografia"
-    fr: "Lithographie"
-    de: "Lithographie"
-    en: "Lithography"
-    es: "Litografía"
-    pl: Litografia
-"Photoreproductive process":
-  label:
-    it: "Cianografia"
-    fr: "Reproduction photo (blueprint)"
-    de: "Blaupause"
-    en: "Photoreproductive process (bluprint)"
-    es: "Proceso fotoreproductivo"
-    pl: Proces optyczny (światłokopia)
+  label: records.lithography
+Misattributed:
+  label: records.misattributed
+Other:
+  label: records.other
+Photoreproductive process:
+  label: records.photoreproductive_process
 Reproduction:
-  label:
-    it: "Riproduzione"
-    fr: "Reproduction"
-    de: "Reproduktion"
-    en: "Reproduction"
-    es: "Reproducción"
-    pl: Reprodukcja
+  label: records.reproduction
 Transparency:
-  label:
-    it: "Trasparente"
-    fr: "Transparent"
-    de: "Transparentfolie"
-    en: "Transparency"
-    es: "Transparencia"
-    pl: Przezrocze
+  label: records.transparency
 Typescript:
-  label:
-    it: "Dattiloscritto"
-    fr: "Tapuscrit"
-    de: "Typescript"
-    en: "Typescript"
-    es: "Escrito mecanografiado"
-    pl: Maszynopis
+  label: records.typescript
 Typography:
-  label:
-    it: "Stampa tipografica"
-    fr: "Typographie"
-    de: "Typendruck"
-    en: "Typography"
-    es: "Tipografía"
-    pl: Typografia
-IIIF: 
-  label: 
-    it: "Manifesto IIIF"
-    fr: "Manifeste IIIF"
-    de: "IIIF manifest"
-    en: "IIIF manifest"
-    es: "Manifiesto IIIF"
-    pl: Manifest IIIF
-Digitalization: 
-  label: 
-    it: "Fonte digitalizzata"
-    fr: "Sources numérisées"
-    de: "Notendigitalisat"
-    en: "Digitized music"
-    es: "Música digitalizada"
-    pl: Cyfrowa reprodukcja źródła
-Other: 
-  label: 
-    it: "Altro"
-    fr: "Autre"
-    de: "Sonstiges"
-    en: "Other"
-    es: "Otro"
-    pl: Pozostałe
+  label: records.typography
+Verified:
+  label: general.verified
+arr:
+  label: records.arranger
+art:
+  label: records.artist
+asn:
+  label: records.associated_name
+aut:
+  label: records.author
+bnd:
+  label: records.binder
+bsl:
+  label: records.bookseller
+ccp:
+  label: records.conceptor
+chr:
+  label: records.choreographer
+clb:
+  label: records.contributor
+cmp:
+  label: records.composer_cross_reference
+cnd:
+  label: records.conductor
+cns:
+  label: records.censor
+com:
+  label: records.compiler
+cst:
+  label: records.costume_designer
+ctb:
+  label: records.co-composer
+dnc:
+  label: records.dancer
+dnr:
+  label: records.donor
+doc_abbr_dates:
+  label: records.dates
+doc_abbr_general:
+  label: records.general_abbreviations
+doc_abbr_keys:
+  label: records.keys
+doc_abbr_lang:
+  label: records.language_codes
+doc_abbr_modes:
+  label: records.ecclesiastical_modes
+doc_abbr_voices_instr:
+  label: records.terms_voices_instruments
+doc_abbr_voices_instr2:
+  label: general.rism_instrument_abbreviations
+doc_abbreviations:
+  label: records.abbreviations_terminology
+doc_added_entries:
+  label: records.added_entry_name
+doc_administration:
+  label: records.administration
+doc_aid:
+  label: records.aids
+doc_aid_liturgical_feasts:
+  label: records.liturgical_festivals
+doc_aid_locations:
+  label: records.location_on_source
+doc_aid_texts_sacred_works:
+  label: records.standard_texts_sacred_works
+doc_aid_titles_keywords:
+  label: records.standardized_titles_subject_headings
+doc_aid_transposing_instruments:
+  label: records.help_transposing_instruments
+doc_bibliographical_reference:
+  label: records.references
+doc_cat_authorities:
+  label: records.authorities
+doc_cat_collections:
+  label: records.cataloging_collection_convoluta
+doc_cat_templates:
+  label: records.templates
+doc_cataloguing:
+  label: records.general_cataloguing_guidelines
+doc_content:
+  label: records.content
+doc_date:
+  label: records.dates
+doc_diplomatic_title:
+  label: records.diplomatic_title
+doc_edit_functions:
+  label: records.basic_functions
+doc_edit_searching:
+  label: general.searching
+doc_edit_workflow:
+  label: general.workflow
+doc_editor:
+  label: general.using_muscat
+doc_images:
+  label: records.images
+doc_incipit:
+  label: records.incipits
+doc_institutions:
+  label: records.institutions
+doc_introduction:
+  label: records.introduction
+doc_library:
+  label: records.library_information
+doc_linkage:
+  label: records.linkage
+doc_main_entry_fields:
+  label: records.main_entry_fields
+doc_masks:
+  label: records.cataloging_musical_sources
+doc_name_variants:
+  label: records.name_variants
+doc_numbers:
+  label: records.numbers_code_fields
+doc_people:
+  label: records.people_institutions
+doc_performance:
+  label: records.performances
+doc_personal_names:
+  label: records.personal_names
+doc_physical_description:
+  label: records.material_description
+doc_provenance:
+  label: records.provenance
+doc_references:
+  label: records.references
+doc_relations:
+  label: records.relations
+doc_tag_index:
+  label: general.index_marc_fields
+doc_title:
+  label: records.title_content_description
+dpt:
+  label: records.depositor
+dsr:
+  label: records.designer
+dte:
+  label: records.dedicatee
+edit_administration:
+  label: records.administration
+edit_library:
+  label: records.library_information_relations
+edit_material:
+  label: records.material_description
+edit_names:
+  label: records.people_institutions
+edit_references:
+  label: records.references_and_notes
+edt:
+  label: records.editor
+egr:
+  label: records.engraver
+evp:
+  label: records.event_place
+fmo:
+  label: records.former_owner
+ill:
+  label: records.illustrator
+itr:
+  label: records.instrumentalist
+lbt:
+  label: records.librettist
+ltg:
+  label: records.lithographer
+lyr:
+  label: records.text_author
+oth:
+  label: records.other
+otm:
+  label: records.event_organizer
+pat:
+  label: records.patron
+pbl:
+  label: records.publisher
+ppm:
+  label: records.papermaker
+prd:
+  label: records.production_personnel
+prf:
+  label: records.performer
+prt:
+  label: records.printer
+pub:
+  label: records.publisher
+scr:
+  label: records.copyist
+show_admin:
+  label: records.administration
+show_content:
+  label: records.content
+show_distribution:
+  label: records.distribution
+show_information:
+  label: records.further_information
+show_library:
+  label: records.library_information
+show_links:
+  label: records.related_titles
+show_material:
+  label: records.material_description
+show_references:
+  label: records.references
+show_resources:
+  label: records.related_resources
+show_summary:
+  label: records.summary
+show_terms:
+  label: records.index_terms
+trl:
+  label: records.translator
+unmatched:
+  label: general.unknown_fields
+voc:
+  label: records.vocalist

--- a/config/editor_profiles/default/configurations/InstitutionLabels.yml
+++ b/config/editor_profiles/default/configurations/InstitutionLabels.yml
@@ -1,1671 +1,444 @@
---- !map:ActiveSupport::HashWithIndifferentAccess
-
-doc_abbreviations:
-  label:
-    it: Abbreviazioni
-    de: "Abkürzungen"
-    en: Abbreviations
-    es: Abreviaturas
-    pl: Skróty
-doc_aid:
-  label:
-    it: Aiuti
-    de: Arbeitshilfen
-    en: Aide
-    es: Asistencia
-    pl: Asystent
-doc_cataloguing_collections:
-  label:
-    it: Catalogazione di raccolte e volumi compositi
-    de: Erfassung von Sammlungen
-    en: Cataloging collection and convoluta
-    es: "Catalogación de colecciones y volúmenes compuestos"
-    pl: Katalogowanie kolekcji i klocka introligatorskiego
-doc_edit_functions:
-  label:
-    it: Funzioni base
-    de: "Grundsätzliche Funktionen"
-    en: Basic functions
-    es: "Funciones básicas"
-    pl: Podstawowe funkcje
-doc_introduction:
-  label:
-    it: Introduzione
-    de: Einleitung
-    en: Introduction
-    es: "Introducción"
-    pl: Wprowadzenie
-doc_masks:
-  label:
-    it: Formulari di catalogazione
-    de: Masken
-    en: Cataloging forms
-    es: "Formularios de catalogación"
-    pl: Formularze katalogowania
-doc_tag_index:
-  label:
-    it: indice dei campi MARC
-    de: MARC Tag Index
-    en: MARC tag index
-    es: "Índice de etiquetas MARC"
-    pl: Indeks znaczników MARC
-doc_templates:
-  label:
-    it: Template
-    de: Templates
-    en: Templates
-    es: Plantillas
-    pl: Szablony
-"000":
-  label:
-    it: Leader
-    fr: Guide
-    de: Leader
-    en: Leader
-    es: "Líder"
-    pl: Leader
-"001":
-  label:
-    it: Numero documento RISM
-    fr: No. RISM
-    de: RISM Dokumentnummer
-    en: RISM ID no.
-    es: "Número de ID de RISM"
-    pl: RISM ID
-"003":
-  label:
-    it: Identificatore del numero di controllo
-    fr: "Identité du numéro de contrôle"
-    de: Kontrollnummer-Bezeichnung
-    en: Control number identifier
-    es: "Identificador de número de control"
-    pl: Identyfikator numeru kontrolnego
-"005":
-  label:
-    it: Data e ora dell'ultima transazione
-    fr: "Date/heure de la dernière transaction"
-    de: Datum und Zeit der letzten Transaktion
-    en: Date and time of last transaction
-    es: "Fecha y hora de la última transacción"
-    pl: Data i godzina ostatniej operacji
-"008":
-  label:
-    it: Data di creazione
-    fr: Date de création
-    de: Datum der Erstellung
-    en: Date of creation
-    es: "Fecha de creación"
-    pl: Data utworzenia
-"024":
-  label:
-    it: "Riferimento autorità"
-    fr: "Référence d'authorité"
-    de: Normdatenverweise
-    en: Authority Reference
-    es: Referencia de autoridad
-    pl: Odniesienie do bazy haseł wzorcowych
+'000':
+  label: records.leader
+'001':
+  label: records.rism_id_number
+'003':
+  label: records.control_number_identifier
+'005':
+  label: records.date_time_last_transaction
+008:
+  label: records.date_of_creation
+01_codes_artistic:
+  label: records.artistic_production
+'024':
   fields:
+    '2':
+      label: records.authority_agency
     a:
-      label:
-        it: "Riferimento autorità"
-        fr: "Référence d'authorité"
-        de: Normdatenverweise
-        en: Authority Reference
-        es: Referencia de autoridad
-        pl: Odniesienie do bazy haseł wzorcowych
-    "2":
-      label:
-        it: "Agenzia autorità"
-        fr: "Agence d'authorité"
-        de: Normdatenagentur
-        en: Authority Agency
-        es: Agencia de autoridad
-        pl: Baza haseł wzorcowych
-"034":
-  label:
-    it: Posizione
-    fr: Position
-    de: Position
-    en: Location
-    es: Ubicación
-    pl: Lokalizacja
+      label: records.authority_reference
+  label: records.authority_reference
+02_codes_performing:
+  label: records.performance
+'034':
   fields:
     d:
-      label:
-        it: Longitudine
-        fr: Longitude
-        de: Längengrad 
-        en: Longitude
-        es: Longitud
-        pl: Długość geograficzna
+      label: records.longitude
     f:
-      label:
-        it: Latitudine
-        fr: Latitude
-        de: Breitengrad 
-        en: Latitude
-        es: Latitud
-        pl: Szerokość geograficzna
-"040":
-  label:
-    it: Fonte della catalogazione
-    fr: Source du catalogage
-    de: Katalogisierungsquelle
-    en: Cataloguing agency
-    es: "Agencia de catalogación"
-    pl: Jednostka katalogująca
+      label: records.latitude
+  label: records.location
+03_codes_technical:
+  label: records.technical_production
+'040':
   fields:
     a:
-      label:
-        it: Agenzia catalografica originale
-        fr: Organisme du catalogage original
-        de: Original-Katalogisierungsstelle
-        en: Original cataloguing agency
-        es: "Agencia de catalogación original"
-        pl: Jednostka katalogująca pierwotny rekord
+      label: records.original_cataloging_agency
     b:
-      label:
-        it: Lingua della catalogazione
-        fr: Langue de catalogage
-        de: Katalogisierungssprache
-        en: Language of cataloguing
-        es: "Idioma de la catalogación"
-        pl: Język katalogowania
+      label: records.language_of_cataloging
     c:
-      label:
-        it: Agenzia della trascrizione
-        fr: Organisme de la transcription
-        de: "Übertragende Katalogisierungsstelle"
-        en: Transcribing agency
-        es: "Agencia de la transcripción"
-        pl: Jednostka transkrybująca
+      label: records.transcribing_agency
     d:
-      label:
-        it: Agenzia della modifica
-        fr: Organisme de la modification
-        de: Modifizierende Katalogisierungsstelle
-        en: Modifying agency
-        es: "Agencia de la modificación"
-        pl: Jednostka modyfikująca
-
-
-"043":
-  label:
-    it: Codice del Paese
-    fr: Country code
-    de: Länder-Code
-    en: Country code
-    es: "Código de país"
-    pl: Kod kraju
+      label: records.modifying_agency
+  label: records.cataloging_agency
+'043':
   fields:
     c:
-      label:
-        it: Codice del Paese
-        fr: Country code
-        de: Länder-Code  
-        en: Country code
-        es: "Código de país"
-        pl: Kod kraju
-"110":
-  label:
-    it: Nome di ente
-    fr: "Nom de la collectivité"
-    de: "Körperschaftsname"
-    en: Institution
-    es: "Institución"
-    pl: Instytucja
-  accepts: 
-  - "710"
+      label: records.country_code
+  label: records.country_code
+04_codes_other:
+  label: records.other
+'110':
   fields:
     a:
-      label:
-        it: Nome di ente
-        fr: "Nom de la collectivité"
-        de: "Körperschaftsname"
-        en: Institution
-        es: "Institución"
-        pl: Instytucja
+      label: records.institution
     b:
-      label:
-        it: Ente subordinato
-        fr: "Collectivité subordonnée"
-        de: "Untergeordnete Körperschaft"
-        en: Subordinate unit
-        es: Unidad subordinada
-        pl: Jednostka podporządkowana
+      label: records.subordinate_unit
     c:
-      label:
-        it: Luogo
-        fr: Place 
-        de: Ort
-        en: Place
-        es: Lugar
-        pl: Miejsce
+      label: records.place
     g:
-      label:
-        it: Sigla
-        fr: "Siglum"
-        de: "Sigel"
-        en: Siglum
-        es: Sigla
-        pl: Siglum
-"368":
-  label:
-    it: Tipo di ente
-    fr: "Type d'institution"
-    de: Typ der Körperschaft
-    en: Type of Institution
-    es: "Tipo de institución"
-    pl: Rodzaj instytucji
+      label: records.siglum
+  label: records.institution
+'368':
   fields:
     a:
-      label:
-        it: Tipo di ente
-        fr: "Type d'institution"
-        de: Typ der Körperschaft
-        en: Type of institution
-        es: "Tipo de institución"
-        pl: Rodzaj instytucji
-"371":
-  label:
-    it: Luogo ed indirizzo
-    fr: Lieu et adresse
-    de: "Adresse"
-    en: Location and Address
-    es: "Ubicación y dirección"
-    pl: Lokalizacja i adres
+      label: records.type_institution
+  label: records.type_institution
+'371':
   fields:
     a:
-      label:
-        it: Via e numero civico
-        fr: "Nom de la collectivité"
-        de: Strasse
-        en: Street address
-        es: "Calle y número"
-        pl: Ulica, numer, numer lokalu
-    e:
-      label:
-        it: Codice postale
-        fr: Code Postal
-        de: Postleitzahl
-        en: Postal code
-        es: "Código postal"
-        pl: Kod pocztowy
+      label: records.street_address
     b:
-      label:
-        it: "Città"
-        fr: Ville
-        de: Ort
-        en: City
-        es: Ciudad
-        pl: Miejscowość
+      label: records.city
     c:
-      label:
-        it: Cantone o provincia
-        fr: Canton ou province
-        de: Bezirk oder Staat
-        en: County or province
-        es: "País o provincia"
-        pl: Stan, hrabstwo, prowincja...
+      label: records.county_province
     d:
-      label:
-        it: Paese
-        fr: Pays
-        de: Land
-        en: Country
-        es: "País"
-        pl: Kraj
+      label: records.country
+    e:
+      label: records.postal_code
     m:
-      label:
-        it: E-mail
-        fr: E-Mail
-        de: E-Mail
-        en: E-mail
-        es: E-mail
-        pl: E-mail
+      label: general.e_mail
     u:
-      label:
-        it: URL
-        fr: URL
-        de: URL
-        en: URL
-        es: URL
-        pl: URL
+      label: general.url
     z:
-      label:
-        it: Altri dati sul contatto
-        fr: Note publique
-        de: Bemerkungen
-        en: Public Note
-        es: "Nota pública"
-        pl: Inne informacje kontaktowe
-"410":
-  label:
-    it: Altre forme del nome
-    fr: Autre forme de nom
-    de: Andere Namensformen
-    en: Other form of name
-    es: Otra forma del nombre
-    pl: Wariant nazwy instytucji
+      label: records.public_note
+  label: records.location_and_address
+'410':
   fields:
     a:
-      label:
-        it: Altre forme del nome
-        fr: Autre forme de nom
-        de: Andere Namensformen
-        en: Other form of name
-        es: Otra forma del nombre
-        pl: Wariant nazwy instytucji
-"510":
-  label:
-    it: Forma parallela del nome
-    fr: Forme de nom parallèle
-    de: Parallele Namensformen
-    en: Parallel form of name
-    es: Forma paralela del nombre
-    pl: Współistniejąca forma nazwy
+      label: records.other_form_of_name
+  label: records.other_form_of_name
+'510':
   fields:
     a:
-      label:
-        it: Forma parallela del nome
-        fr: Forme de nom parallèle
-        de: Namensvarianten  
-        en: Parallel form of name
-        es: Forma paralela del nombre
-        pl: Współistniejąca forma nazwy
-"551":
-  label:
-    it: Luoghi
-    fr: Lieu
-    de: Orte
-    en: Places
-    es: Lugares
-    pl: Miejsca
+      label: records.parallel_form
+  label: records.parallel_form
+'551':
   fields:
     a:
-      label:
-        it: Luogo
-        fr: Lieu
-        de: Ort
-        en: Place
-        es: Lugares
-        pl: Miejsce
-"580":
-  label:
-    it: Ora in
-    fr: Maintenant à
-    de: Heute in
-    en: Now in
-    es: Actualmente en
-    pl: Obecnie w …
+      label: records.place
+  label: records.places
+'580':
   fields:
     x:
-      label:
-        it: Ora in
-        fr: Maintenant à
-        de: Heute in
-        en: Now in
-        es: Actualmente en
-        pl: Obecnie w …
-"667":
-  label:
-    it: Nota interna
-    fr: Note interne
-    de: Interne Bemerkungen
-    en: Internal Notes
-    es: Notas internas
-    pl: Uwagi wewnętrzne
+      label: records.now_in
+  label: records.now_in
+'667':
   fields:
     a:
-      label:
-        it: Nota interna
-        fr: Note interne
-        de: Interne Bemerkungen
-        en: Internal notes
-        es: Notas internas
-        pl: Uwagi wewnętrzne
-"670":
-  label:
-    it: Bibliografia
-    fr: Littérature
-    de: Literatur
-    en: Literature
-    es: Bibliografía
-    pl: Literatura
+      label: records.internal_note
+  label: records.internal_note
+'670':
   fields:
     a:
-      label:
-        it: Bibliografia
-        fr: Littérature
-        de: Literatur
-        en: Literature
-        es: Bibliografía
-        pl: Literatura
+      label: records.literature
     b:
-      label:
-        it: Informazione rinvenuta
-        fr: "Numéro/page"
-        de: Fundstelle
-        en: Information found
-        es: Información encontrada
-        pl: Odnaleziona informacja
-"678":
-  label:
-    it: "Storia dell'ente"
-    fr: "Historique de l'institution"
-    de: Geschichte der Körperschaft
-    en: History of institution
-    es: "Historia de la institución"
-    pl: Historia instytucji
+      label: records.information_found
+  label: records.literature
+'678':
   fields:
     a:
-      label:
-        it: "Storia dell'ente"
-        fr: "Historique de l'institution"
-        de: Geschichte der Körperschaft
-        en: History of institution
-        es: "Historia de la institución"
-        pl: Historia instytucji
-"680":
-  label:
-    it: Altre note sulla descrizione
-    fr: Remarque général
-    de: Allgemeine Fussnote
-    en: General note
-    es: Nota general
-    pl: Uwaga ogólna
+      label: records.history_institution
+  label: records.history_institution
+'680':
   fields:
     a:
-      label:
-        it: Altre note sulla descrizione
-        fr: Remarque générale
-        de: Allgemeine Fussnote
-        en: General note
-        es: Nota general
-        pl: Uwaga ogólna
-"700":
-  label:
-    it: Persona
-    fr: Personne
-    de: Person
-    en: Person
-    es: Persona
-    pl: Osoba
+      label: records.general_note
+  label: records.general_note
+'700':
   fields:
     a:
-      label:
-        it: Persona
-        fr: Personne
-        de: Person
-        en: Person
-        es: Persona
-        pl: Osoba
-
-"710":
-  label:
-    it: Ente correlato
-    fr: Institution liée
-    de: in Beziehung stehende Körpschaft
-    en: Related institution
-    es: "Institución relacionada"
-    pl: Powiązana instytucja
+      label: records.person
+  label: records.person
+'710':
   fields:
     a:
-      label:
-        it: Ente correlato
-        fr: Institution liée
-        de: In Beziehung stehende Körperschaft
-        en: Related institution
-        es: "Institución relacionada"
-        pl: Powiązana instytucja
-
-"856":
-  label:
-    it: Aiuti alla ricerca, guide e pubblicazioni
-    fr: En Ligne
-    de: Archivführer und andere Publikationen
-    en: Online finding aids
-    es: Asistencia online encontrada
-    pl: Pomoce do wyszukiwania on-line
+      label: records.related_institution
+  label: records.related_institution
+'856':
   fields:
     u:
-      label:
-        it: Aiuti alla ricerca, guide e pubblicazioni
-        fr: En Ligne
-        de: Archivführer und andere Publikationen
-        en: Online finding aids
-        es: Asistencia online encontrada
-        pl: Pomoce do wyszukiwania on-line
+      label: records.online_finding_aids
     z:
-      label:
-        it: Nota
-        fr: Note
-        de: Bemerkung
-        en: Note
-        es: Nota
-        pl: Uwaga
-
-
-main:
-  label:
-    it: Campi principali
-    fr: "Entrées principales"
-    de: Haupteintragungen
-    en: Main entry fields
-    es: Campos principales
-    pl: Główne pola edycji
-codes:
-  label:
-    it: Numeri e codici
-    fr: "Numéros et codes"
-    de: Nummern und Codes
-    en: Numbers and code fields
-    es: Números y códigos
-    pl: Pola liczb i kodów
-control:
-  label:
-    fr: "Champs de contrôle"
-    de: Kontrollfelder
-    it: Campi di controllo
-    en: Control Fields
-    es: Campos de control
-    pl: Pola kontrolne
-notes:
-  label:
-    it: Note
-    fr: Notes
-    de: Fussnoten
-    en: Note fields
-    es: Notas
-    pl: Pola uwag
-other:
-  label:
-    it: Varia
-    fr: Divers
-    de: Verschiedenes
-    en: Miscellaneous
-    es: Varios
-    pl: Pozostałe
-administration:
-  label:
-    it: Amministrazione
-    fr: Administration
-    de: Administration
-    en: Administration
-    es: Administración
-    pl: Administracja
-sigla:
-  label:
-    it: Sigla
-    fr: Sigla
-    de: Sigel
-    en: Sigla
-    es: Sigla
-    pl: Sigla
-contact:
-  label:
-    it: Contatto
-    fr: Contact
-    de: Kontakt
-    en: Contact
-    es: Contacto
-    pl: Kontakt
-identity:
-  label:
-    it: "Identità"
-    fr: "Identité"
-    de: Identifizierung
-    en: Identity
-    es: Identidad
-    pl: Tożsamość
-description:
-  label:
-    it: Descrizione
-    fr: Description
-    de: Beschreibung
-    en: Description
-    es: Decripción
-    pl: Opis
-
-
-
-
-# Person related
-01_codes_artistic:
-  label:
-    it: Autore
-    fr: Auteur
-    de: Verfasser
-    en: Artistic production
-    es: "Producción artística"
-    pl: Autor produkcji artystycznej
-02_codes_performing:
-  label:
-    it: Partecipanti
-    fr: Performance
-    de: Mitwirkende
-    en: Performance
-    es: Interpretación
-    pl: Wykonanie
-03_codes_technical:
-  label:
-    it: Produttore
-    fr: "Création"
-    de: Hersteller
-    en: Technical production
-    es: "Producción técncia"
-    pl: Produkcja techniczna
-04_codes_other:
-  label:
-    it: Altri
-    fr: Autre
-    de: Weitere
-    en: Other
-    es: Otro
-    pl: Pozostałe
-ed:
-  label:
-    it: Edizione
-    fr: "édition"
-    de: Edition
-    en: Edition
-    es: Edición
-    pl: Edycja
+      label: records.note_external_resource
+  label: records.online_finding_aids
+Archive:
+  label: records.archive
+Documentation center:
+  label: records.documentation_center
 H:
-  label:
-    it: Curatore
-    fr: Editeur
-    de: Herausgeber
-    en: Editor
-    es: "Editor (curador)/Editorial"
-    pl: Edytor
+  label: records.editor
+Institution:
+  label: records.institution
+Library:
+  label: records.library
+Museum:
+  label: records.museum
+Other:
+  label: records.other
+Printer:
+  label: records.printer
+Publisher:
+  label: records.publisher
+Research institute:
+  label: records.research_institute
+XA-AT:
+  label: places.austria
+XA-AT-2:
+  label: places.austria_carinthia
+XA-AT-3:
+  label: places.austria_lower_austria
+XA-AT-4:
+  label: places.austria_upper_austria
+XA-AT-5:
+  label: places.austria_salzburg
+XA-AT-6:
+  label: places.austria_styria
+XA-AT-7:
+  label: places.austria_tyrol
+XA-AT-9:
+  label: places.austria_vienna
+XA-BE:
+  label: places.belgium
+XA-BG:
+  label: places.bulgaria
+XA-CH:
+  label: places.switzerland
+XA-CH-VD:
+  label: places.switzerland_vaud
+XA-CZ:
+  label: places.czech_republic
+XA-DE:
+  label: places.germany
+XA-DE-BY:
+  label: places.germany_bavaria
+XA-DE-SN:
+  label: places.germany_saxony
+XA-DK:
+  label: places.denmark
+XA-EE:
+  label: places.estonia
+XA-ES:
+  label: places.spain
+XA-FI:
+  label: places.finland
+XA-FR:
+  label: places.france
+XA-GB:
+  label: places.uk
+XA-GB-NIR:
+  label: places.northern_ireland
+XA-GR:
+  label: places.greece
+XA-HR:
+  label: places.croatia
+XA-HU:
+  label: places.hungary
+XA-IE:
+  label: places.ireland
+XA-IS:
+  label: places.iceland
+XA-IT:
+  label: places.italy
+XA-IT-32:
+  label: places.italy_trentino_alto_adige
+XA-LT:
+  label: places.lithuania
+XA-LU:
+  label: places.luxembourg
+XA-LV:
+  label: places.latvia
+XA-MC:
+  label: places.monaco
+XA-ME:
+  label: places.montenegro
+XA-MT:
+  label: places.malta
+XA-NL:
+  label: places.netherlands
+XA-NO:
+  label: places.norway
+XA-PL:
+  label: places.poland
+XA-PT:
+  label: places.portugal
+XA-RO:
+  label: places.romania
+XA-RS:
+  label: places.serbia
+XA-RU:
+  label: places.russian_federation
+XA-SE:
+  label: places.sweden
+XA-SI:
+  label: places.slovenia
+XA-SK:
+  label: places.slovakia
+XA-UA:
+  label: places.ukraine
+XA-VA:
+  label: places.holy_see
+XB-AM:
+  label: places.armenia
+XB-CN:
+  label: places.china
+XB-HK:
+  label: places.hong_kong
+XB-ID:
+  label: places.indonesia
+XB-IL:
+  label: places.israel
+XB-IN:
+  label: places.india
+XB-IR:
+  label: places.iran
+XB-JP:
+  label: places.japan
+XB-KH:
+  label: places.cambodia
+XB-KR:
+  label: places.korea
+XB-PH:
+  label: places.philippines
+XB-SA:
+  label: places.saudi_arabia
+XB-SY:
+  label: places.syrian_arab_republic
+XB-TR:
+  label: places.turkey
+XB-TW:
+  label: places.taiwan
+XB-VN:
+  label: places.vietnam
+XC-BJ:
+  label: places.benin
+XC-DZ:
+  label: places.algeria
+XC-EG:
+  label: places.egypt
+XC-ZA:
+  label: places.south_africa
+XD-AR:
+  label: places.argentina
+XD-BR:
+  label: places.brazil
+XD-CA:
+  label: places.canada
+XD-CL:
+  label: places.chile
+XD-CO:
+  label: places.colombia
+XD-CU:
+  label: places.cuba
+XD-EC:
+  label: places.ecuador
+XD-GT:
+  label: places.guatemala
+XD-HN:
+  label: places.honduras
+XD-MX:
+  label: places.mexico
+XD-PR:
+  label: places.puerto_rico
+XD-PY:
+  label: places.paraguay
+XD-TT:
+  label: places.trinidad_tobego
+XD-US:
+  label: places.usa
+XD-UY:
+  label: places.uruguay
+XD-VE:
+  label: places.venezuela
+XE-AU:
+  label: places.australia
+XE-NZ:
+  label: places.new_zealand
+XE-PG:
+  label: places.papua_new_guinea
+administration:
+  label: records.administration
 arr:
-  label:
-    it: Arrangiatore
-    fr: Arrangeur
-    de: Bearbeiter
-    en: Arranger
-    es: Arreglador
-    pl: Aranżer
+  label: records.arranger
 art:
-  label:
-    it: Scenografo
-    fr: "Metteur en scène"
-    de: "Bühnenbildner"
-    en: Artist
-    es: Artista
-    pl: Artysta
+  label: records.artist
 asn:
-  label:
-    it: Altro nome
-    fr: Autre nom
-    de: Weiterer Name
-    en: Associated name
-    es: Nombre asociado
-    pl: Powiązana osoba
+  label: records.associated_name
 aut:
-  label:
-    it: Autore
-    fr: Auteur
-    de: Autor
-    en: Author
-    es: Autor
-    pl: Autor
+  label: records.author
 bnd:
-  label:
-    it: Rilegatore
-    fr: Relieur
-    de: Buchbinder
-    en: Binder
-    es: Encuadernador
-    pl: Introligator
+  label: records.binder
 bsl:
-  label:
-    it: Libraio musicale
-    fr: Libraire
-    de: "Musikalienhändler"
-    en: Bookseller
-    es: Librero
-    pl: Księgarz
+  label: records.bookseller
 ccp:
-  label:
-    it: Autore della fonte letteraria
-    fr: Auteur du texte
-    de: Autor der Textvorlage
-    en: Conceptor
-    es: Autor del concepto
-    pl: Autor koncepcji
+  label: records.conceptor
 chr:
-  label:
-    it: Coreografo
-    fr: "Chorégraphe"
-    de: Choreograph
-    en: Choreographer
-    es: "Coreógrafo"
-    pl: Choreograf
+  label: records.choreographer
 clb:
-  label:
-    it: Autore secondario
-    fr: Collabarateur
-    de: Mitverfasser
-    en: Collaborator
-    es: Colaborador
-    pl: Współtwórca
+  label: records.collaborator
 cmp:
-  label:
-    it: Compositore/Compositore secondario
-    fr: Compositeur / Co-compositeur
-    de: Komponist / Mitkomponist
-    en: Composer
-    es: Compositor
-    pl: Kompozytor
+  label: records.composer
 cnd:
-  label:
-    it: Direttore d'orchestra
-    fr: Chef d'orchestre
-    de: Dirigent
-    en: Conductor
-    es: Director musical
-    pl: Dyrygent
+  label: records.conductor
 cns:
-  label:
-    it: Censore
-    fr: Censeur
-    de: Zensor
-    en: Censor
-    es: Censor
-    pl: Cenzor
+  label: records.censor
+codes:
+  label: records.numbers_code_fields
 com:
-  label:
-    it: Compilatore
-    fr: Compilateur
-    de: Kompilator
-    en: Compiler
-    es: Compilador
-    pl: Kompilator
+  label: records.compiler
+contact:
+  label: records.contact
+control:
+  label: records.control_fields
 cst:
-  label:
-    it: Costumista
-    fr: Costumier
-    de: "Kostümbildner"
-    en: Costume designer
-    es: Vestuarista
-    pl: Projektant kostiumów
+  label: records.costume_designer
+description:
+  label: records.description
 dnc:
-  label:
-    it: Ballerino
-    fr: Danceur
-    de: "Tänzer"
-    en: Dancer
-    es: Bailarín(a)
-    pl: Tancerz
+  label: records.dancer
 dnr:
-  label:
-    it: Donatore
-    fr: Donateur
-    de: Donator
-    en: Donor
-    es: Donante
-    pl: Donator
+  label: records.donor
+doc_abbreviations:
+  label: records.abbreviations
+doc_aid:
+  label: records.aide
+doc_cataloguing_collections:
+  label: records.cataloging_collection_convoluta
+doc_edit_functions:
+  label: records.basic_functions
+doc_introduction:
+  label: records.introduction
+doc_masks:
+  label: records.cataloging_forms
+doc_tag_index:
+  label: general.marc_tag_index
+doc_templates:
+  label: records.templates
 dte:
-  label:
-    it: Dedicatario
-    fr: "Dédicataire"
-    de: "Widmungsträger"
-    en: Dedicatee
-    es: Dedicatario
-    pl: Adresat dedykacji
-asn: 
-  label: 
-    it: Nome associato
-    fr: Nom associé
-    de: Zugehöriger Name
-    en: Associated name
-    es: Nombre asociado
-    pt: Nome associado
-    pl: Powiązana osoba
+  label: records.dedicatee
+ed:
+  label: records.edition
 edt:
-  label:
-    it: Curatore
-    fr: Editeur
-    de: Herausgeber
-    en: Editor
-    es: Editor (curador)
-    pl: Edytor
+  label: records.editor
 egr:
-  label:
-    it: Incisore
-    fr: Graveur
-    de: Stecher
-    en: Engraver
-    es: Grabador
-    pl: Rytownik
+  label: records.engraver
 fmo:
-  label:
-    it: Proprietario precedente
-    fr: "Propriétaire précédent"
-    de: Vorbesitzer
-    en: Former owner
-    es: Propietario anterior
-    pl: Poprzedni właściciel
+  label: records.former_owner
+identity:
+  label: records.identity
 ill:
-  label:
-    it: Disegnatore
-    fr: Illustrateur
-    de: Illustrator
-    en: Illustrator
-    es: Ilustrador
-    pl: Ilustrator
+  label: records.illustrator
 itr:
-  label:
-    it: Strumentista
-    fr: Instrumentiste
-    de: Instrumentalist
-    en: Instrumentalist
-    es: Instrumentista
-    pl: Instrumentalista
+  label: records.instrumentalist
 lbt:
-  label:
-    it: Librettista
-    fr: Librettiste
-    de: Librettist
-    en: Librettist
-    es: Libretista
-    pl: Autor libretta
+  label: records.librettist
 ltg:
-  label:
-    it: Litografo
-    fr: Litographe
-    de: Lithograph
-    en: Lithograph
-    es: Litógrafo
-    pl: Litograf
+  label: records.lithograph
 lyr:
-  label:
-    it: Poeta
-    fr: Parolier
-    de: Textdichter
-    en: Lyricist
-    es: Letrista
-    pl: Autor słów
+  label: records.lyricist
+main:
+  label: records.main_entry_fields
+notes:
+  label: records.note_fields
+other:
+  label: records.miscellaneous
 otm:
-  label:
-    it: Organizzatore
-    fr: Organisateur
-    de: Veranstalter
-    en: Event organizer
-    es: "Organizador del evento"
-    pl: Organizator wydarzenia
+  label: records.event_organizer
 pat:
-  label:
-    it: Committente
-    fr: "Mécène"
-    de: "Mäzen/Auftraggeber"
-    en: Patron
-    es: Comitente
-    pl: Sponsor
+  label: records.patron
 pbl:
-  label:
-    it: Editore
-    fr: Editeur
-    de: Verleger
-    en: Publisher
-    es: "Editor (publicador)/Editorial (publicadora)"
-    pl: Wydawca
+  label: records.publisher
 ppm:
-  label:
-    it: Fabbricante di carta
-    fr: Papetier
-    de: Papierhersteller
-    en: Paper maker
-    es: "Fabricante de papel"
-    pl: Producent papieru
+  label: records.paper_maker
 prd:
-  label:
-    it: Personale alla produzione
-    fr: "Personnel de réalisation"
-    de: Produktionspersonal
-    en: Production personnel
-    es: "Personal de producción"
-    pl: Personel produkcyjny
+  label: records.production_personnel
 prf:
-  label:
-    it: Interprete
-    fr: "Interprète"
-    de: Interpret
-    en: Performer
-    es: "Intérprete"
-    pl: Wykonawca
+  label: records.performer
 prt:
-  label:
-    it: Stampatore
-    fr: Imprimeur
-    de: Drucker
-    en: Printer
-    es: Impresor
-    pl: Drukarnia
+  label: records.printer
 scr:
-  label:
-    it: Copista
-    fr: Scribe
-    de: Schreiber
-    en: Scribe
-    es: Copista
-    pl: Kopista
+  label: records.scribe
+sigla:
+  label: records.sigla
 trl:
-  label:
-    it: Traduttore
-    fr: Traducteur
-    de: "Übersetzer"
-    en: Translator
-    es: Traductor
-    pl: Tłumacz
+  label: records.translator
 voc:
-  label:
-    it: Cantante
-    fr: Vocaliste
-    de: "Sänger"
-    en: Vocalist
-    es: Cantante
-    pl: Wokalista
-#Country Codes
-"XC-DZ":
-  label:
-    it: "Algeria"
-    fr: "Algeria"
-    de: "Algerien"
-    en: "Algeria"
-    es: "Argelia"
-    pl: Algieria
-"XD-AR":
-  label:
-    it: "Argentina"
-    fr: "Argentina"
-    de: "Argentinien"
-    en: "Argentina"
-    es: "Argentina"
-    pl: Argentyna
-"XB-AM":
-  label:
-    it: "Armenia"
-    fr: "Armenia"
-    de: "Armenien"
-    en: "Armenia"
-    es: "Armenia"
-    pl: Armenia
-"XE-AU":
-  label:
-    it: "Australia"
-    fr: "Australia"
-    de: "Australien"
-    en: "Australia"
-    es: "Australia"
-    pl: Australia
-"XA-AT":
-  label:
-    it: "Austria"
-    fr: "Austria"
-    de: "Österreich"
-    en: "Austria"
-    es: "Austria"
-    pl: Austria
-"XA-AT-2":
-  label:
-    it: "Austria: Carinzia"
-    fr: "Austria: Carinthia"
-    de: "Austria: Carinthia"
-    en: "Austria: Carinthia"
-    es: "Austria: Carintia"
-    pl: "Austria: Karyntia"
-"XA-AT-3":
-  label:
-    it: "Austria: Austria Inferiore"
-    fr: "Austria: Lower Austria"
-    de: "Austria: Lower Austria"
-    en: "Austria: Lower Austria"
-    es: "Austria: Baja Austria"
-    pl: "Austria: Dolna Austria"
-"XA-AT-5":
-  label:
-    it: "Austria: Salisburgo"
-    fr: "Austria: Salzburg"
-    de: "Austria: Salzburg"
-    en: "Austria: Salzburg"
-    es: "Austria: Salzburgo"
-    pl: "Austria: Salzburg"
-"XA-AT-6":
-  label:
-    it: "Austria: Stiria"
-    fr: "Austria: Styria"
-    de: "Austria: Styria"
-    en: "Austria: Styria"
-    es: "Austria: Estiria"
-    pl: "Austria: Styria"
-"XA-AT-7":
-  label:
-    it: "Austria: Tirole"
-    fr: "Austria: Tyrol"
-    de: "Austria: Tyrol"
-    en: "Austria: Tyrol"
-    es: "Austria: Tirol"
-    pl: "Austria: Tyrol"
-"XA-AT-4":
-  label:
-    it: "Austria: Austria Superiore"
-    fr: "Austria: Upper Austria"
-    de: "Austria: Upper Austria"
-    en: "Austria: Upper Austria"
-    es: "Austria: Alta Austria"
-    pl: "Austria: Górna Austria"
-"XA-AT-9":
-  label:
-    it: "Austria: Vienna"
-    fr: "Austria: Vienna"
-    de: "Austria: Vienna"
-    en: "Austria: Vienna"
-    es: "Austria: Viena"
-    pl: "Austria: Wiedeń"
-"XA-BE":
-  label:
-    it: "Belgio"
-    fr: "Belgium"
-    de: "Belgien"
-    en: "Belgium"
-    es: "Bélgica"
-    pl: Belgia
-"XC-BJ":
-  label:
-    it: "Benin"
-    fr: "Benin"
-    de: "Benin"
-    en: "Benin"
-    es: "Benín"
-    pl: Benin
-"XD-BR":
-  label:
-    it: "Brasile"
-    fr: "Brazil"
-    de: "Brasilien"
-    en: "Brazil"
-    es: "Brasil"
-    pl: Brazylia
-"XA-BG":
-  label:
-    it: "Bulgaria"
-    fr: "Bulgaria"
-    de: "Bulgarien"
-    en: "Bulgaria"
-    es: "Bulgaria"
-    pl: Bułgaria
-"XB-KH":
-  label:
-    it: "Cambogia"
-    fr: "Cambodia"
-    de: "Cambodia"
-    en: "Cambodia"
-    es: "Camboya"
-    pl: Kambodża
-"XD-CA":
-  label:
-    it: "Canada"
-    fr: "Canada"
-    de: "Kanada"
-    en: "Canada"
-    es: "Canadá"
-    pl: Kanada
-"XD-CL":
-  label:
-    it: "Cile"
-    fr: "Chile"
-    de: "Chile"
-    en: "Chile"
-    es: "Chile"
-    pl: Chile
-"XB-CN":
-  label:
-    it: "Cina"
-    fr: "China"
-    de: "China"
-    en: "China"
-    es: "China"
-    pl: Chiny
-"XD-CO":
-  label:
-    it: "Colombia"
-    fr: "Colombia"
-    de: "Kolombien"
-    en: "Colombia"
-    es: "Colombia"
-    pl: Kolumbia
-"XA-HR":
-  label:
-    it: "Croazia"
-    fr: "Croatia"
-    de: "Kroatien"
-    en: "Croatia"
-    es: "Croacia"
-    pl: Chorwacja
-"XD-CU":
-  label:
-    it: "Cuba"
-    fr: "Cuba"
-    de: "Kuba"
-    en: "Cuba"
-    es: "Cuba"
-    pl: Kuba
-"XA-CZ":
-  label:
-    it: "Repubblica Ceca"
-    fr: "Czech Republic"
-    de: "Czech Republic"
-    en: "Czech Republic"
-    es: "República Checa"
-    pl: Czechy
-"XA-DK":
-  label:
-    it: "Danimarca"
-    fr: "Denmark"
-    de: "Dänemark"
-    en: "Denmark"
-    es: "Dinamarca"
-    pl: Dania
-"XC-EG":
-  label:
-    it: "Egitto"
-    fr: "Egypt"
-    de: "Ägypten"
-    en: "Egypt"
-    es: "Egipto"
-    pl: Egipt
-"XA-EE":
-  label:
-    it: "Estonia"
-    fr: "Estonia"
-    de: "Estonia"
-    en: "Estonia"
-    es: "Estonia"
-    pl: Estonia
-"XA-FI":
-  label:
-    it: "Finlandia"
-    fr: "Finland"
-    de: "Finland"
-    en: "Finland"
-    es: "Finlandia"
-    pl: Finlandia
-"XA-FR":
-  label:
-    it: "Francia"
-    fr: "France"
-    de: "Frankreich"
-    en: "France"
-    es: "Francia"
-    pl: Francja
-"XA-DE":
-  label:
-    it: "Germania"
-    fr: "Germany"
-    de: "Deutschland"
-    en: "Germany"
-    es: "Alemania"
-    pl: Niemcy
-"XA-DE-BY":
-  label:
-    it: "Germania: Baviera"
-    fr: "Germany: Bavaria"
-    de: "Germany: Bavaria"
-    en: "Germany: Bavaria"
-    es: "Alemania: Bavaria"
-    pl: "Niemcy: Bawaria"
-"XA-DE-SN":
-  label:
-    it: "Germania: Sassonia"
-    fr: "Germany: Saxony"
-    de: "Germany: Saxony"
-    en: "Germany: Saxony"
-    es: "Alemania: Sajonia"
-    pl: "Niemcy: Saksonia"
-"XA-GR":
-  label:
-    it: "Grecia"
-    fr: "Greece"
-    de: "Griechenland"
-    en: "Greece"
-    es: "Grecia"
-    pl: Grecja
-"XD-GT":
-  label:
-    it: "Guatemala"
-    fr: "Guatemala"
-    de: "Guatemala"
-    en: "Guatemala"
-    it: "Guatemala"
-    pl: Gwatemala
-"XA-VA":
-  label:
-    it: "Santa Sede"
-    fr: "Holy See"
-    de: "Holy See"
-    en: "Holy See"
-    es: "Santa Sede"
-    pl: Watykan
-"XD-HN":
-  label:
-    it: "Honduras"
-    fr: "Honduras"
-    de: "Honduras"
-    en: "Honduras"
-    es: "Honduras"
-    pl: Honduras
-"XA-HU":
-  label:
-    it: "Ungheria"
-    fr: "Hungary"
-    de: "Ungarn"
-    en: "Hungary"
-    es: "Hungría"
-    pl: Węgry
-"XA-IS":
-  label:
-    it: "Islanda"
-    fr: "Iceland"
-    de: "Island"
-    en: "Iceland"
-    es: "Islandia"
-    pl: Islandia
-"XB-IN":
-  label:
-    it: "India"
-    fr: "India"
-    de: "Indien"
-    en: "India"
-    es: "India"
-    pl: Indie
-"XB-IR":
-  label:
-    it: "Iran, Repubblica Islamica dell'"
-    fr: "Iran, Islamic Republic of"
-    de: "Iran, Islamic Republic of"
-    en: "Iran, Islamic Republic of"
-    es: "Irán, República Islámica de"
-    pl: Iran, Republika Islamska
-"XA-IE":
-  label:
-    it: "Irlanda"
-    fr: "Ireland"
-    de: "Irland"
-    en: "Ireland"
-    es: "Irlanda"
-    pl: Irlandia
-"XB-IL":
-  label:
-    it: "Israele"
-    fr: "Israel"
-    de: "Israel"
-    en: "Israel"
-    es: "Israel"
-    pl: Izrael
-"XA-IT-32":
-  label:
-    it: "Italia: Trentino-Alto Adige"
-    fr: "Italy: Trentino-Alto Adige"
-    de: "Italy: Trentino-Alto Adige"
-    en: "Italy: Trentino-Alto Adige"
-    es: "Italia: Trentino-Alto Adigio"
-    pl: "Włochy: Trentino-Alto Adige"
-"XA-IT":
-  label:
-    it: "Italia"
-    fr: "Italy"
-    de: "Italien"
-    en: "Italy"
-    es: "Italia"
-    pl: Włochy
-"XB-JP":
-  label:
-    it: "Giappone"
-    fr: "Japan"
-    de: "Japan"
-    en: "Japan"
-    es: "Japón"
-    pl: Japonia
-"XB-KR":
-  label:
-    it: "Corea, Repubblica di"
-    fr: "Korea, Republic of"
-    de: "Korea, Republic of"
-    en: "Korea, Republic of"
-    es: "Corea, República de"
-    pl: Korea, Republika
-"XA-LV":
-  label:
-    it: "Lettonia"
-    fr: "Latvia"
-    de: "Latvia"
-    en: "Latvia"
-    es: "Letonia"
-    pl: Łotwa
-"XA-LT":
-  label:
-    it: "Lituania"
-    fr: "Lithuania"
-    de: "Lithuania"
-    en: "Lithuania"
-    es: "Lituania"
-    pl: Litwa
-"XA-LU":
-  label:
-    it: "Lussemburgo"
-    fr: "Luxembourg"
-    de: "Luxemburg"
-    en: "Luxembourg"
-    es: "Luxemburgo"
-    pl: Luksemburg
-"XA-MT":
-  label:
-    it: "Malta"
-    fr: "Malta"
-    de: "Malta"
-    en: "Malta"
-    es: "Malta"
-    pl: Malta
-"XD-MX":
-  label:
-    it: "Messico"
-    fr: "Mexico"
-    de: "Mexiko"
-    en: "Mexico"
-    es: "México"
-    pl: Meksyk
-"XA-ME":
-  label:
-    it: "Montenegro"
-    fr: "Montenegro"
-    de: "Montenegro"
-    en: "Montenegro"
-    es: "Montenegro"
-    pl: Czarnogóra
-"XA-NL":
-  label:
-    it: "Paesi Bassi"
-    fr: "Netherlands"
-    de: "Niederlande"
-    en: "Netherlands"
-    es: "Países Bajos"
-    pl: Niderlandy
-"XE-NZ":
-  label:
-    it: "Nuova Zelanda"
-    fr: "New Zealand"
-    de: "New Zealand"
-    en: "New Zealand"
-    es: "Nueva Zelanda"
-    pl: Nowa Zelandia
-"XA-NO":
-  label:
-    it: "Norvegia"
-    fr: "Norway"
-    de: "Norwegen"
-    en: "Norway"
-    es: "Noruega"
-    pl: Norwegia
-"XD-PY":
-  label:
-    it: "Paraguay"
-    fr: "Paraguay"
-    de: "Paraguay"
-    en: "Paraguay"
-    es: "Paraguay"
-    pl: Paragwaj
-"XA-PL":
-  label:
-    it: "Polonia"
-    fr: "Poland"
-    de: "Polen"
-    en: "Poland"
-    es: "Polonia"
-    pl: Polska
-"XA-PT":
-  label:
-    it: "Portogallo"
-    fr: "Portugal"
-    de: "Portugal"
-    en: "Portugal"
-    es: "Portugal"
-    pl: Portugalia
-"XD-PR":
-  label:
-    it: "Puerto Rico"
-    fr: "Puerto Rico"
-    de: "Puerto Rico"
-    en: "Puerto Rico"
-    es: "Puerto Rico"
-    pl: Portoryko
-"XA-RO":
-  label:
-    it: "Romania"
-    fr: "Romania"
-    de: "Rumänien"
-    en: "Romania"
-    es: "Rumania"
-    pl: Rumunia
-"XA-RU":
-  label:
-    it: "Federazione Russa"
-    fr: "Russian Federation"
-    de: "Russian Federation"
-    en: "Russian Federation"
-    es: "Federación Rusa"
-    pl: Federacja Rosyjska
-"XA-RS":
-  label:
-    it: "Serbia"
-    fr: "Serbia"
-    de: "Serbien"
-    en: "Serbia"
-    es: "Serbia"
-    pl: Serbia
-"XA-SK":
-  label:
-    it: "Slovacchia"
-    fr: "Slovakia"
-    de: "Slovakia"
-    en: "Slovakia"
-    es: "Eslovaquia"
-    pl: Słowacja
-"XA-SI":
-  label:
-    it: "Slovenia"
-    fr: "Slovenia"
-    de: "Slovenien"
-    en: "Slovenia"
-    es: "Eslovenia"
-    pl: Słowenia
-"XC-ZA":
-  label:
-    it: "Sudafrica"
-    fr: "South Africa"
-    de: "South Africa"
-    en: "South Africa"
-    es: "Sudáfrica"
-    pl: Republika Południowej Afryki
-"XA-ES":
-  label:
-    it: "Spagna"
-    fr: "Spain"
-    de: "Spanien"
-    en: "Spain"
-    es: "España"
-    pl: Hiszpania
-"XA-SE":
-  label:
-    it: "Svezia"
-    fr: "Sweden"
-    de: "Schweden"
-    en: "Sweden"
-    es: "Suecia"
-    pl: Szwecja
-"XA-CH-VD":
-  label:
-    it: "Svizzera: Vaud"
-    fr: "Switzerland: Vaud"
-    de: "Switzerland: Vaud"
-    en: "Switzerland: Vaud"
-    es: "Suiza: cantón de Vaud"
-    pl: "Szwajcaria: kanton Vaud"
-"XA-CH":
-  label:
-    it: "Svizzera"
-    fr: "Switzerland"
-    de: "Schweiz"
-    en: "Switzerland"
-    es: "Suiza"
-    pl: Szwajcaria
-"XB-SY":
-  label:
-    it: "Repubblica Araba Siriana"
-    fr: "Syrian Arab Republic"
-    de: "Syrian Arab Republic"
-    en: "Syrian Arab Republic"
-    es: "República Árabe Siria"
-    pl: Syryjska Republika Arabska
-"XD-TT":
-  label:
-    it: "Trinidad e Tobago"
-    fr: "Trinidad and Tobago"
-    de: "Trinidad and Tobago"
-    en: "Trinidad and Tobago"
-    es: "Trinidad y Tobago"
-    pl: Trynidad i Tobago
-"XB-TR":
-  label:
-    it: "Turchia"
-    fr: "Turkey"
-    de: "Türkei"
-    en: "Turkey"
-    es: "Turquía"
-    pl: Turcja
-"XA-UA":
-  label:
-    it: "Ucraina"
-    fr: "Ukraine"
-    de: "Ukraine"
-    en: "Ukraine"
-    es: "Ucrania"
-    pl: Ukraina
-"XA-GB":
-  label:
-    it: "Regno Unito"
-    fr: "United Kingdom"
-    de: "United Kingdom"
-    en: "United Kingdom"
-    es: "Reino Unido"
-    pl: Zjednoczone Królestwo
-"XD-US":
-  label:
-    it: "Stati Uniti d'America"
-    fr: "United States of America"
-    de: "Vereinigte Staaten von Amerika (USA)"
-    en: "United States of America"
-    es: "Estados Unidos de América"
-    pl: Stany Zjednoczone AP
-"XD-UY":
-  label:
-    it: "Uruguay"
-    fr: "Uruguay"
-    de: "Uruguay"
-    en: "Uruguay"
-    es: "Uruguay"
-    pl: Urugwaj
-"XD-VE":
-  label:
-    it: "Venezuela, Repubblica Bolivariana del"
-    fr: "Venezuela, Bolivarian Republic of"
-    de: "Venezuela, Bolivarian Republic of"
-    en: "Venezuela, Bolivarian Republic of"
-    es: "Venezuela, República Bolivariana de"
-    pl: Wenezuela, Republika Boliwariańska
-"XB-VN":
-  label:
-    it: "Vietnam"
-    fr: "Viet Nam"
-    de: "Viet Nam"
-    en: "Viet Nam"
-    es: "Vietnam"
-    pl: Wietnam
-"XD-EC":
-  label:
-    it: "Ecuador"
-    fr: "Ecuador"
-    de: "Ecuador"
-    en: "Ecuador"
-    es: "Ecuador"
-    pl: Ekwador
-"Library":
-  label:
-    it: "Biblioteca"
-    fr: "Bibliothèque"
-    de: "Bibliothek"
-    en: "Library"
-    es: "Biblioteca"
-    pl: Biblioteka
-"Archive":
-  label:
-    it: "Archivio"
-    fr: "Archives"
-    de: "Archiv"
-    en: "Archive"
-    es: "Archivo"
-    pl: Archiwum
-"Publisher":
-  label:
-    it: Editore
-    fr: Editeur
-    de: Verleger
-    en: Publisher
-    es: "Editor (Publicador)/Editorial"
-    pl: Wydawca
-"Other":
-  label:
-    it: Altri
-    fr: Autre
-    de: Weitere
-    en: Other
-    es: Otro
-    pl: Pozostałe
-"Institution":
-  label:
-    it: "Ente collettivo"
-    fr: "Institution"
-    de: "Körperschaft"
-    en: "Institution"
-    pl: Instytucja
-"Documentation center":
-  label:
-    it: "Centro di documentazione"
-    fr: "DOCUMENTATION CENTER"
-    de: "Dokumentationszentrum"
-    en: "Documentation center"
-    pl: Centrum dokumentacji
-"Museum":
-  label:
-    it: "Museo"
-    fr: "MUSEUM"
-    de: "Museum"
-    en: "Museum"
-    pl: Muzeum
-"Printer":
-  label:
-    it: "Stampatore"
-    fr: "PRINTER"
-    de: "Druckerei"
-    en: "Printer"
-    pl: Drukarnia
-"Research institute":
-  label:
-    it: "Istituto di ricerca"
-    fr: "RESEARCH INSTITUTE"
-    de: "Forschungsinstitut"
-    en: "Research institute"
-    es: "Institución"
-    pl: Instytut badawczy
+  label: records.vocalist

--- a/config/editor_profiles/default/configurations/PersonLabels.yml
+++ b/config/editor_profiles/default/configurations/PersonLabels.yml
@@ -1,1561 +1,399 @@
----  !map:ActiveSupport::HashWithIndifferentAccess 
-doc_abbreviations:
-  label:
-    it: Abbreviazioni
-    de: "Abkürzungen"
-    en: Abbreviations
-    es: Abreviaturas
-    pl: Skróty
-doc_aid:
-  label:
-    it: Aiuti
-    de: Arbeitshilfen
-    en: Aide
-    es: Asistencia
-    pl: Asystent
-doc_cataloguing_collections:
-  label:
-    it: Catalogazione di raccolte e volumi compositi
-    de: Erfassung von Sammlungen
-    en: Cataloging collection and convoluta
-    es: "Catalogación de colecciones y volúmenes compuestos"
-    pl: Katalogowanie kolekcji i klocka introligatorskiego
-doc_edit_functions:
-  label:
-    it: Funzioni base
-    de: "Grundsätzliche Funktionen"
-    en: Basic functions
-    es: "Funciones básicas"
-    pl: Podstawowe funkcje
-doc_introduction:
-  label:
-    it: Introduzione
-    de: Einleitung
-    en: Introduction
-    es: "Introducción"
-    pl: Wprowadzenie
-doc_masks:
-  label:
-    it: Formulari di catalogazione
-    de: Masken
-    en: Cataloging forms
-    es: "Formularios de catalogación"
-    pl: Formularze katalogowania
-doc_tag_index:
-  label:
-    it: indice dei campi MARC
-    de: MARC Tag Index
-    en: MARC tag index
-    es: "Índice de etiquetas MARC"
-    pl: Indeks znaczników MARC
-doc_templates:
-  label:
-    it: Template
-    de: Templates
-    en: Templates
-    es: Plantillas
-    pl: Szablony
-
-################
-
-doc_editor: 
-  label: 
-    it: Guida all'editor
-    de: "Editor Hilfe"
-    en: Editor help
-    es: Ayuda del editor
-    pl: Pomoc do edycji
-doc_edit_workflow: 
-  label: 
-    it: Workflow
-    de: "Workflow"
-    en: Workflow
-    es: Flujo de trabajo
-    pl: Przepływ pracy
-    
-################
-
-
-"000":
-  label:
-    it: Leader
-    fr: Guide
-    de: Leader
-    en: Leader
-    es: "Líder"
-    pl: Leader
-"001":
-  label:
-    it: Numero documento RISM
-    fr: No. RISM
-    de: RISM Dokumentnummer
-    en: RISM ID number
-    es: "Número de ID de RISM"
-    pl: RISM ID
-"003":
-  label:
-    it: Identificatore del numero di controllo
-    fr: "Identité du numéro de contrôle"
-    de: Kontrollnummer-Bezeichnung
-    en: Control number identifier
-    es: "Identificador de número de control"
-    pl: Identyfikator numeru kontrolnego
-"005":
-  label:
-    it: Data e ora dell'ultima transazione
-    fr: "Date/heure de la dernière transaction"
-    de: Datum und Zeit der letzten Transaktion
-    en: Date and time of last transaction
-    es: "Fecha y hora de la última transacción"
-    pl: Data i godzina ostatniej operacji
-"024":
-  label:
-    it: "Riferimento autorità"
-    fr: "Référence d'authorité"
-    de: Normdatenverweise
-    en: Other standard identifier
-    es: "Otro identificador estándar"
-    pl: Identyfikator innego standardu
+'000':
+  label: records.leader
+'001':
+  label: records.rism_id_number
+'003':
+  label: records.control_number_identifier
+'005':
+  label: records.date_time_last_transaction
+'024':
+  fields:
+    '2':
+      label: records.source_number_code
+    a:
+      label: records.standard_number_code
+  label: records.other_standard_identifier
+'040':
   fields:
     a:
-      label:
-        it: "Riferimento autorità"
-        fr: "Référence d'authorité"
-        de: Normdatenverweise
-        en: Standard number or code
-        es: "Número o código estándar"
-        pl: Standardowy numer lub kod
-    "2":
-      label:
-        it: "Agenzia autorità"
-        fr: "Agence d'authorité"
-        de: Normdatenagentur
-        en: Source of number or code
-        es: "Fuente de número o código"
-        pl: Źródło numeru lub kodu
-"040":
-  label:
-    it: Fonte della catalogazione
-    fr: Source du catalogage
-    de: Katalogisierungsquelle
-    en: Cataloging source
-    es: "Fuente de la catalogación"
-    pl: Katalogowanie źródła
-  fields:
-    a:
-      label:
-        it: Agenzia catalografica originale
-        fr: Organisme du catalogage original
-        de: Original-Katalogisierungsstelle
-        en: Original cataloging agency
-        es: "Agencia de catalogación original"
-        pl: Jednostka katalogująca pierwotny rekord
+      label: records.original_cataloging_agency
     b:
-      label:
-        it: Lingua della catalogazione
-        fr: Langue de catalogage
-        de: Katalogisierungssprache
-        en: Language of cataloging
-        es: "Idioma de la catalogación"
-        pl: Język katalogowania
+      label: records.language_of_cataloging
     c:
-      label:
-        it: Agenzia della trascrizione
-        fr: Organisme de la transcription
-        de: "Übertragende Katalogisierungsstelle"
-        en: Transcribing agency
-        es: "Agencia de la transcripción"
-        pl: Jednostka transkrybująca
+      label: records.transcribing_agency
     d:
-      label:
-        it: Agenzia della modifica
-        fr: Organisme de la modification
-        de: Modifizierende Katalogisierungsstelle
-        en: Modifying agency
-        es: "Agencia de la modificación"
-        pl: Jednostka modyfikująca
-"042":
-  label:
-    it: Codice di autenticazione
-    fr: "Code d'authentification"
-    de: Authentication Code
-    en: Authentication Code
-    es: "Código de autenticación"
-    pl: Kod uwierzytelnienia
+      label: records.modifying_agency
+  label: records.cataloging_source
+'042':
   fields:
     a:
-      label:
-        it: Codice di autenticazione
-        fr: "Code d'authentification"
-        de: Authentication Code
-        en: Authentication Code
-        es: "Código de autenticación"
-        pl: Kod uwierzytelnienia
-"043":
-  label:
-    it: Codice del Paese
-    fr: Code du pays
-    de: Länder-Code
-    en: Nationality
-    es: Nacionalidad
-    pl: Narodowość
+      label: records.authentication_code
+  label: records.authentication_code
+'043':
   fields:
     c:
-      label:
-        it: Codice del Paese
-        fr: Code du pays
-        de: Länder-Code  
-        en: Nationality
-        es: Nacionalidad
-        pl: Narodowość
-"100":
-  label:
-    it: Nome di persona
-    fr: Compositeur/Auteur
-    de: Ansetzungsform
-    en: Heading - Personal name
-    es: Nombre personal
-    pl: Nagłówek – Osoba
-  accepts: 
-  - "700"
+      label: records.nationality
+  label: records.nationality
+'100':
   fields:
     a:
-      label:
-        it: Nome
-        fr: Nom
-        de: Name
-        en: Heading - personal name
-        es: Nombre personal
-        pl: Nagłówek – Osoba
+      label: records.heading_personal_name
     c:
-      label:
-        it: Ordine religioso
-        fr: Ordre/titre
-        de: Orden/Titel
-        en: Religious order
-        es: "Orden religiosa"
-        pl: Zgromadzenie zakonne
+      label: records.religious_order
     d:
-      label:
-        it: Data di nascita e di morte
-        fr: Dates de vie
-        de: Geburts- und Todesdaten
-        en: Years of birth and death
-        es: "Años de nacimiento y muerte"
-        pl: Lata urodzenia i śmierci
+      label: records.years_birth_death
     w:
-      label:
-        it: Status
-        fr: Status
-        de: Status
-        en: Status
-        es: Estado
-        pl: Status
+      label: general.status
     y:
-      label:
-        it: Altre date
-        fr: Autres dates
-        de: Andere Lebensdaten
-        en: Other life dates
-        es: "Otras fechas de vida"
-        pl: Pozostałe daty urodzenia i śmierci
-"370":
-  label:
-    it: Luogo associato
-    fr: Endroit associé
-    de: Associated Place
-    en: Associated Place
-    es: Lugar asociado
-    pl: Powiązane miejsce
+      label: records.other_life_dates
+  label: records.heading_personal_name
+'370':
   fields:
     a:
-      label:
-        it: Luogo di nascita
-        fr: Lieu de naissance
-        de: Geburtsort  
-        en: Place of birth
-        es: Lugar de nacimiento
-        pl: Miejsce urodzenia
-"375":
-  label:
-    it: Genere
-    fr: Gender
-    de: Geschlecht
-    en: Gender
-    es: "Género"
-    pl: Płeć społeczno-kulturowa
+      label: records.place_birth
+  label: records.associated_place
+'375':
   fields:
     a:
-      label:
-        it: Genere
-        fr: Gender
-        de: Geschlecht 
-        en: Gender
-        es: "Género"
-        pl: Płeć społeczno-kulturowa
-"400":
-  label:
-    it: Varianti del nome
-    fr: Name variant
-    de: Namensvarianten
-    en: Name variant
-    es: Variantes del nombre
-    pl: Alternatywna nazwa osoby
+      label: records.gender
+  label: records.gender
+'400':
   fields:
     a:
-      label:
-        it: Varianti del nome
-        fr: Name variants
-        de: Namensvarianten  
-        en: Name variant
-        es: Variantes del nombre
-        pl: Alternatywna nazwa osoby
+      label: records.name_variant
     d:
-      label:
-        it: Data di nascita e di morte
-        fr: Dates de vie
-        de: Geburts- und Todesdaten
-        en: Life dates
-        es: Fechas de nacimiento y muerte
-        pl: Daty urodzenia i śmierci
+      label: records.life_dates
     j:
-      label:
-        it: Descrizione della variante del nome
-        fr: Description de la variante du nom
-        de: Art der Namensvariante
-        en: Type of name variant
-        es: Tipo de variante de nombre
-        pl: Typ alternatywnej nazwy osoby
-"500":
-  label:
-    it: Persone correlate
-    fr: Personnes liées
-    de: Zugehörige Personen
-    en: Related personal name
-    es: Nombre personal relacionado
-    pl: Powiązana osoba
+      label: records.type_name_variant
+  label: records.name_variant
+'500':
   fields:
     a:
-      label:
-        it:  Nome
-        fr:  Nom
-        de:  Name
-        en:  Related personal name
-        es:  Nombre personal relacionado
-        pl: Powiązana osoba
+      label: records.related_personal_name
     y:
-      label:
-        it:  Relazione
-        fr:  Relation
-        de:  Beziehung
-        en:  Type of relationship
-        es:  "Tipo de relación"
-        pl: Rodzaj relacji
-
-"510":
-  label:
-    it: Istituzioni correlate
-    fr: Institutions liées
-    de: Beziehung Körperschaft 
-    en: Associated institution
-    es: "Institución asociada"
-    pl: Powiązana instytucja
+      label: records.type_relationship
+  label: records.related_personal_name
+'510':
   fields:
     a:
-      label:
-        it:  Istituzioni correlate
-        fr:  Institutions liées
-        de:  Beziehung Körperschaft
-        en:  Associated institution
-        es:  "Institución asociada" 
-        pl: Powiązana instytucja
-"550":
-  label:
-    it: Professione o funzione
-    fr: Sujet
-    de: Beruf oder Funktion
-    en: Profession or function
-    es: "Profesión o función"
-    pl: Zawód lub funkcja
+      label: records.associated_institution
+  label: records.associated_institution
+'550':
   fields:
     a:
-      label:
-        it: Professione o funzione
-        fr: Sujet
-        de: Beruf oder Funktion
-        en: Profession or function
-        es: "Profesión o función"
-        pl: Zawód lub funkcja
+      label: records.profession_or_function
     i:
-      label:
-        it:  Relazione
-        fr:  Relation
-        de:  Bedeutung
-        en:  Type
-        es:  Tipo
-        pl: Rodzaj
-"551":
-  label:
-    it: Nome geografico
-    fr: Lieu
-    de: Orte
-    en: Geographic name
-    es: "Nombre geográfico"
-    pl: Nazwa geograficzna
+      label: records.type
+  label: records.profession_or_function
+'551':
   fields:
     a:
-      label:
-        it:  Nome geografico
-        fr:  Lieu
-        de:  Ort
-        en:  Geographic name
-        es:  "Nombre geográfico"
-        pl: Nazwa geograficzna
+      label: records.geographic_name
     i:
-      label:
-        it:  Tipo
-        fr:  "Description de l'endroit"
-        de:  Ort Bedeutung
-        en:  Type
-        es:  Tipo
-        pl: Rodzaj
-
-"667":
-  label:
-    it:  Nota interna
-    fr:  Note non publique
-    de:  Non public note
-    en:  Internal note
-    es:  Nota interna
-    pl: Uwaga wewnętrzna
+      label: records.type
+  label: records.geographic_name
+'667':
   fields:
     a:
-      label:
-        it:  Nota interna
-        fr:  Note non publique
-        de:  Non public note
-        en:  Internal note
-        es:  Nota Interna
-        pl: Uwaga wewnętrzna
-"670":
-  label:
-    it: Fonte dei dati 
-    fr: Source des données
-    de: Literaturnachweis
-    en: Source data found 
-    es: "Fuente de los datos encontrados"
-    pl: Odnalezione źródło danych
+      label: records.internal_note
+  label: records.internal_note
+'670':
   fields:
     a:
-      label:
-        it: Fonte dei dati
-        fr: Source des données
-        de: Literaturnachweis
-        en: Source data found
-        es: "Fuente de los datos encontrados"
-        pl: Odnalezione źródło danych
+      label: records.source_data_found
     b:
-      label:
-        it: Informazione rinvenuta
-        fr: "Numéro/page"
-        de: Fundstelle
-        en: Information found
-        es: "Información encontrada"
-        pl: Odnaleziona informacja
-"678":
-  label:
-    it: Informazioni biografiche addizionali 
-    fr: Référence biographique additionnelle 
-    de: Weitere biographische Angaben
-    en: Additional biographical information
-    es: "Información biográfica adicional"
-    pl: Dodatkowe informacje biograficzne
+      label: records.information_found
+  label: records.source_data_found
+'678':
   fields:
     a:
-      label:
-        it: Riferimento biografico addizionale 
-        fr: Référence biographique additionnelle
-        de: Weitere biographische Angaben
-        en: Additional biographical information
-        es: "Información biográfica adicional"
-        pl: Dodatkowe informacje biograficzne
-"680":
-  label:
-    it: Osservazioni
-    fr: Remarque générale
-    de: Allgemeine Bemerkungen
-    en: General note
-    es: Nota general
-    pl: Uwaga ogólna
+      label: records.additional_biographical_information
+  label: records.additional_biographical_information
+'680':
   fields:
     a:
-      label:
-        it: Osservazioni
-        fr: Remarque générale
-        de: Externe Bemerkungen
-        en: General note
-        es: Nota general
-        pl: Uwaga ogólna
-"856":
-  label:
-    it: Localizzazione e accesso elettronico
-    fr: "Ressource électronique externe"
-    de: Elektronische Lokalisierung und Zugriff
-    en: External resource
-    es: Recurso externo
-    pl: Zasób zewnętrzny
+      label: records.general_note_personal
+  label: records.general_note_personal
+'856':
   fields:
-    y:
-      label:
-        it: Nota sulla risorsa esterna
-        fr: Remarque sur la ressource externe
-        de: "Für das Publikum bestimmte Fussnote"
-        en: Note about external resource
-        es: Nota sobre el recurso externo
-        pl: Uwaga o zasobie zewnętrznym
     u:
-      label:
-        it: Risorsa esterna URL
-        fr: Ressource externe URL
-        de: Uniform Resource Identifier
-        en: External resource URL
-        es: URL del recurso externo
-        pl: URL zasobu zewnętrznego
-main_person:
-  label:
-    it: Campi principali
-    fr: "Entrées principales"
-    de: Haupteintragungen
-    en: Main entry fields
-    es: Campos principales
-    pl: Główne pola edycji
-codes:
-  label:
-    it: Numeri e codici
-    fr: "Numéros et codes"
-    de: Nummern und Codes
-    en: Numbers and code fields
-    es: "Números y códigos"
-    pl: Pola liczb i kodów
-control:
-  label:
-    fr: "Champs de contrôle"
-    de: Kontrollfelder
-    it: Campi di controllo
-    en: Control fields
-    es: Campos de control
-    pl: Pola kontrolne
-notes:
-  label:
-    it: Note
-    fr: Notes
-    de: Bemerkungen
-    en: Note fields
-    es: Campos de notas
-    pl: Pola uwag
-subject:
-  label:
-    it: Soggetti
-    fr: "Entrées de sujets"
-    de: Schlagworteintragungen
-    en: Subject access fields
-    es: Campos de los puntos de acceso
-    pl: Pola haseł tematycznych
-places:
-  label:
-    it: Luoghi
-    fr: Lieu
-    de: Länder und Orte
-    en: Countries and Places
-    es: "Países y lugares"
-    pl: Kraje i miejsca
-other:
-  label:
-    it: Varia
-    fr: Divers
-    de: Verschiedenes
-    en: Miscellaneous
-    es: Varios
-    pl: Pozostałe
-references:
-  label:
-    it: Riferimento
-    fr: "Références"
-    de: Literatur und Bemerkungen
-    en: References and notes
-    es: Referencias y notas
-    pl: Odniesienia i uwagi
-relations:
-  label:
-    it: Relazione
-    fr: Relation
-    de: Beziehungen
-    en: Relations
-    es: Relaciones
-    pl: Relacje
-variants:
-  label:
-    it: Varianti
-    fr: Variantes
-    de: Namensvarianten
-    en: Name Variants
-    es: Variantes del nombre
-    pl: Alternatywne nazwy osoby
+      label: records.external_resource_url
+    y:
+      label: records.note_external_resource
+  label: records.external_resource
+XA-AT:
+  label: places.austria
+XA-AT-2:
+  label: places.austria_carinthia
+XA-AT-3:
+  label: places.austria_lower_austria
+XA-AT-4:
+  label: places.austria_upper_austria
+XA-AT-5:
+  label: places.austria_salzburg
+XA-AT-6:
+  label: places.austria_styria
+XA-AT-7:
+  label: places.austria_tyrol
+XA-AT-9:
+  label: places.austria_vienna
+XA-BE:
+  label: places.belgium
+XA-BG:
+  label: places.bulgaria
+XA-CH:
+  label: places.switzerland
+XA-CH-VD:
+  label: places.switzerland_vaud
+XA-CZ:
+  label: places.czech_republic
+XA-DE:
+  label: places.germany
+XA-DE-BY:
+  label: places.germany_bavaria
+XA-DE-SN:
+  label: places.germany_saxony
+XA-DK:
+  label: places.denmark
+XA-EE:
+  label: places.estonia
+XA-ES:
+  label: places.spain
+XA-FI:
+  label: places.finland
+XA-FR:
+  label: places.france
+XA-GB:
+  label: places.uk
+XA-GR:
+  label: places.greece
+XA-HR:
+  label: places.croatia
+XA-HU:
+  label: places.hungary
+XA-IE:
+  label: places.ireland
+XA-IS:
+  label: places.iceland
+XA-IT:
+  label: places.italy
+XA-IT-32:
+  label: places.italy_trentino_alto_adige
+XA-LT:
+  label: places.lithuania
+XA-LU:
+  label: places.luxembourg
+XA-LV:
+  label: places.latvia
+XA-MC:
+  label: places.monaco
+XA-MD:
+  label: places.moldavia
+XA-ME:
+  label: places.montenegro
+XA-MT:
+  label: places.malta
+XA-NL:
+  label: places.netherlands
+XA-NO:
+  label: places.norway
+XA-PL:
+  label: places.poland
+XA-PT:
+  label: places.portugal
+XA-RO:
+  label: places.romania
+XA-RS:
+  label: places.serbia
+XA-RU:
+  label: places.russian_federation
+XA-SE:
+  label: places.sweden
+XA-SI:
+  label: places.slovenia
+XA-SK:
+  label: places.slovakia
+XA-UA:
+  label: places.ukraine
+XA-VA:
+  label: places.holy_see
+XB-AM:
+  label: places.armenia
+XB-CN:
+  label: places.china
+XB-GE:
+  label: places.georgia
+XB-IL:
+  label: places.israel
+XB-IN:
+  label: places.india
+XB-IQ:
+  label: places.iraq
+XB-IR:
+  label: places.iran
+XB-JP:
+  label: places.japan
+XB-KH:
+  label: places.cambodia
+XB-KR:
+  label: places.korea
+XB-SY:
+  label: places.syrian_arab_republic
+XB-TR:
+  label: places.turkey
+XB-TW:
+  label: places.taiwan
+XB-VN:
+  label: places.vietnam
+XC-BJ:
+  label: languages.benin
+XC-DZ:
+  label: places.algeria
+XC-EG:
+  label: places.egypt
+XC-GN:
+  label: places.guinea
+XC-ZA:
+  label: places.south_africa
+XD-AR:
+  label: places.argentina
+XD-BR:
+  label: places.brazil
+XD-CA:
+  label: places.canada
+XD-CL:
+  label: places.chile
+XD-CO:
+  label: places.colombia
+XD-CU:
+  label: places.cuba
+XD-EC:
+  label: places.ecuador
+XD-HN:
+  label: places.honduras
+XD-MX:
+  label: places.mexico
+XD-PE:
+  label: places.peru
+XD-PR:
+  label: places.puerto_rico
+XD-PY:
+  label: places.paraguay
+XD-TT:
+  label: places.trinidad_tobego
+XD-US:
+  label: places.usa
+XD-UY:
+  label: places.uruguay
+XD-VE:
+  label: places.venezuela
+XE-AU:
+  label: places.australia
+XE-NZ:
+  label: places.new_zealand
 administration:
-  label:
-    it: Amministrazione
-    fr: Administration
-    de: Administration
-    en: Administration
-    es: "Administración"
-    pl: Administracja
-male:
-  label:
-    it: maschio
-    fr: homme
-    de: männlich
-    en: male
-    es: masculino
-    pl: mężczyzna
-female:
-  label:
-    it: femmina
-    fr: femme
-    de: weiblich
-    en: female
-    es: femenino
-    pl: kobieta
-unknown:
-  label:
-    it: sconosciuto
-    fr: inconnu
-    de: unbekannt
-    en: unknown
-    es: desconocido
-    pl: płeć nieznana
-
-#########################
-go:
-  label:
-    it: Luogo di nascita
-    fr: Lieu de naissance
-    de: Geburtsort
-    en: Place of birth
-    es: Lugar de nacimiento
-    pl: Miejsce urodzenia
-ha:
-  label:
-    it: Luogo di origine
-    fr: "Lieu d'origine"
-    de: Herkunftsangabe
-    en: Place of origin
-    es: Lugar de origen
-    pl: Miejsce pochodzenia
-po:
-  label:
-    it: Luogo postale
-    fr: endroit postal
-    de: postalischer Ort
-    en: postal Place
-    es: "Dirección postal"
-    pl: Rejon pocztowy
-so:
-  label:
-    it: Luogo di morte
-    fr: Lieu de décès
-    de: Sterbeort
-    en: Place of death
-    es: Lugar de fallecimiento
-    pl: Miejsce śmierci
-wl:
-  label:
-    it: "Paese di attività"
-    fr: "Pays d'activité"
-    de: Wirkungsland
-    en: Country active
-    es: "País de actividad"
-    pl: Kraj aktywności artystycznej
-wo:
-  label:
-    it: "Luogo di attività"
-    fr: "Lieu d'activité"
-    de: Wirkungsort
-    en: Place active
-    es: "Lugar de actividad"
-    pl: Miejsce aktywności artystycznej
-wr:
-  label:
-    it: "Regione di attività"
-    fr: "Région d'activité"
-    de: Wirkungsregion
-    en: Region active
-    es: "Región de actividad"
-    pl: Region aktywności artystycznej
-#Country Codes
-"XC-DZ":
-  label:
-    it: "Algeria"
-    fr: "Algeria"
-    de: "Algeria"
-    en: "Algeria"
-    es: "Argelia"
-    pl: Algieria
-"XD-AR":
-  label:
-    it: "Argentina"
-    fr: "Argentina"
-    de: "Argentina"
-    en: "Argentina"
-    es: "Argentina"
-    pl: Argentyna
-"XB-AM":
-  label:
-    it: "Armenia"
-    fr: "Armenia"
-    de: "Armenia"
-    en: "Armenia"
-    es: "Armenia"
-    pl: Armenia
-"XE-AU":
-  label:
-    it: "Australia"
-    fr: "Australia"
-    de: "Australia"
-    en: "Australia"
-    es: "Australia"
-    pl: Australia
-"XA-AT":
-  label:
-    it: "Austria"
-    fr: "Austria"
-    de: "Austria"
-    en: "Austria"
-    es: "Austria"
-    pl: Austria
-"XA-AT-2":
-  label:
-    it: "Austria: Carinzia"
-    fr: "Austria: Carinthia"
-    de: "Austria: Carinthia"
-    en: "Austria: Carinthia"
-    es: "Austria: Carintia"
-    pl: "Austria: Karyntia"
-"XA-AT-3":
-  label:
-    it: "Austria: Austria Inferiore"
-    fr: "Austria: Lower Austria"
-    de: "Austria: Lower Austria"
-    en: "Austria: Lower Austria"
-    es: "Austria: Baja Austria"
-    pl: "Austria: Dolna Austria"
-"XA-AT-5":
-  label:
-    it: "Austria: Salisburgo"
-    fr: "Austria: Salzburg"
-    de: "Austria: Salzburg"
-    en: "Austria: Salzburg"
-    es: "Austria: Salzburgo"
-    pl: "Austria: Salzburg"
-"XA-AT-6":
-  label:
-    it: "Austria: Stiria"
-    fr: "Austria: Styria"
-    de: "Austria: Styria"
-    en: "Austria: Styria"
-    es: "Austria: Estiria"
-    pl: "Austria: Styria"
-"XA-AT-7":
-  label:
-    it: "Austria: Tirolo"
-    fr: "Austria: Tyrol"
-    de: "Austria: Tyrol"
-    en: "Austria: Tyrol"
-    es: "Austria: Tirol"
-    pl: "Austria: Tyrol"
-"XA-AT-4":
-  label:
-    it: "Austria: Austria Superiore"
-    fr: "Austria: Upper Austria"
-    de: "Austria: Upper Austria"
-    en: "Austria: Upper Austria"
-    es: "Austria: Alta Austria"
-    pl: "Austria: Górna Austria"
-"XA-AT-9":
-  label:
-    it: "Austria: Vienna"
-    fr: "Austria: Vienna"
-    de: "Austria: Vienna"
-    en: "Austria: Vienna"
-    es: "Austria: Viena"
-    pl: "Austria: Wiedeń"
-"XA-BE":
-  label:
-    it: "Belgio"
-    fr: "Belgium"
-    de: "Belgium"
-    en: "Belgium"
-    es: "Bélgica"
-    pl: Belgia
-"XC-BJ":
-  label:
-    it: "Benin"
-    fr: "Benin"
-    de: "Benin"
-    en: "Benin"
-    es: "Benín"
-    pl: Benin
-"XD-BR":
-  label:
-    it: "Brasile"
-    fr: "Brazil"
-    de: "Brazil"
-    en: "Brazil"
-    es: "Brasil"
-    pl: Brazylia
-"XA-BG":
-  label:
-    it: "Bulgaria"
-    fr: "Bulgaria"
-    de: "Bulgaria"
-    en: "Bulgaria"
-    es: "Bulgaria"
-    pl: Bułgaria
-"XB-KH":
-  label:
-    it: "Cambogia"
-    fr: "Cambodia"
-    de: "Cambodia"
-    en: "Cambodia"
-    es: "Camboya"
-    pl: Kambodża
-"XD-CA":
-  label:
-    it: "Canada"
-    fr: "Canada"
-    de: "Canada"
-    en: "Canada"
-    es: "Canadá"
-    pl: Kanada
-"XD-CL":
-  label:
-    it: "Cile"
-    fr: "Chile"
-    de: "Chile"
-    en: "Chile"
-    es: "Chile"
-    pl: Chile
-"XB-CN":
-  label:
-    it: "Cina"
-    fr: "China"
-    de: "China"
-    en: "China"
-    es: "China"
-    pl: Chiny
-"XD-CO":
-  label:
-    it: "Colombia"
-    fr: "Colombia"
-    de: "Colombia"
-    en: "Colombia"
-    es: "Colombia"
-    pl: Kolumbia
-"XA-HR":
-  label:
-    it: "Croazia"
-    fr: "Croatia"
-    de: "Croatia"
-    en: "Croatia"
-    es: "Croacia"
-    pl: Chorwacja
-"XD-CU":
-  label:
-    it: "Cuba"
-    fr: "Cuba"
-    de: "Cuba"
-    en: "Cuba"
-    es: "Cuba"
-    pl: Kuba
-"XA-CZ":
-  label:
-    it: "Repubblica Ceca"
-    fr: "Czech Republic"
-    de: "Czech Republic"
-    en: "Czech Republic"
-    es: "República Checa"
-    pl: Czechy
-"XA-DK":
-  label:
-    it: "Danimarca"
-    fr: "Denmark"
-    de: "Denmark"
-    en: "Denmark"
-    es: "Dinamarca"
-    pl: Dania
-"XC-EG":
-  label:
-    it: "Egitto"
-    fr: "Egypt"
-    de: "Egypt"
-    en: "Egypt"
-    es: "Egipto"
-    pl: Egipt
-"XA-EE":
-  label:
-    it: "Estonia"
-    fr: "Estonia"
-    de: "Estonia"
-    en: "Estonia"
-    es: "Estonia"
-    pl: Estonia
-"XA-FI":
-  label:
-    it: "Finlandia"
-    fr: "Finland"
-    de: "Finland"
-    en: "Finland"
-    es: "Finlandia"
-    pl: Finlandia
-"XA-FR":
-  label:
-    it: "Francia"
-    fr: "France"
-    de: "France"
-    en: "France"
-    es: "Francia"
-    pl: Francja
-"XB-GE":
-  label:
-    it: "Georgia"
-    fr: "Georgia"
-    de: "Georgia"
-    en: "Georgia"
-    es: "Georgia"
-    pl: Gruzja
-"XA-DE":
-  label:
-    it: "Germania"
-    fr: "Germany"
-    de: "Germany"
-    en: "Germany"
-    es: "Alemania"
-    pl: Niemcy
-"XA-DE-BY":
-  label:
-    it: "Germana: Baviera"
-    fr: "Germany: Bavaria"
-    de: "Germany: Bavaria"
-    en: "Germany: Bavaria"
-    es: "Alemania: Bavaria"
-    pl: "Niemcy: Bawaria"
-"XA-DE-SN":
-  label:
-    it: "Germania: Sassonia"
-    fr: "Germany: Saxony"
-    de: "Germany: Saxony"
-    en: "Germany: Saxony"
-    es: "Alemania: Sajonia"
-    pl: "Niemcy: Saksonia"
-"XA-GR":
-  label:
-    it: "Grecia"
-    fr: "Greece"
-    de: "Greece"
-    en: "Greece"
-    es: "Grecia"
-    pl: Grecja
-"XC-GN":
-  label:
-    it: "GUINEA"
-    fr: "GUINEA"
-    de: "Guinea"
-    en: "Guinea"
-    es: "Guinea"
-    pl: Gwinea
-"XA-VA":
-  label:
-    it: "Santa Sede"
-    fr: "Holy See"
-    de: "Holy See"
-    en: "Holy See"
-    es: "Santa Sede"
-    pl: Watykan
-"XD-HN":
-  label:
-    it: "Honduras"
-    fr: "Honduras"
-    de: "Honduras"
-    en: "Honduras"
-    es: "Honduras"
-    pl: Honduras
-"XA-HU":
-  label:
-    it: "Ungheria"
-    fr: "Hungary"
-    de: "Hungary"
-    en: "Hungary"
-    es: "Hungría"
-    pl: Węgry
-"XA-IS":
-  label:
-    it: "Islanda"
-    fr: "Iceland"
-    de: "Iceland"
-    en: "Iceland"
-    es: "Islandia"
-    pl: Islandia
-"XB-IN":
-  label:
-    it: "India"
-    fr: "India"
-    de: "India"
-    en: "India"
-    es: "India"
-    pl: Indie
-"XB-IR":
-  label:
-    it: "Iran, Repubblica Islamica dell'"
-    fr: "Iran, Islamic Republic of"
-    de: "Iran, Islamic Republic of"
-    en: "Iran, Islamic Republic of"
-    es: "Irán, República Islámica de"
-    pl: Iran, Republika Islamska
-"XA-IE":
-  label:
-    it: "Irlanda"
-    fr: "Ireland"
-    de: "Ireland"
-    en: "Ireland"
-    es: "Irlanda"
-    pl: Irlandia
-"XB-IQ":
-  label:
-    it: "Iraq"
-    fr: "IRAQ"
-    de: "Irak"
-    en: "Iraq"
-    pl: Irak
-"XB-IL":
-  label:
-    it: "Israele"
-    fr: "Israel"
-    de: "Israel"
-    en: "Israel"
-    es: "Israel"
-    pl: Izrael
-"XA-IT-32":
-  label:
-    it: "Italia: Trentino-Alto Adige"
-    fr: "Italy: Trentino-Alto Adige"
-    de: "Italy: Trentino-Alto Adige"
-    en: "Italy: Trentino-Alto Adige"
-    es: "Italia: Trentino-Alto Adigio"
-    pl: "Włochy: Trentino-Alto Adige"
-"XA-IT":
-  label:
-    it: "Italia"
-    fr: "Italy"
-    de: "Italy"
-    en: "Italy"
-    es: "Italia"
-    pl: Włochy
-"XB-JP":
-  label:
-    it: "Giappone"
-    fr: "Japan"
-    de: "Japan"
-    en: "Japan"
-    es: "Japón"
-    pl: Japonia
-"XB-KR":
-  label:
-    it: "Corea, Repubblica di"
-    fr: "Korea, Republic of"
-    de: "Korea, Republic of"
-    en: "Korea, Republic of"
-    es: "Corea, República de"
-    pl: Korea, Republika
-"XA-LV":
-  label:
-    it: "Lettonia"
-    fr: "Latvia"
-    de: "Latvia"
-    en: "Latvia"
-    es: "Letonia"
-    pl: Łotwa
-"XA-LT":
-  label:
-    it: "Lituania"
-    fr: "Lithuania"
-    de: "Lithuania"
-    en: "Lithuania"
-    es: "Lituania"
-    pl: Litwa
-"XA-LU":
-  label:
-    it: "Lussemburgo"
-    fr: "Luxembourg"
-    de: "Luxembourg"
-    en: "Luxembourg"
-    es: "Luxemburgo"
-    pl: Luksemburg
-"XA-MT":
-  label:
-    it: "Malta"
-    fr: "Malta"
-    de: "Malta"
-    en: "Malta"
-    es: "Malta"
-    pl: Malta
-"XD-MX":
-  label:
-    it: "Messico"
-    fr: "Mexico"
-    de: "Mexico"
-    en: "Mexico"
-    es: "México"
-    pl: Meksyk
-"XA-MD":
-  label:
-    it: "Moldavia"
-    fr: "MOLDAVIA"
-    de: "Moldawien"
-    en: "Moldavia"
-    es: "Moldavia"
-    pl: Mołdawia
-"XA-MC":
-  label:
-    it: "Monaco"
-    fr: "Monaco"
-    de: "Monaco"
-    en: "Monaco"
-    es: "Mónaco"
-    pl: Monako
-"XA-ME":
-  label:
-    it: "Montenegro"
-    fr: "Montenegro"
-    de: "Montenegro"
-    en: "Montenegro"
-    es: "Montenegro"
-    pl: Czarnogóra
-"XA-NL":
-  label:
-    it: "Paesi Bassi"
-    fr: "Netherlands"
-    de: "Netherlands"
-    en: "Netherlands"
-    es: "Países Bajos"
-    pl: Niderlandy
-"XE-NZ":
-  label:
-    it: "Nuova Zelanda"
-    fr: "New Zealand"
-    de: "New Zealand"
-    en: "New Zealand"
-    es: "Nueva Zelanda"
-    pl: Nowa Zelandia
-"XA-NO":
-  label:
-    it: "Norvegia"
-    fr: "Norway"
-    de: "Norway"
-    en: "Norway"
-    es: "Noruega"
-    pl: Norwegia
-"XD-PY":
-  label:
-    it: "Paraguay"
-    fr: "Paraguay"
-    de: "Paraguay"
-    en: "Paraguay"
-    es: "Paraguay"
-    pl: Paragwaj
-"XD-PE":
-  label:
-    it: "Perù"
-    fr: "Pérou"
-    de: "Peru"
-    en: "Peru"
-    es: "Perú"
-    pl: Peru
-"XA-PL":
-  label:
-    it: "Polonia"
-    fr: "Poland"
-    de: "Poland"
-    en: "Poland"
-    es: "Polonia"
-    pl: Polska
-"XA-PT":
-  label:
-    it: "Portogallo"
-    fr: "Portugal"
-    de: "Portugal"
-    en: "Portugal"
-    es: "Portugal"
-    pl: Portugalia
-"XD-PR":
-  label:
-    it: "Puerto Rico"
-    fr: "Puerto Rico"
-    de: "Puerto Rico"
-    en: "Puerto Rico"
-    es: "Puerto Rico"
-    pl: Portoryko
-"XA-RO":
-  label:
-    it: "Romania"
-    fr: "Romania"
-    de: "Romania"
-    en: "Romania"
-    es: "Rumania"
-    pl: Rumunia
-"XA-RU":
-  label:
-    it: "Federazione Russa"
-    fr: "Russian Federation"
-    de: "Russian Federation"
-    en: "Russian Federation"
-    es: "Federación Rusa"
-    pl: Federacja Rosyjska
-"XA-RS":
-  label:
-    it: "Serbia"
-    fr: "Serbia"
-    de: "Serbia"
-    en: "Serbia"
-    es: "Serbia"
-    pl: Serbia
-"XA-SK":
-  label:
-    it: "Slovacchia"
-    fr: "Slovakia"
-    de: "Slovakia"
-    en: "Slovakia"
-    es: "Eslovaquia"
-    pl: Słowacja
-"XA-SI":
-  label:
-    it: "Slovenia"
-    fr: "Slovenia"
-    de: "Slovenia"
-    en: "Slovenia"
-    es: "Eslovenia"
-    pl: Słowenia
-"XC-ZA":
-  label:
-    it: "Sudafrica"
-    fr: "South Africa"
-    de: "South Africa"
-    en: "South Africa"
-    es: "Sudáfrica"
-    pl: Republika Południowej Afryki
-"XA-ES":
-  label:
-    it: "Spagna"
-    fr: "Spain"
-    de: "Spain"
-    en: "Spain"
-    es: "España"
-    pl: Hiszpania
-"XA-SE":
-  label:
-    it: "Svezia"
-    fr: "Sweden"
-    de: "Sweden"
-    en: "Sweden"
-    es: "Suecia"
-    pl: Szwecja
-"XA-CH-VD":
-  label:
-    it: "Svizzera: Vaud"
-    fr: "Switzerland: Vaud"
-    de: "Switzerland: Vaud"
-    en: "Switzerland: Vaud"
-    es: "Suiza: cantón de Vaud"
-    pl: "Szwajcaria: kanton Vaud"
-"XA-CH":
-  label:
-    it: "Svizzera"
-    fr: "Switzerland"
-    de: "Switzerland"
-    en: "Switzerland"
-    es: "Suiza"
-    pl: Szwajcaria
-"XB-SY":
-  label:
-    it: "Repubblica Araba Siriana"
-    fr: "Syrian Arab Republic"
-    de: "Syrian Arab Republic"
-    en: "Syrian Arab Republic"
-    es: "República Árabe Siria"
-    pl: Syryjska Republika Arabska
-"XB-TW":
-  label:
-    it: "Taiwan (provincia della Cina)"
-    fr: "Taiwan (Province of China)"
-    de: "Taiwan (Province of China)"
-    en: "Taiwan (Province of China)"
-    es: "Taiwán (Provincia de China)"
-    pl: Tajwan (prowincja Chin)
-"XD-TT":
-  label:
-    it: "Trinidad e Tobago"
-    fr: "Trinidad and Tobago"
-    de: "Trinidad and Tobago"
-    en: "Trinidad and Tobago"
-    es: "Trinidad y Tobago"
-    pl: Trynidad i Tobago
-"XB-TR":
-  label:
-    it: "Turchia"
-    fr: "Turkey"
-    de: "Turkey"
-    en: "Turkey"
-    es: "Turquía"
-    pl: Turcja
-"XA-UA":
-  label:
-    it: "Ucraina"
-    fr: "Ukraine"
-    de: "Ukraine"
-    en: "Ukraine"
-    es: "Ucrania"
-    pl: Ukraina
-"XA-GB":
-  label:
-    it: "Regno Unito"
-    fr: "United Kingdom"
-    de: "United Kingdom"
-    en: "United Kingdom"
-    es: "Reino Unido"
-    pl: Zjednoczone Królestwo
-"XD-US":
-  label:
-    it: "Stati Uniti d'America"
-    fr: "United States of America"
-    de: "United States of America"
-    en: "United States of America"
-    es: "Estados Unidos de América"
-    pl: Stany Zjednoczone AP
-"XD-UY":
-  label:
-    it: "Uruguay"
-    fr: "Uruguay"
-    de: "Uruguay"
-    en: "Uruguay"
-    es: "Uruguay"
-    pl: Urugwaj
-"XD-VE":
-  label:
-    it: "Venezuela, Repubblica Bolivariana del"
-    fr: "Venezuela, Bolivarian Republic of"
-    de: "Venezuela, Bolivarian Republic of"
-    en: "Venezuela, Bolivarian Republic of"
-    es: "Venezuela, República Bolivariana de"
-    pl: Wenezuela, Republika Boliwariańska
-"XB-VN":
-  label:
-    it: "Vietnam"
-    fr: "Vietnam"
-    de: "Vietnam"
-    en: "Vietnam"
-    es: "Vietnam"
-    pl: Wietnam
-"XD-EC":
-  label:
-    it: "Ecuador"
-    fr: "Ecuador"
-    de: "Ecuador"
-    en: "Ecuador"
-    es: "Ecuador"
-    pl: Ekwador
-# Relationships
-brother of:
-  label:
-    it: Fratello di
-    fr: "frère de"
-    de: Bruder von
-    en: brother of
-    es: hermano de
-    pl: Brat …
-child of:
-  label:
-    it: Figlio/figlia di
-    fr: Enfant de
-    de: Kind von
-    en: child of
-    es: "hijo/a de"
-    pl: Potomek …
-mother of:
-  label:
-    it: Madre di
-    fr: "Mère de"
-    de: Mutter von
-    en: mother of
-    es: madre de
-    pl: Matka …
-confused with:
-  label:
-    it: Confuso/confusa con
-    fr: "Confondu avec"
-    de: Verwechselt mit
-    en: confused with
-    es: "Confundido/a con"
-    pl: Mylon(y/a) z …
-sister of:
-  label:
-    it: Sorella di
-    fr: Soeur de
-    de: Schwester von
-    en: sister of
-    pl: Siostra …
-married to:
-  label:
-    it: Sposato/sposata con
-    fr: "Marié avec"
-    de: Verheiratet mit
-    es: hermana de
-    en: married to
-    es: "casado/a con"
-    pl: W małżeństwie z …
-father of:
-  label:
-    it: Padre di
-    fr: "Père de"
-    de: Vater von
-    en: father of
-    es: padre de
-    pl: Ojciec …
-related to:
-  label:
-    it: Parente di
-    fr: "Relatif à"
-    de: Verwandt mit
-    en: related to
-    es: relacionado/a con
-    pl: W pokrewieństwie z …
-other:
-  label:
-    it: Altro
-    fr: Autres
-    de: Weiteres
-    en: other
-    es: otro
-    pl: Pozostałe
-    
-# Name variant codes
+  label: records.administration
 bn:
-  label:
-    it: Soprannome
-    fr: Surnom
-    de: Beiname
-    en: Nickname
-    es: Apodo
-    pl: Przezwisko
+  label: records.nickname
+brother of:
+  label: records.brother_of
+child of:
+  label: records.child_of
+codes:
+  label: records.numbers_code_fields
+confused with:
+  label: records.confused_with
+control:
+  label: records.control_fields
 da:
-  label:
-    it: Pseudonimo
-    fr: Pseudonym
-    de: Pseudonym
-    en: Pseudonym
-    es: "Seudónimo"
-    pl: Pseudonim
+  label: records.pseudonym
 do:
-  label:
-    it: Nome di religione
-    fr: "Nom d'ordre"
-    de: Ordensname
-    en: Religious name
-    es: Nombre religioso
-    pl: Imię z wyznania
+  label: records.religious_name
+doc_abbreviations:
+  label: records.abbreviations
+doc_aid:
+  label: records.aide
+doc_cataloguing_collections:
+  label: records.cataloging_collection_convoluta
+doc_edit_functions:
+  label: records.basic_functions
+doc_edit_workflow:
+  label: general.workflow
+doc_editor:
+  label: general.editor_help
+doc_introduction:
+  label: records.introduction
+doc_masks:
+  label: records.cataloging_forms
+doc_tag_index:
+  label: general.marc_tag_index
+doc_templates:
+  label: records.templates
 dv:
-  label:
-    it: Altra forma di ricerca
-    fr: Autre forme de recherche
-    de: andere Suchform
-    en: Other variant
-    es: Otra variante
-    pl: Inny wariant
+  label: records.other_variant
 ee:
-  label:
-    it: Nome da sposato
-    fr: Nom de mariage
-    de: Ehename
-    en: Married name
-    es: Apellido de casada/o
-    pl: Nazwisko po mężu
+  label: records.married_name
 ef:
-  label:
-    it: Nome di famiglia
-    fr: Nom de famillie
-    de: Familienname
-    en: Name of family
-    es: Apellido
-    pl: Nazwa rodziny
+  label: records.name_family
+father of:
+  label: records.father_of
+female:
+  label: general.female
 ff:
-  label:
-    it: Nome di persona
-    fr: Nom de la personne
-    de: Personenname
-    en: Personal name
-    es: Nombre de pila
-    pl: Imię i nazwisko
+  label: records.personal_name
 gg:
-  label:
-    it: Nome da nubile/celibe
-    fr: Nom de naissance
-    de: Geburtsname
-    en: Birth name
-    es: Nombre de nacimiento
-    pl: Nazwisko rodowe
+  label: records.birth_name
+go:
+  label: records.place_birth
+ha:
+  label: records.place_origin
 in:
-  label:
-    it: Iniziali
-    fr: Initiale
-    de: Initiale
-    en: Initials
-    es: Iniciales
-    pl: Inicjały
+  label: records.initials
+main_person:
+  label: records.main_entry_fields
+male:
+  label: general.male
+married to:
+  label: records.married_to
 mo:
-  label:
-    it: Monogramma
-    fr: Monogramme
-    de: Monogramm
-    en: Monogram
-    es: Monograma
-    pl: Monogram
+  label: records.monogram
+mother of:
+  label: records.mother_of
+notes:
+  label: records.note_fields
+other:
+  label: records.other
+places:
+  label: records.countries_places
+po:
+  label: records.postal_place
+references:
+  label: records.references_and_notes
+related to:
+  label: records.related_to
+relations:
+  label: records.relations
+sister of:
+  label: records.sister_of
+so:
+  label: records.place_death
+subject:
+  label: records.subject_access_fields
 tn:
-  label:
-    it: Nome di battesimo
-    fr: Nom baptismale
-    de: Taufname
-    en: Baptsimal name
-    es: Nombre bautismal
-    pl: Imię z chrztu
+  label: records.baptismal_name
 ub:
-  label:
-    it: Traduzione
-    fr: Traduction
-    de: Übersetzung
-    en: Translation
-    es: Traducción
-    pl: Tłumaczenie
-z:
-  label:
-    it: Ortografia alternativa
-    fr: Autres formes
-    de: Andere Schreibweise
-    en: Alternate spelling
-    es: Ortografía alternativa
-    pl: Alternatywna pisownia
+  label: records.translation
+unknown:
+  label: records.unknown
+variants:
+  label: records.name_variants
+wl:
+  label: records.country_active
+wo:
+  label: records.place_active
+wr:
+  label: records.region_active
 xx:
-  label:
-    it: Sconosciuto
-    fr: Inconnu
-    de: Unbekannt
-    en: Unknown
-    es: Desconcido
-    pl: Nieznane
-
+  label: records.unknown
+z:
+  label: records.alternate_spelling

--- a/config/editor_profiles/default/configurations/SourceLabels.yml
+++ b/config/editor_profiles/default/configurations/SourceLabels.yml
@@ -1,6167 +1,1384 @@
---- !map:ActiveSupport::HashWithIndifferentAccess
-
-doc_introduction:
-  label:
-    de: Einleitung
-    en: Introduction
-    it: Introduzione
-    pt: "Introdução"
-    es: "Introducción"
-    pl: Wprowadzenie
-doc_masks:
-  label:
-    de: Katalogisierung von Musikquellen
-    en: Cataloging musical sources
-    it: Catalogazione delle fonti musicali
-    pt: "Catalogando fontes musicais"
-    es: "Catalogación de fuentes musicales"
-    pl: Katalogowanie źródeł muzycznych
-doc_tag_index:
-  label:
-    de: MARC Tag Index
-    en: Index of MARC fields
-    it: Indice dei campi MARC
-    pt: "Índice dos campos MARC"
-    es: "Índice de campos MARC"
-    pl: Indeks pól MARC
-
-################
-
-doc_abbreviations:
-  label:
-    de: "Abkürzungen und Bezeichnungen"
-    en: "Abbreviations and terminology"
-    it: "Abbreviazioni e terminologia"
-    pt: "Abreviaturas e terminologia"
-    es: "Abreviaturas y terminología"
-    pl: Skróty i pojęcia
-doc_abbr_dates:
-  label:
-    de: "Datierung"
-    en: "Dates"
-    it: "Date"
-    pt: Data
-    es: "Fechas"
-    pl: Daty
-doc_abbr_general:
-  label:
-    de: "Allgemeine Abkürzungen und Begriffe"
-    en: "General abbreviations and terms"
-    it: "Abbreviazioni generali e terminologia"
-    pt: "Abreviaturas e termos gerais"
-    es: "Abreviaturas y términos generales"
-    pl: Ogólne skróty i pojęcia
-doc_abbr_keys:
-  label:
-    de: "Tonarten"
-    en: "Keys"
-    it: "Tonalità"
-    es: "Tonalidades"
-    pt: Tonalidades
-    pl: Tonacje
-doc_abbr_lang:
-  label:
-    de: "Sprachcodes"
-    en: "Language codes"
-    it: "Codice lingua"
-    pt: "Código de idioma"
-    es: "Código de Idioma"
-    pl: Kody języków
-doc_abbr_modes:
-  label:
-    de: "Kirchentonarten"
-    en: "Ecclesiastical modes"
-    it: "Modi ecclesiastici"
-    pt: "Modos eclesiáticos"
-    es: "Modos eclesiásticos"
-    pl: Skale kościelne
-doc_abbr_voices_instr:
-  label:
-    de: "Stimmen- und Instrumentenbezeichnungen"
-    en: "Terms for voices and instruments"
-    it: "Terminologia per voci e strumenti"
-    pt: Termos para vozes e instrumentos
-    es: "Terminología para voces e instrumentos"
-    pl: Określenia głosów i instrumentów
-doc_abbr_voices_instr2:
-  label:
-    de: "Stimmen- und Instrumentenbezeichnungen tabellarisch"
-    en: "RISM instrument abbreviations"
-    it: "Abbreviazioni RISM per gli strumenti"
-    pt: "Abreviaturas de instrumentos do RISM"
-    es: "Abreviaturas de instrumentos de RISM"
-    pl: Skróty instrumentów wg RISM
-
-###############
-
-doc_aid:
-  label:
-    de: Arbeitshilfen
-    en: Aide
-    it: Aiuti alla catalogazione
-    es: Ayuda
-    pl: Asystent
-doc_aid_liturgical_feasts:
-  label:
-    de: "Liturgische Feste"
-    en: "Liturgical festivals"
-    it: "Feste liturgiche"
-    pt: "Festa litúrgica"
-    es: "Festividades litúrgicas"
-    pl: Święta liturgiczne
-doc_aid_locations:
-  label:
-    de: "Fundorte auf Quellen"
-    en: "Locations on the source"
-    it: "Luogo sulla fonte"
-    es: "Ubicaciones en la fuente"
-    pl: Lokalizacje w źródle
-doc_aid_texts_sacred_works:
-  label:
-    de: "Standardtexte Sakralwerke"
-    en: "Standard texts of sacred works"
-    it: "Testo standard dei brani musicali sacri"
-    pt: "Textos padronizados de obras sacras"
-    es: "Textos estándar de obras sacras"
-    pl: Standardowe teksty utworów sakralnych
-doc_aid_titles_keywords:
-  label:
-    de: "Schlagworte"
-    en: "Subject headings"
-    it: "Intestazione del soggetto"
-    pt: "Cabeçalhos de assunto"
-    es: "Descriptores"
-    pl: Słowa kluczowe
-doc_aid_transposing_instruments:
-  label:
-    de: "Hilfe zur Transponierung von Instrumenten"
-    en: "Help for transposing instruments"
-    it: "Aiuto per gli strumenti traspositori"
-    pt: Ajuda para instrumentos transpositores
-    es: Ayuda para instrumentos transpositores
-    pl: Pomoc przy transpozycji instrumentów
-
-################
-
-doc_cataloguing:
-  label:
-    de: Allgemeine Erfassung Hilfe
-    en: General cataloging guidelines
-    it: Regole di catalogazione generali
-    pt: "Diretrizes gerais para catalogação"
-    es: "Lineamientos generales para la catalogación"
-    pl: Ogólne wskazówki do katalogowania
-doc_cat_collections:
-  label:
-    de: Erfassung von Sammlungen
-    en: Cataloging collections
-    it: Catalogazione delle raccolte
-    pt: "Catalogação de coletâneas"
-    es: "Catalogación de colecciones"
-    pl: Katalogowanie kolekcji
-doc_cat_language:
-  label:
-    de: Katalogisierungsspache
-    en: Cataloging language
-    it: Lingua di catalogazione
-    pt: "Idioma de catalogação"
-    es: "Idioma de catalogación"
-    pl: Język katalogowania
-doc_cat_templates:
-  label:
-    de: Templates
-    en: Templates
-    it: Template
-    pt: Modelos
-    es: Plantillas
-    pl: Szablony
-doc_cat_authorities:
-  label:
-    de: Normdaten
-    en: Authorities
-    it: Voci di autorità
-    pt: "Autoridades"
-    es: Autoridades
-    pl: Hasła wzorcowe
-doc_when_new_record:
-  label:
-    de: Wann soll einen neuen Eintrag erstellt werden (Musikdrucke)
-    en: When to input a new record (printed music)
-    it: Quando inserire una nuova scheda (edizioni musicali a stampa)
-    pt: "Quando criar um novo registro (música impressa)"
-    es: "Cuándo crear un nuevo registro (música impresa)"
-    pl: Kiedy wprowadzić nowy rekord (dla druków muzycznych)
-doc_scope_printed_music:
-  label:
-    de: Umfang der Dokumentation von Musikdrucke in RISM
-    en: Scope of printed music in RISM
-    it: Copertura delle edizioni musicali a stampa in RISM
-    pt: "Âmbito da música impressa no RISM"
-    es: "Cobertura de la música impresa en RISM"
-    pl: Zakres druków muzycznych w RISM
-doc_standardized_titles_printed_music:
-  label:
-    de: Einordnungstitel für Musikdrucke
-    en: Standardized titles for printed music
-    it: Titolo uniforme
-    pt: "Títulos uniformes para música impressa"
-    es: "Títulos uniformes para música impresa"
-    pl: Znormalizowane tytuły dla druków muzycznych
-
-################
-
-doc_editor:
-  label:
-    de: "Editor Hilfe"
-    en: Using Muscat
-    it: Guida all'editor
-    pt: "Catalogando fontes"
-    es: Uso de Muscat
-    pl: Korzystanie z Muscatu
-doc_edit_functions:
-  label:
-    de: "Grundsätzliche Funktionen"
-    en: Basic functions
-    it: Funzioni base
-    pt: "Funções básicas"
-    es: "Funciones básicas"
-    pl: Podstawowe funkcje
-doc_edit_workflow:
-  label:
-    de: "Workflow"
-    en: Workflow
-    it: Workflow
-    pl: Przepływ pracy
-doc_edit_searching:
-  label:
-    de: "Suche"
-    en: "Searching"
-    it: "Ricerca"
-    es: "Búsqueda"
-    pl: Wyszukiwanie
-
-
-
-################
-
-doc_library:
-  label:
-    de: Besitzerangaben
-    en: Library information
-    it: Informazioni sulla biblioteca
-    pt: "Informação da instituição"
-    es: "Información del repositorio"
-    pl: Informacje o bibliotece
-doc_provenance:
-  label:
-    de: Provenienz
-    en: Provenance
-    it: Provenienza
-    pt: "Proveniência"
-    es: Procedencia
-    pl: Pochodzenie
-doc_linkage:
-  label:
-    de: Verlinkung
-    en: Linkage
-    it: Collegamenti
-    es: "Vínculos"
-    pl: Powiązanie
-doc_diplomatic_title:
-  label:
-    de: Diplomatischer Titel
-    en: Diplomatic title
-    it: Titolo diplomatico
-    es: "Título diplomático"
-    pl: Tytuł dyplomatyczny
-doc_physical_description:
-  label:
-    de: Materialbeschreibung
-    en: Material description
-    it: Descrizione del materiale
-    pt: "Descrição de material"
-    es: "Descripción del material"
-    pl: Opis materiału
-doc_content:
-  label:
-    de: Inhalt
-    en: Content
-    it: Contenuto
-    es: Contenido
-    pl: Zawartość
-doc_incipit:
-  label:
-    de: Incipits
-    en: Incipits
-    it: Incipit
-    es: "Íncipits"
-    pl: Incipity
-doc_bibliographical_reference:
-  label:
-    de: Literatur
-    en: References
-    it: Riferimenti
-    pt: Referências
-    es: Referencias
-    pl: Odniesienia
-doc_added_entries:
-  label:
-    de: Nebeneintragungen
-    en: Added entry name
-    it: Nomi aggiuntivi
-    pl: Dodana nazwa wpisu
-doc_performance:
-  label:
-    de: "Aufführungen"
-    en: Performances
-    it: Esecuzioni
-    es: "Interpretaciones"
-    pl: Wykonania
-doc_date:
-  label:
-    de: Daten
-    en: Dates
-    it: Date
-    es: Fechas
-    pl: Daty
-doc_administration:
-  label:
-    de: Administration
-    en: Administration
-    it: Amministrazione
-    pt: "Administração"
-    es: "Administración"
-    pl: Administracja
-doc_personal_names:
-  label:
-    de: "Personen"
-    en: "Personal names"
-    it: "Nomi di persona"
-    pt: "Nomes de pessoas"
-    es: "Nombres personales"
-    pl: Osoby
-doc_images:
-  label:
-    de: "Bilder"
-    en: "Images"
-    it: "immagini"
-    pt: "Imagens"
-    es: "Imágenes"
-    pl: Obrazy
-doc_institutions:
-  label:
-    de: "Körperschaften"
-    en: "Institutions"
-    it: "Enti collettivi"
-    pt: "Instituições"
-    es: "Instituciones"
-    pl: Instytucje
-doc_title:
-  label:
-    de: "Titel und Inhaltsangaben"
-    en: "Title and content description"
-    it: "Titolo e descrizione del contenuto"
-    pt: "Título e descrição de conteúdo"
-    es: "Título y descripción del contenido"
-    pl: Tytuł i opis źródła
-doc_people:
-  label:
-    de: "Personen und Körperschaften"
-    en: "People and institutions"
-    it: "Persone ed enti colletivi"
-    pt: "Pessoas e instituições"
-    es: "Personas e instituciones"
-    pl: Osoby i instytucje
-doc_main_entry_fields:
-  label:
-    de: "Haupteintragungen"
-    en: "Main entry fields"
-    it: "Campi principali"
-    pt: "Campos de entrada principal"
-    es: "Campos principales"
-    pl: Główne pola edycji
-doc_mult_copies:
-  label:
-    de: "Mehrere Exemplare"
-    en: "Multiple copies"
-    it: "Exemplari multipli"
-    pt: "Múltiplos exemplares em uma instituição"
-    es: "Múltiples ejemplares en una institución"
-    pl: Wiele kopii
-doc_numbers:
-  label:
-    de: "Nummern und Codes"
-    en: "Numbers and code fields"
-    it: "Campi numerici e codici"
-    pt: "Números e campos de código"
-    es: "Números y campos de código"
-    pl: Pola liczb i kodów
-doc_name_variants:
-  label:
-    de: "Namensvarianten"
-    en: "Name variants"
-    it: "Varianti del nome"
-    pt: Variantes de nome
-    es: Variantes del nombre
-    pl: Alternatywne nazwy osoby
-doc_relations:
-  label:
-    de: "Beziehungen"
-    en: "Relations"
-    it: "Relazioni"
-    pt: "Relacionamentos"
-    es: "Relaciones"
-    pl: Relacje
-doc_references:
-  label:
-    de: "Literatur und Bemerkungen"
-    en: "References"
-    it: "Riferimenti"
-    pt: "Referências"
-    es: "Referencias"
-    pl: Odniesienia
-doc_record_actions:
-  label:
-    de: "Titel veröffentlichen"
-    en: "Record actions"
-    it: "Azioni per la scheda"
-    pt: "Ações do registro"
-    es: "Acciones del registro"
-    pl: Działania na rekordzie
-doc_record_status:
-  label:
-    de: "RECORD STATUS"
-    en: "Record status"
-    it: "Stato della scheda"
-    pt: "Estado do registro"
-    es: "Estado del registro"
-    pl: Status rekordu
-################
-
+'000':
+  label: records.leader
+'001':
+  label: records.rism_id_number
 01_codes_artistic:
-  label:
-    it: Autore
-    fr: Auteur
-    de: Verfasser
-    en: Artistic production
-    pl: Autor produkcji artystycznej
-02_codes_performing:
-  label:
-    it: Partecipanti
-    fr: Exécuteurs
-    de: Mitwirkende
-    en: Performance
-    pl: Wykonanie
-03_codes_technical:
-  label:
-    it: Produttore
-    fr: "Création"
-    de: Hersteller
-    en: Technical production
-    pl: Produkcja techniczna
-04_codes_other:
-  label:
-    it: Altri
-    fr: Autre
-    de: Weitere
-    en: Other
-    pl: Pozostałe
-
-################
-
-"000":
-  label:
-    it: Leader
-    fr: Guide
-    de: Leader
-    en: Leader
-    pt: "Líder"
-    es: "Líder"
-    pl: Leader
-"001":
-  label:
-    it: Numero documento RISM
-    fr: No. RISM
-    de: RISM Dokumentnummer
-    en: RISM ID No.
-    pt: "Número ID RISM"
-    es: "Número de ID de RISM"
-    pl: RISM ID
-"026":
-  label:
-    it: Impronta
-    fr: Indentificateur d'empreintes
-    de: Fingerprint-Erkennung
-    en: Fingerprint Identifier
-    pt: "Identificador de impressão"
-    es: "Identificador tipográfico"
-    pl: Identyfikator odcisku palca
-  fields:
-    a:
-      label:
-        it: Primo/Secondo gruppo
-        fr: Premier/deuxième groupe de caractères
-        de: Erste und zweite Zeichengruppe
-        en: First/second group
-        pt: Primeiro/Segundo grupo
-        es: Primero/segundo grupo
-        pl: Pierwsza / druga grupa
-      comment: "NEW IN 2018"
-    b:
-      label:
-        it: Terzo/Quarto gruppo
-        fr: Troisième/quatrième groupe de caractères
-        de: Dritte und vierte Zeichengruppe
-        en: Third/fourth group
-        pt: Terceiro/Quarto grupo
-        es: Tercero/cuarto grupo
-        pl: Grupa trzecia / czwarta
-      comment: "NEW IN 2018"
-    c:
-      label:
-        it: Data
-        fr: Date
-        de: Datum
-        en: Date
-        pt: Data
-        es: Fecha
-        pl: Data
-      comment: "NEW IN 2018"
-    d:
-      label:
-        it: Numero del volume/parte
-        fr: Nombre de volumes ou de pièces
-        de: Nummer des Bandes oder Teils
-        en: Number of volume/part
-        pt: "Número de volume/parte"
-        es: "Número de volúmen/parte"
-        pl: Numer wolumenu / części
-      comment: "NEW IN 2018"
-    e:
-      label:
-        it: Impronta non analizzata
-        fr: Empreinte non analysée
-        de: Zusammenhängender Fingerprint
-        en: Unparsed fingerprint
-        pt: "Identificador de impressão não analisado"
-        es: "Identificador tipográfico no disgregado"
-        pl: Nieprzeanalizowany odcisk palca
-      comment: "NEW IN 2018"
-028:
-  label:
-    it: Numero della lastra
-    fr: "Numéro de plaque"
-    de: Plattennummer
-    en: Plate Number
-    pt: "Número de chapa"
-    es: "Número de plancha"
-    pl: Numer wydawniczy
-  fields:
-    a:
-      label:
-        it: Numero della lastra
-        fr: "Numéro de plaque"
-        de: Plattennummer
-        en: Plate number
-        pt: "Número de chapa"
-        es: "Número de plancha"
-        pl: Numer wydawniczy
-    "8":
-      label:
-        it: Gruppo di materiale
-        fr: Documents
-        de: Set
-        en: Set
-        pt: Set
-        es: Set
-        pl: Zbiór
-"031":
-  label:
-    it: Incipit musicale
-    fr: Incipit musical
-    de: Musikincipit
-    en: Incipit
-    pt: Incipit
-    es: Íncipit
-    pl: Incipit
-  fields:
-    a:
-      label:
-        it: Numero dell'incipit
-        fr: "Numéro de l'œuvre"
-        de: Incipitnummer
-        en: Work number
-        pt: "Número de obra"
-        es: "Número de obra"
-        pl: Numer dzieła
-      edit_label:
-        it: Numero
-        fr: "No. de l'œuvre"
-        de: Nummer
-        en: Work number
-        pt: "Número de obra"
-        es: "Número de obra"
-        pl: Numer dzieła
-    b:
-      label:
-        it: Movimento N.
-        fr: "Numéro du mouvement"
-        de: Satznummer
-        en: Movement number
-        pt: "Número de movimento"
-        es: "Número de movimiento"
-        pl: Numer części
-      edit_label:
-        it: Movimento N.
-        fr: "No. du mouvement"
-        de: Satznummer
-        en: Movement number
-        pt: "Número de movimento"
-        es: "Número de movimiento"
-        pl: Numer części
-    c:
-      label:
-        it: Numero dell'estratto
-        fr: "Numéro de l'extrait"
-        de: Abschnitt
-        en: Incipit number
-        pt: "Número de incipit"
-        es: "Número de íncipit"
-        pl: Numer incipitu
-      edit_label:
-        it: Estratto No.
-        fr: "No. de l'extrait"
-        de: Nummer Abschnitt
-        en: Incipit number
-        pt: "Número de incipit"
-        es: "Número de íncipit"
-        pl: Numer incipitu
-    m:
-      label:
-        it: Organico
-        fr: Voix/instrument
-        de: Besetzung
-        en: Voice/instrument
-        pt: Voz/instrumento
-        es: Voz/instrumento
-        pl: Głos/instrument
-    n:
-      label:
-        it: Armatura di chiave
-        fr: Armure
-        de: Akzidentien
-        en: Key signature
-        pt: "Armadura de clave"
-        es: "Armadura de clave"
-        pl: Znaki przykluczowe
-      edit_label:
-        it: Armat.
-        fr: Armure
-        de: Vorzeichen
-        en: Key signature
-        pt: "Armadura de clave"
-        es: "Armadura de clave"
-        pl: Znaki przykluczowe
-    d:
-      label:
-        it: Intestazione, Tempo
-        fr: Titre/tempo
-        de: Satztitel, Tempo
-        en: Title of movement, tempo
-        pt: "Título do movimento, tempo"
-        es: "Título del movimiento, tempo"
-        pl: Tytuł części, tempo
-    o:
-      label:
-        it: Misura
-        fr: Indication de mesure
-        de: Metrum
-        en: Time signature
-        pt: Compasso
-        es: "Indicación de compás"
-        pl: Metrum
-      edit_label:
-        it: Misura
-        fr: Ind. mesure
-        de: Metrum
-        en: Time signature
-        pt: Compasso
-        es: "Indicación de compás"
-        pl: Metrum
-    e:
-      label:
-        it: Ruolo
-        fr: "Rôle"
-        de: Rolle
-        en: Role
-        pt: Personagem
-        es: Personaje
-        pl: Rola
-    p:
-      label:
-        it: Incipit musicale
-        fr: Notation musicale
-        de: Musikincipit
-        en: Music incipit
-        pt: Incipit musical
-        es: "Íncipit musical"
-        pl: Incipit muzyczny
-    q:
-      label:
-        it: Commento all'incipit mus.
-        fr: "Note générale"
-        de: Kommentar zum Musikincipit
-        en: General note
-        pt: Nota geral
-        es: Nota general
-        pl: Uwaga ogólna
-    g:
-      label:
-        it: Chiave
-        fr: "Clé"
-        de: "Schlüssel"
-        en: Clef
-        pt: Clave
-        es: Clave
-        pl: Klucz
-      edit_label:
-        it: Chiave
-        fr: "Clé"
-        de: "Schlüssel"
-        en: Clef
-        pt: Clave
-        es: Clave
-        pl: Klucz
-    r:
-      label:
-        it: "Tonalità, modo"
-        fr: "Tonalité, mode"
-        de: Tonart, Modus
-        en: Key or mode
-        pt: Tonalidade ou modo
-        es: Tonalidad o modo
-        pl: Tonacja lub modus
-      edit_label:
-        it: "Tonalità"
-        fr: "Tonalité"
-        de: Tonart
-        en: Key
-        pt: Tonalidade
-        es: Tonalidad
-        pl: Tonacja
-    s:
-      label:
-        it: "Validità"
-        fr: "Validité"
-        de: "Gültigkeit"
-        en: Validity
-        pt: Validade
-        es: Validez
-        pl: Ważność
-      edit_label:
-        it: "Validità"
-        fr: "Validité"
-        de: "Gültigkeit"
-        en: "Validity"
-        pt: Validade
-        es: Validez
-        pl: Ważność
-    t:
-      label:
-        it: Incipit testuale
-        fr: Incipit du texte
-        de: Textincipit
-        en: Text incipit
-        pt: "Incipit literário"
-        es: "Íncipit literario"
-        pl: Incipit tekstowy
-    z:
-      label:
-        it: Organico del movimento
-        fr: Distribution du mouvement
-        de: Besetzung Satz
-        en: Scoring in movement
-        pt: "Formação instrumental no movimento"
-        es: "Plantilla/orgánico del movimiento"
-        pl: Obsada w części
-"033":
-  label:
-    it: Data
-    fr: Date
-    de: Datum
-    en: Coded date
-    pt: Data codificada
-    es: Fecha codificada
-    pl: Znormalizowana data
-  fields:
-    a:
-      label:
-        it: Data e luogo di un evento
-        fr: "Date et lieu d'un événement"
-        de: Datum und Ort eines Ereignisses (codiert)
-        en: Coded date
-        pt: Data codificada
-        es: Fecha codificada
-        pl: Znormalizowana data
-    indicator:
-      label:
-        it: Tipo di datazione
-        fr: Type de date
-        de: Datierungtypus
-        en: Date type
-        pt: Tipo de data
-        es: Tipo de fecha
-        pl: Rodzaj daty
-    2#:
-      label:
-        it: Ambito di datazione
-        fr: Intervalle de dates
-        de: Datierungsbereich
-        en: Range of dates
-        pt: Faixa de datas
-        es: Rango de fechas
-        pl: Zakres dat
-    1#:
-      label:
-        it: Date singole multiple
-        fr: Dates uniques multiples
-        de: Mehrere Einzeldaten
-        en: Multiple single dates
-        pt: "Datas múltiplas"
-        es: "Fechas múltiples"
-        pl: Wiele pojedynczych dat
-    0#:
-      label:
-        it: Data singola
-        fr: Date unique
-        de: Einzeldatum
-        en: Single date
-        pt: "Data única"
-        es: "Fecha única"
-        pl: Pojedyncza data
-"035":
-  label:
-    it: Num. locale
-    fr: No. local
-    de: Lokale Nummer
-    en: Local Number
-    pt: "Número local"
-    es: "Número local"
-    pl: Numer kontrolny
-  fields:
-    a:
-      label:
-        it: Num. locale
-        fr: No. local
-        de: Lokale Nummer
-        en: Local ID no.
-        pt: "Número local"
-        es: "Número local"
-        pl: Local ID no.
-      edit_label:
-        en: ""
-"040":
-  label:
-    it: Fonte della catalogazione
-    fr: Source du catalogage
-    de: Katalogisierungsquelle
-    en: Cataloguing agency
-    pt: "Agência de catalogação"
-    es: "Agencia de catalogación"
-    pl: Jednostka katalogująca
-  fields:
-    b:
-      label:
-        it: Lingua della catalogazione
-        fr: Langue de catalogage
-        de: Katalogisierungssprache
-        en: Language of cataloguing
-        pt: "Idioma de catalogação"
-        es: "Idioma de catalogación"
-        pl: Język katalogowania
-"041":
-  label:
-    it: Codice di lingua
-    fr: Code de langue
-    de: Sprachcode
-    en: Language code
-    pt: "Código de idioma"
-    es: "Código de idioma"
-    pl: Kod języka
-  fields:
-    a:
-      label:
-        it: Lingua del testo cantato
-        fr: "Langue du texte chanté"
-        de: Sprachcode
-        en: Language of text
-        pt: "Idioma do texto"
-        es: "Idioma del texto"
-        pl: Język tekstu
-    e:
-      label:
-        it: Lingua del libretto
-        fr: Langue du livret
-        de: Sprachcode von Libretti
-        en: Language of libretto
-        pt: "Idioma do libreto"
-        es: "Idioma del libreto"
-        pl: Język libretta
-    h:
-      label:
-        it: Lingua del testo originale
-        fr: Langue du texte original
-        de: Sprachcode des Originaltextes
-        en: Language of original text
-        pt: "Idioma do texto original"
-        es: "Idioma del texto original"
-        pl: Język tekstu oryginalnego
-    indicator:
-      label:
-        it: Traduzione
-        fr: Traduction
-        de: "Übersetzung"
-        en: Translation
-        pt: "Tradução"
-        es: "Traducción"
-        pl: Tłumaczenie
-    1#:
-      label:
-        it: "Sì"
-        fr: Oui
-        de: Ja
-        en: "Yes"
-        pt: Sim
-        es: "Sí"
-        pl: Tak
-    0#:
-      label:
-        it: "No"
-        fr: Non
-        de: Nein
-        en: "No"
-        pt: "Não"
-        Es: "No"
-        pl: Nie
-"100":
-  label:
-    it: Compositore/Autore
-    fr: Compositeur/Auteur
-    de: Komponist/Autor
-    en: Composer/Author
-    pt: "Compositor/Autor"
-    es: Compositor/Autor
-    pl: Kompozytor / Autor
-  fields:
-    a:
-      label:
-        it: Nome
-        fr: Nom
-        de: Name
-        en: Name
-        pt: Nome
-        es: Nombre
-        pl: Imię i nazwisko
-    d:
-      label:
-        it: Data di nascita e di morte
-        fr: Dates de vie
-        de: Geburts- und Todesdaten
-        en: Life dates
-        pt: Datas de nascimento e morte
-        es: Fechas de nacimiento y muerte
-        pl: Daty urodzenia i śmierci
-    j:
-      label:
-        it: Qualificazione d'attribuzione
-        fr: Qualificatif d'attribution
-        de: Zuschreibungsvermerk
-        en: Attribution qualifier
-        pt: "Atribuição"
-        es: "Atribución"
-        pl: Kwalifikator atrybucji
-      edit_label:
-        it: Attribuzione
-        fr: Attribution
-        de: Zuschreibung
-        en: Attribution
-        pt: "Atribuição"
-        es: "Atribución"
-        pl: Atrybucja
-"240":
-  label:
-    it: Titolo uniforme
-    fr: Titre uniforme
-    de: Einordnungstitel
-    en: Standardized title
-    pt: "Título uniforme"
-    es: "Título uniforme"
-    pl: Znormalizowany tytuł
-  fields:
-    k:
-      label:
-        it: Suddivisione formale
-        fr: Sous-vedette de forme
-        de: Unterteilung nach der Form
-        en: Subheading
-        pt: Tipo especial de fonte
-        es: Tipo especial de fuente
-        pl: Pod-nagłówek
-    a:
-      label:
-        it: Titolo uniforme
-        fr: Titre uniforme
-        de: Einordnungstitel
-        en: Standardized title
-        pt: "Título uniforme"
-        es: "Título uniforme"
-        pl: Znormalizowany tytuł
-    m:
-      label:
-        it: Organico sintetico
-        fr: Distribution
-        de: Besetzungshinweis
-        en: Scoring summary
-        pt: "Sintese da formação instrumental"
-        es: "Resumen de Plantilla/Orgánico"
-        pl: Podsumowanie obsady
-    o:
-      label:
-        it: Arrangiamento
-        fr: Mention d'arrangement
-        de: Bearbeitung
-        en: Arrangement statement
-        pt: "Menção de arranjo"
-        es: "Declaración de arreglo"
-        pl: Uwaga do aranżacji
-    p:
-      label:
-        it: Titolo della sezione o parte
-        fr: Nom de la partie/section
-        en: Title of section or part
-        es: "Título de la sección o parte"
-        pl: Tytuł sekcji lub części
-    r:
-      label:
-        it: "Tonalità"
-        fr: "Tonalité"
-        de: Tonart
-        en: Key or mode
-        pt: Tonalidade ou modo
-        es: Tonalidad o modo
-        pl: Tonacja lub modus
-"245":
-  label:
-    it: Titolo diplomatico
-    fr: Titre diplomatique
-    de: Diplomatischer Titel
-    en: Title on source
-    pt: "Título na fonte"
-    es: "Título en fuente (diplomático)"
-    pl: Tytuł w źródle
-  fields:
-    a:
-      label:
-        it: Titolo diplomatico
-        fr: Titre diplomatique
-        de: Diplomatischer Titel
-        en: Title on source
-        pt: Título na fonte
-        es: "Título en fuente"
-        pl: Tytuł w źródle
-"246":
-  label:
-    it: Varianti del titolo diplomatico
-    fr: Variante du titre diplomatique
-    de: Weiterer diplomatischer Titel
-    en: Variant title on source
-    pt: "Título variante na fonte"
-    es: "Variante de título en fuente"
-    pl: Alternatywny tytuł w źródle
-  fields:
-    a:
-      label:
-        it: Varianti del titolo diplomatico
-        fr: Variante du titre diplomatique
-        de: Weiterer diplomatischer Titel
-        en: Variant title on manuscript
-        pt: "Variante de título na fonte"
-        es: "Variante de título en fuente"
-        pl: Alternatywny tytuł w rękopisie
-      edit_label:
-        en: ""
-"260":
-  label:
-    it: Copia o dati editoriali
-    fr: Copie ou impressum
-    de: Abschrift oder Impressum
-    en: "Publishing, Printing and Production Information"
-    pt: "Informação de publicação, impressão e produção"
-    es: "Información de publicación, impresión y producción"
-    pl: Informacje o publikacji, druku i produkcji
-  fields:
-    a:
-      label:
-        it: Luogo
-        fr: Lieu
-        de: Ort
-        en: Place
-        pt: Local
-        es: Lugar
-        pl: Miejsce
-    b:
-      label:
-        it: Copista, editore, casa editrice
-        fr: "Copiste ou maison d'édition"
-        de: Schreiber, Verleger, Verlag
-        en: Publisher, copyist
-        pt: Editor, copista
-        es: Editor, copista
-        pl: Wydawca, kopista
-    c:
-      label:
-        it: Anno
-        fr: "Année"
-        de: Jahr
-        en: Date
-        pt: Data
-        es: Fecha
-        pl: Data
-    e:
-      label:
-        it: Luogo di stampa
-        fr: Lieu d'impression
-        de: Druckort
-        en: Location of printer
-        pt: Local de impressão
-        es: "Lugar de impresión"
-        pl: Lokalizacja drukarni
-    f:
-      label:
-        it: Stampatore, stamperia
-        fr: Imprimeur, imprimerie
-        de: Drucker, Druckerei
-        en: Name of printer
-        pt: Nome do impressor
-        es: Nombre del impresor
-        pl: Nazwa drukarni
-    "8":
-      label:
-        it: Gruppo di materiale
-        fr: Documents
-        de: Set
-        en: Set
-        pt: Set
-        es: Set
-        pl: Zbiór
-"300":
-  label:
-    it: Materiale
-    fr: "Matériel"
-    de: Material
-    en: Physical description
-    pt: "Descrição física"
-    es: "Descripción física"
-    pl: Opis fizyczny
-  fields:
-    a:
-      label:
-        it: Categoria di fonte, estensione
-        fr: Type de source
-        de: Quellenart, Umfang
-        en: Format, extent
-        pt: "Formato, extensão"
-        es: "Formato, extensión"
-        pl: Rodzaj źródła, objętość
-    b:
-      label:
-        it: Altri dettagli sul materiale
-        fr: Autres détails du matériau
-        de: Zusätzliche Materialbeschreibung
-        en: Other physical details
-        pt: "Outros detalhes físicos"
-        es: "Otros detalles físicos"
-        pl: Pozostałe dane fizyczne
-    c:
-      label:
-        it: Dimensioni
-        fr: Dimension
-        de: Format
-        en: Dimensions
-        pt: "Dimensões"
-        es: "Dimensiones"
-        pl: Wymiary
-    "8":
-      label:
-        it: Gruppo di materiale
-        fr: Documents
-        de: Set
-        en: Set
-        pt: Set
-        es: Set
-        pl: Zbiór
-"340":
-  label:
-    it: Tecnica di produzione speciale
-    fr: "Technique de production spéciale"
-    de: Spezielle Fertigungstechnik
-    en: Special production technique
-    pt: "Técnica de produção especial"
-    es: "Técnica de producción específica"
-    pl: Specjalna technika produkcji
-  fields:
-    d:
-      label:
-        it: Tecnica di stampa
-        fr: "Technique d'impression"
-        de: Drucktechnik
-        en: Printing technique
-        pt: "Técnica de impressão"
-        es: "Técnica de impresión"
-        pl: Technika druku
-    m:
-      label:
-        it: Formato librario
-        fr: Format du livre
-        de: Buchformat
-        en: Book format
-        pt: Formato do livro
-        es: Formato de libro
-        pl: Format książki
-      comment: "NEW IN 2018"
-    "8":
-      label:
-        it: Gruppo di materiale
-        fr: Documents
-        de: Set
-        en: Set
-        pt: Set
-        es: Set
-        pl: Zbiór
-"383":
-  label:
-    it: Num. d'opera
-    fr: "Opus"
-    de: Opus
-    en: Opus number
-    pt: Número de Opus
-    es: "Número de Opus"
-    pl: Numer opus
-  fields:
-    b:
-      label:
-        it: Num. d'opera
-        fr: "No. de Opus"
-        de: Opus
-        en: Opus number
-        pt: "Número de opus"
-        pl: Numer opus
-"500":
-  label:
-    it: Osservazioni
-    fr: "Remarque générale"
-    de: Bemerkungen
-    en: General note
-    pt: Nota geral
-    es: Nota general
-    pl: Uwaga ogólna
-  fields:
-    a:
-      label:
-        it: Osservazioni
-        fr: "Remarque générale"
-        de: Bemerkungen
-        en: General note
-        pt: Nota geral
-        es: Nota general
-        pl: Uwaga ogólna
-      edit_label:
-        en: ""
-    "8":
-      label:
-        it: Gruppo di materiale
-        fr: Documents
-        de: Set
-        en: Set
-        pt: Set
-        es: Set
-        pl: Zbiór
-"505":
-  label:
-    it: Nota di contenuto
-    fr: Remarque sur le contenu
-    de: Bemerkungen zu Inhaltsangaben
-    en: Contents note
-    pt: "Nota de conteúdo"
-    es: Nota sobre el contenido
-    pl: Uwaga do zawartości
-  fields:
-    a:
-      label:
-        it: Nota di contenuto
-        fr: Remarque sur le contenu
-        de: Bemerkungen zu Inhaltsangaben
-        en: Contents note
-        pt: "Nota de conteúdo"
-        es: Nota sobre el contenido
-        pl: Uwaga do zawartości
-      edit_label:
-        en: ""
-"506":
-  label:
-    it: Restrizioni all'accesso
-    fr: Restriction d'accès
-    de: "Zugangsbeschränkungen"
-    en: Access restrictions
-    pt: "Restrições de acesso"
-    es: Restricciones de acceso
-    pl: Ograniczenia dostępu
-  fields:
-    a:
-      label:
-        it: Restrizioni all'accesso
-        fr: Restriction d'accès
-        de: "Zugangsbeschränkungen"
-        en: Access restriction
-        pt: "Restrições de acesso"
-        es: Restricciones de acceso
-        pl: Ograniczenie dostępu
-      edit_label:
-        en: ""
-"508":
-  label:
-    it: Nota sulle responsabilità di creazione/produzione
-    fr: "Remarque sur la création/production"
-    de: Bemerkung zur Person / Körperschaft
-    en: Creation/production note
-    pt: "Nota de produção/criação"
-    es: "Nota de producción/creación"
-    pl: Uwagi do wytworzenia / produkcji
-  fields:
-    a:
-      label:
-        it: Nota sulle responsabilità di creazione/produzione
-        fr: "Note sur la création/production"
-        de: Bemerkung zur Person / Körperschaft
-        en: Creation/production note
-        pt: "Nota de produção/criação"
-        es: "Nota de producción/creación"
-        pl: Uwagi do wytworzenia / produkcji
-      edit_label:
-        en: ""
-"510":
-  label:
-    it: Serie RISM
-    fr: Série RISM
-    de: RISM Series
-    en: RISM Series
-    pt: "Série RISM"
-    es: Serie RISM
-    pl: Seria RISM
-  fields:
-    a:
-      label:
-        it: Serie
-        fr: Série
-        de: Series
-        en: Series
-        pt: "Séries"
-        es: Serie
-        pl: Seria
-    c:
-      label:
-        it: N.o
-        fr: "No"
-        de: "No"
-        en: "No"
-        pt: "Não"
-        es: "No"
-        pl: Nie
-"518":
-  label:
-    it: Nota sull'esecuzione
-    fr: "Remarque sur les interprètes"
-    de: "Bemerkungen zu den Aufführungen"
-    en: Note on performance
-    pt: Nota sobre performance
-    es: "Nota sobre ocasión de interpretación"
-    pl: Uwaga o wykonaniu
-  fields:
-    a:
-      label:
-        it: Nota sull'esecuzione
-        fr: "Remarque sur les interprètes"
-        de: "Bemerkungen zu den Aufführungen"
-        en: Note on Performance
-        pt: Nota sobre performance
-        es: "Nota sobre ocasión de interpretación"
-        pl: Uwaga o wykonaniu
-      edit_label:
-        en: ""
-"520":
-  label:
-    it: Riassunto
-    fr: "Résumé"
-    de: Zusammenfassende Beschreibung
-    en: Description summary
-    pt: "Síntese da descrição"
-    es: "Descripción sumaria"
-    pl: Podsumowanie
-  fields:
-    a:
-      label:
-        it: Riassunto
-        fr: "Résumé"
-        de: Zusammenfassende Beschreibung
-        en: Description summary
-        pt: "Síntese da descrição"
-        es: "Descripción sumaria"
-        pl: Podsumowanie
-      edit_label:
-        en: ""
-"525":
-  label:
-    it: Materiali allegati
-    fr: "Matériel supplémentaire"
-    de: Beigelegtes Material, Addenda
-    en: Supplementary material
-    pt: Material suplementar
-    es: Material suplementario
-    pl: Materiał uzupełniający
-  fields:
-    a:
-      label:
-        it: Materiali allegati
-        fr: "Matériel supplémentaire"
-        de: Beigelegtes Material, Addenda
-        en: Supplementary material
-        pt: Material suplementar
-        es: Material suplementario
-        pl: Materiał uzupełniający
-      edit_label:
-        en: ""
-"541":
-  label:
-    it: Fonte immediata d'acquisto
-    fr: Source d'acquisition
-    de: Unmittelbare Beschaffungsquelle
-    en: Source of acquisition
-    pt: "Origem da aquisição"
-    es: "Fuente de adquisición"
-    pl: Źródło nabycia
-  fields:
-    a:
-      label:
-        it: Nota sulla fonte d'acquisto
-        fr: Source d'acquisition
-        de: Beschaffungsquelle
-        en: Source of acquisition note
-        pt: "Nota de origem da aquisição"
-        es: "Nota sobre la fuente de adquisición"
-        pl: Uwaga o źródle nabycia
-    c:
-      label:
-        it: Metodo d'acquisto
-        fr: "Méthode d'acquisition"
-        de: Beschaffungsart
-        en: Method of acquisition
-        pt: "Método de aquisição"
-        es: "Método de adquisición"
-        pl: Sposób nabycia
-    d:
-      label:
-        it: Data d'acquisto
-        fr: Date d'acquisition
-        de: Beschaffungsdatum
-        en: Date of acquisition
-        pt: "Data de aquisição"
-        es: "Fecha de adquisición"
-        pl: Data nabycia
-    e:
-      label:
-        it: Numero di acquisizione
-        fr: Numéro d'acquisition
-        de: Akzessionsnumer
-        en: Accession number
-        pt: "Número de aquisição"
-        es: "Número de accesión"
-        pl: Numer akcesji
-"546":
-  label:
-    it: Nota sulla lingua
-    fr: Note sur la langue
-    de: Sprachenvermerk
-    en: Language note
-    pt: "Nota de idioma"
-    es: "Nota de idioma"
-    pl: Uwaga o języku
-  fields:
-    a:
-      label:
-        it: Nota sulla lingua
-        fr: Note sur la langue
-        de: Sprachenvermerk
-        en: Language note
-        pt: "Nota de idioma"
-        es: "Nota de idioma"
-        pl: Uwaga o języku
-      edit_label:
-        en: ""
-"561":
-  label:
-    it: Provenienza
-    fr: Provenance
-    de: Provenienzvermerke
-    en: Provenance note
-    pt: "Nota de proveniência"
-    es: Nota de procedencia
-    pl: Uwaga o pochodzeniu
-  fields:
-    a:
-      label:
-        it: Provenienza
-        fr: Provenance
-        de: Provenienzvermerke
-        en: Provenance notes
-        pt: "Nota de proveniência"
-        es: Nota de procedencia
-        pl: Uwagi o pochodzeniu
-      edit_label:
-        en: ""
-"563":
-  label:
-    it: Rilegatura
-    fr: Reliure
-    de: Einband
-    en: Binding note
-    pt: "Nota de encadernação"
-    es: "Nota de encuadernación"
-    pl: Uwaga o oprawie
-  fields:
-    a:
-      label:
-        it: Rilegatura
-        fr: Reliure
-        de: Einband
-        en: Binding note
-        pt: "Nota de encadernação"
-        es: "Nota de encuadernación"
-        pl: Uwaga o oprawie
-    u:
-      label:
-        it: "INUTILIZZATO - VERRÀ RIMOSSO"
-        fr: "UNUSED - WILL BE REMOVED"
-        de: "UNUSED - WILL BE REMOVED"
-        en: "UNUSED - WILL BE REMOVED"
-        pt: "UNUSED - WILL BE REMOVED"
-        es: "EN DESUSO - SERÁ REMOVIDO"
-        comment: "NEW IN 2018"
-        pl: NIEWYKORZYSTANE – DO USUNIĘCIA
-"588":
-  label:
-    it: Copa esaminata per la catalogazione
-    fr: Copie consultée pour le catalogage
-    de: Vorlageexemplar
-    en: Source of description note
-    pt: "Exemplar examinado para catalogação"
-    es: "Copia examinada para la catalogación"
-    pl: Uwaga o źródle opisu
-  fields:
-    a:
-      label:
-        it: Copa esaminata per la catalogazione
-        fr: Copie consultée pour le catalogage
-        de: Vorlageexemplar
-        en: Copy examined for cataloging
-        pt: "Exemplar examinado para catalogação"
-        es: "Copia examinada para la catalogación"
-        pl: Katalogowany egzemplarz
-      comment: "NEW IN 2018"
-"590":
-  label:
-    it: Parti staccate
-    fr: Parties
-    de: Stimmenmaterial
-    en: Parts held and extent
-    pt: "Partes existentes e extensão"
-    es: "Particellas conservadas y extensión de las mismas"
-    pl: Głosy, objętość
-  fields:
-    a:
-      label:
-        it: Parti staccate esistenti
-        fr: Parties existantes
-        de: Vorhandene Stimmen
-        en: Parts held
-        pt: Partes existentes
-        es: Particellas conservadas
-        pl: Głosy
-    b:
-      label:
-        it: Estensione (parti)
-        fr: Extension (parties)
-        de: Umfang Stimmenmaterial
-        en: Extent (parts)
-        pt: "Extensão das partes"
-        es: "Extensión (particellas)"
-        pl: Objętność
-    "8":
-      label:
-        it: Gruppo di materiale
-        fr: Documents
-        de: Set
-        en: Set
-        pt: Set
-        es: Set
-        pl: Zbiór
-"591":
-  label:
-    it: Altra segnatura
-    fr: Autre cote
-    de: Weitere Signatur
-    en: Other shelfmark
-    pt: "Outro código"
-    es: Otra signatura
-    pl: Inna sygnatura
-  fields:
-    a:
-      label:
-        it: Altra segnatura
-        fr: Autre cote
-        de: Weitere Signatur
-        en: Other shelfmark
-        pt: "Outro código"
-        es: Otra signatura
-        pl: Inna sygnatura
-"592":
-  label:
-    it: Filigrana
-    fr: Filigrane
-    de: Wasserzeichen
-    en: Watermark description
-    pt: "Descrição de Marca de água"
-    es: "Descripción de las filigranas"
-    pl: Opis znaku wodnego
-  fields:
-    a:
-      label:
-        it: Filigrana
-        fr: Filigrane
-        de: Wasserzeichen
-        en: Watermark description
-        pt: "Descrição de Marca de água"
-        es: "Descripción de las filigranas"
-        pl: Opis znaku wodnego
-    "8":
-      label:
-        it: Gruppo di materiale
-        fr: Documents
-        de: Set
-        en: Set
-        pt: Set
-        es: Set
-        pl: Zbiór
-"593":
-  label:
-    it: Categoria di fonte
-    fr: Type de source
-    de: Quellentyp
-    en: Source type
-    pt: Tipo de fonte
-    es: Tipo de fuente
-    pl: Rodzaj źródła
-  fields:
-    a:
-      label:
-        it: Categoria
-        fr: Type
-        de: Typ
-        en: Type
-        pt: Tipo
-        es: Tipo
-        pl: Rodzaj
-    "8":
-      label:
-        it: Gruppo di materiale
-        fr: Documents
-        de: Set
-        en: Set
-        pt: Set
-        es: Set
-        pl: Zbiór
-"594":
-  label:
-    it: Organico
-    fr: Instrumentation
-    de: Besetzung
-    en: Total scoring
-    pt: "Formação total"
-    es: "Plantilla/orgánico total"
-    pl: Szczegółowy opis obsady
-  fields:
-    b:
-      label:
-        it: Organico
-        fr: Instrumentation
-        de: Besetzung
-        en: "Voice/instrument"
-        pt: "Voz/instrumento"
-        es: "Voz/instrumento"
-        pl: Głos/instrument
- ##       fields:
-    c:
-      label:
-        it: Numero
-        fr: Nombre
-        de: Anzahl
-        en: Number
-        pt: "Número"
-        es: "Número"
-        pl: Liczba
-"595":
-  label:
-    it: "Ruoli: nomi  dei personaggi"
-    fr: "Rôles: noms"
-    de: "Rollennamen: Schreibweise"
-    en: Named dramatic roles
-    pt: "Papéis dramáticos identificados"
-    es: "Nombres de personajes"
-    pl: Postaci
-  fields:
-    a:
-      label:
-        it: Nomi di ruoli standardizzati
-        fr: "Noms de rôles standardisés"
-        de: Rollennamen, standardisierte Schreibweise
-        en: Dramatic roles named, standardized
-        pt: "Papéis dramáticos identificados, normalizados"
-        es: "Nombres de personajes, normalizados"
-        pl: Znormalizowane nazwy postaci
-    u:
-      label:
-        it: "Nomi originali dei personaggi"
-        fr: "Noms originaux"
-        de: "Originale Schreibweise"
-        en: Dramatic roles named, original spelling
-        pt: "Papéis dramáticos mencionado, grafia original"
-        es: "Nombres de personajes, ortografía original"
-        pl: Postaci w oryginalnej pisowni
-"596":
-  label:
-    it: Rimandi a RISM A/I e RISM B
-    fr: "Référence au RISM A/I et B"
-    de: Querverweise zu RISM A/I und RISM B
-    en: RISM Series A/I and B references
-    pt: "Referências às Séries RISM A/I e B"
-    es: Referencias a las Series RISM A/I y B
-    pl: Odniesienia do serii RISM A/I i B
-  fields:
-    a:
-      label:
-        it: Serie RISM
-        fr: "Références au RISM A/I et B"
-        de: Querverweise zu RISM A/I und RISM B
-        en: RISM Series A/I and B references
-        pt: "Referências às séries RISM A/I e B"
-        es: Referencias a las Series RISM A/I y B
-        pl: Odniesienia do serii RISM A/I i B
-      edit_label:
-      en: ""
-    b:
-      label:
-        it: Numero RISM
-        fr: Numéro RISM
-        de: RISM-Nummer
-        en: RISM series number
-        pt: "Número de série RISM"
-        es: "Número de serie RISM"
-        pl: Nr seryjny RISM
-      edit_label:
-      en: ""
-    c:
-      label:
-        it: Numero identificativo della scheda di riferimento
-        fr: REFERENCE RECORD ID
-        de: REFERENCE RECORD ID
-        en: REFERENCE RECORD ID
-        pt: REFERENCE RECORD ID
-        es: ID del Registro de Referencia
-        pl: Referncyjny identyfikator RISM
-      edit_label:
-      comment: "NEW IN 2018"
-"597":
-  label:
-    it: Colofone
-    fr: COLOPHON
-    de: Kolophon
-    en: Colophon
-    pt: "Colofão"
-    es: "Colofón"
-    pl: Kolofon
-  fields:
-    a:
-      label:
-        it: Colofone
-        fr: COLOPHON
-        de: Kolophon
-        en: Colophon
-        pt: "Colofão"
-        es: "Colofón"
-        pl: Kolofon
-"598":
-  label:
-    it: Codice della strumentazione
-    fr: Instrumentation codée
-    de: "Kodierte Besetzung"
-    en: Coded instrumentation
-    pt: "Instrumentação codificada"
-    es: "Intrumentación codificada"
-    pl: Standaryzowany zapis instrumentacji
-  fields:
-    a:
-      label:
-        it: Voce solista
-        fr: Voix seule
-        de: Solostimme
-        en: Solo voice
-        pt: Voz solista
-        es: Voz solista
-        pl: Głos solowy
-
-      edit_label:
-        it: Vsolo
-        fr: Vsolo
-        de: Vsolo
-        en: Vocal solo
-        pt: Voz solista
-        es: Voz solista
-        pl: Solo wokalne
-
-    b:
-      label:
-        it: Voce solista aggiuntiva
-        fr: Voix seule additionnelle
-        de: "Zusätzliche Solostimme"
-        en: Additional solo voice
-        es: Voz solista adicional
-        pl: Dodatkowy głos solowy
-      edit_label:
-        it: Vsolo
-        fr: Vsolo
-        de: Vsolo
-        en: Vocal solo
-        pt: Voz solista
-        es: Voz solista
-        pl: Solo wokalne
-    c:
-      label:
-        it: Voci di coro
-        fr: Voix de choeur
-        de: Chorstimmen
-        en: Choir voice
-        es: Voz en coro
-        pl: Głos chóralny
-      edit_label:
-        it: Coro
-        fr: Coro
-        de: Coro
-        en: Chorus
-        pt: Coro
-        es: Coro
-        pl: Chór
-
-    d:
-      label:
-        it: Voci di coro aggiuntive
-        fr: Voix de choeur additionnelles
-        de: "Zusätzliche Chorstimmen"
-        en: Additional choir voice
-        es: Voz en coro adicional
-        pl: Dodatkowy głos chóralny
-      edit_label:
-        it: Coro
-        fr: Coro
-        de: Coro
-        en: Coro
-        pt: Coro
-        es: Coro
-        pl: Chór
-
-    e:
-      label:
-        it: Strumento solista
-        fr: Instrument soliste
-        de: Solistisches Instrument
-        en: Soloist intrument
-        es: Instrumento solista
-        pl: Instrument solowy
-      edit_label:
-        it: iSol
-        fr: iSol
-        de: iSol
-        en: Solo instruments
-        pt: Instrumento solista
-        es: Instrumento solista
-        pl: Instrumenty solowe
-    f:
-      label:
-        it: Archi
-        fr: Cordes
-        de: Streichinstrumente
-        en: Strings
-        pt: Cordas
-        es: Cuerdas
-        pl: Instrumenty strunowe
-      edit_label:
-        it: strings
-        fr: strings
-        de: strings
-        en: Strings
-        pt: Cordas
-        es: Cuerdas
-        pl: Instrumenty strunowe
-    g:
-      label:
-        it: Legni
-        fr: Bois
-        de: Holzblasinstrumente
-        en: Woodwinds
-        pt: Madeiras
-        es: Vientos-madera
-        pl: Instrumenty dęte drewniane
-      edit_label:
-        it: woodwinds
-        fr: woodwinds
-        de: woodwinds
-        en: Woodwinds
-        pt: Madeiras
-        es: Vientos-madera
-        pl: Instrumenty dęte drewniane
-    h:
-      label:
-        it: Ottoni
-        fr: Cuivres
-        de: Blechblasinstrumente
-        en: Brass instruments
-        pt: Metais
-        es: Vientos-metal
-        pl: Instrumenty dęte blaszane
-      edit_label:
-        it: brasses
-        fr: brasses
-        de: brass instruments
-        en: Brass instruments
-        pt: Metais
-        es: Vientos-metal
-        pl: Instrumenty dęte blaszane
-    i:
-      label:
-        it: Strumenti a pizzico
-        fr: "Instruments à cordes pincées"
-        de: Zupfinstrumente
-        en: Plucked instruments
-        pt: Cordas dedilhadas
-        es: Cuerdas pulsadas
-        pl: Instrumenty szarpane
-      edit_label:
-        it: plck
-        fr: plck
-        de: plck
-        en: Plucked
-        pt: Cordas dedilhadas
-        es: Cuerdas pulsadas
-        pl: Instrumenty szarpane
-    k:
-      label:
-        it: Strumenti a percussione
-        fr: Percussions
-        de: Schlaginstrumente
-        en: Percussion
-        pt: "Percussão"
-        pl: Perkusja
-      edit_label:
-        it: stck
-        fr: stck
-        de: stck
-        en: Percussion
-        pt: "Percussão"
-        es: "Percusión"
-        pl: Perkusja
-    l:
-      label:
-        it: Strumenti a tastiera
-        fr: "Instruments à clavier"
-        de: Tasteninstrumente
-        en: Keyboards
-        pt: Teclados
-        pl: Instrumenty klawiszowe
-      edit_label:
-        it: keyb
-        fr: keby
-        de: keyb
-        en: Keyboards
-        pt: Teclados
-        es: Teclados
-        pl: Instrumenty klawiszowe
-    m:
-      label:
-        it: Altri strumenti
-        fr: Autres instruments
-        de: Weitere Instrumente
-        en: Other instruments
-        pt: Outros instrumentos
-        es: Otros instrumentos
-        pl: Pozostałe instrumenty
-      edit_label:
-        it: other instr.
-        fr: other instr.
-        de: other instr.
-        en: other instruments
-        pt: Outros instrumentos
-        es: Otros instrumentos
-        pl: Pozostałe instrumenty
-    n:
-      label:
-        it: Basso continuo
-        fr: Basso continuo
-        de: Basso continuo
-        en: Basso continuo
-        pt: "Contínuo"
-        es: Bajo continuo
-        pl: Basso continuo
-      edit_label:
-        it: B.c.
-        fr: B.c.
-        de: B.c.
-        en: Continuo
-        pt: "Contínuo"
-        es: Continuo
-        pl: Continuo
-"599":
-  label:
-    it: Commenti interni
-    fr: Commentaires internes
-    de: Interne Fussnoten
-    en: Internal note
-    pt: Campo de notas locais
-    es: Nota interna
-    pl: Uwaga wewnętrzna
-  fields:
-    a:
-      label:
-        it: Commenti interni
-        fr: Commentaires internes
-        de: Interne Fussnoten
-        en: Internal note
-        pt: Campo de notas locais
-        es: Nota interna
-        pl: Uwaga wewnętrzna
-      edit_label:
-        en: ""
-    b:
-      label:
-        it: RECORD AUDIT
-        fr: RECORD AUDIT
-        de: RECORD AUDIT
-        en: RECORD AUDIT
-        pt: RECORD AUDIT
-        es: RECORD AUDIT
-        pl: RECORD AUDIT
-      edit_label:
-        en: ""
-      comment: "NEW IN 2018; filled out automatically by wf_stage"
-"650":
-  label:
-    it: Parola chiave
-    fr: Sujets
-    de: Schlagworteintragung
-    en: Subject heading
-    pt: "Cabeçalho de assunto"
-    es: "Descriptor"
-    pl: Słowo kluczowe
-  fields:
-    a:
-      label:
-        it: Parola chiave
-        de: Sachschlagwort
-        fr: Sujet
-        en: Subject heading
-        pt: "Cabeçalho de assunto"
-        es: "Descriptor"
-        pl: Słowo kluczowe
-      edit_label:
-        en: ""
-"651":
-  label:
-    it: Luogo di un evento
-    fr: "Lieu d'un événement"
-    de: "Aufführungsort"
-    en: Location of performance
-    pt: "Local de performance"
-    es: "Lugar de interpretación"
-    pl: Lokalizacja wykonania
-  fields:
-    a:
-      label:
-        it: Luogo di un evento
-        fr: "Lieu d'un événement"
-        de: "Aufführungsort"
-        en: Location of performance
-        pt: "Local de performance"
-        es: "Lugar de interpretación"
-        pl: Lokalizacja wykonania
-      edit_label:
-        en: ""
-"657":
-  label:
-    it: Feste liturgiche
-    fr: "Fête liturgique"
-    de: Liturgische Feste
-    en: Liturgical festival
-    pt: "Festa litúrgica"
-    es: "Festividad litúrgica"
-    pl: Święto liturgiczne
-  fields:
-    a:
-      label:
-        it: Feste liturgiche
-        fr: "Fête liturgique"
-        de: Liturgische Feste
-        en: Liturgical feasts
-        pt: "Festa litúrgica"
-        es: "Festividad litúrgica"
-        pl: Święta liturgiczne
-      edit_label:
-        en: ""
-"690":
-  label:
-    it: Catalogo tematico
-    fr: Nom de catalogue
-    de: Werkverzeichnis
-    en: Catalog of works
-    pt: "Catálogo de obras"
-    es: "Catálogo de obras"
-    pl: Katalog dzieł
-  fields:
-    a:
-      label:
-        it: Catalogo tematico
-        fr: Nom de catalogue
-        de: Werkverzeichnis
-        en: Catalog of works
-        pt: "Catálogo de obras"
-        es: "Catálogo de obras"
-        pl: Katalog dzieł
-    n:
-      label:
-        it: Numero/pagina
-        fr: "Numéro/page"
-        de: Nummer/Seitenzahl
-        en: Number/page
-        pt: "Número/página"
-        es: "Número/página"
-        pl: Numer / strona
-"691":
-  label:
-    it: Riferimenti bibliografici
-    fr: "Référence bibliographique"
-    de: Literaturverweis
-    en: Bibliographic reference
-    pt: "Referência bibliográfica"
-    es: "Referencia bibliográfica"
-    pl: Odniesienie bibliograficzne
-  fields:
-    a:
-      label:
-        it: Bibliografia
-        fr: "Référence bibliographique"
-        de: Literatur
-        en: Bibliographic reference
-        pt: "Referência bibliográfica"
-        es: "Referencia bibliográfica"
-        pl: Odniesienie bibliograficzne
-    n:
-      label:
-        it: Numero/pagina
-        fr: "Numéro/page"
-        de: Fundstelle
-        en: Number/page
-        pt: "Número/página"
-        es: "Número/página"
-        pl: Numer / strona
-"700":
-  label:
-    it: Nomi di persone aggiuntivi
-    fr: Noms de personnes additionnels
-    de: Nebeneintragung Personen
-    en: Additional personal name
-    pt: Nome de pessoa adicional
-    es: Nombre personal adicional
-    pl: Dodatkowa osoba
-  fields:
-    a:
-      label:
-        it: Nome
-        fr: Nom
-        de: Personenname
-        en: Name
-        pt: Nome
-        es: Nombre
-        pl: Imię i nazwisko
-    d:
-      label:
-        it: Date di nascita e di morte
-        fr: Dates de vie
-        de: Geburts- und Todesdaten
-        en: Life dates
-        pt: Datas de nascimento e morte
-        es: Fechas de nacimiento y muerte
-        pl: Daty urodzenia i śmierci
-    j:
-      label:
-        it: Qualificazione d'attribuzione
-        fr: Qualificatif d'attribution
-        de: Zuschreibungsvermerk
-        en: Attribution qualifier
-        pt: "Atribuição"
-        es: "Calificador de atribución"
-        pl: Kwalifikator atrybucji
-      edit_label:
-        it: Attribuzione
-        fr: Attribution
-        de: Zuschreibung
-        en: Attribution
-        pt: "Atribuição"
-        es: "Atribución"
-        pl: Atrybucja
-    "4":
-      label:
-        it: Funzione
-        fr: Function
-        de: Funktionsbezeichnung
-        en: Function
-        pt: "Função"
-        es: "Función"
-        pl: Funkcja
-    "8":
-      label:
-        it: Gruppo di materiale
-        fr: Documents
-        de: Set
-        en: Set
-        pt: Set
-        es: Set
-        pl: Zbiór
-"710":
-  label:
-    it: Nome di ente
-    fr: "Nom de la collectivité"
-    de: Nebeneintragung Körperschaften
-    en: Additional institution
-    pt: "Instituição adicional"
-    es: "Institución adicional"
-    pl: Dodatkowa instytucja
-  fields:
-    a:
-      label:
-        it: Nome di ente
-        fr: "Nom de la collectivité"
-        de: Körperschaftsname
-        en: Institution
-        pt: "Instituição"
-        es: "Institución"
-        pl: Instytucja
-    b:
-      label:
-        it: Ente subordinato
-        fr: "Collectivité subordonnée"
-        de: Untergeordnete Körperschaft
-        en: Department
-        pt: Departamento
-        es: Departamento
-        pl: Wydział
-    g:
-      label:
-        it: Qualificazione d'attribuzione
-        fr: Qualificatif d'attribution
-        de: Zuschreibungsvermerk
-        en: Attribution qualifier
-        pt: "Atribuição"
-        es: "Atribución"
-        pl: Kwalifikator atrybucji
-      edit_label:
-        it: Attribuzione
-        fr: Attribution
-        de: Zuschreibung
-        en: Attribution
-        pt: "Atribuição"
-        es: "Atribución"
-        pl: Atrybucja
-
-    "4":
-      label:
-        it: Funzione
-        fr: Fonction
-        de: Funktionsbezeichnung
-        en: Function
-        pt: "Função"
-        es: "Función"
-        pl: Funkcja
-    "8":
-      label:
-        it: Gruppo di materiale
-        fr: Documents
-        de: Set
-        en: Set
-        pt: Set
-        es: Set
-        pl: Zbiór
-"730":
-  label:
-    it: Titolo uniforme alternativo
-    fr: Titres uniformes additionnels
-    de: Alternativer Titel
-    en: Additional title
-    pt: "Título adicional"
-    es: "Título adicional"
-    pl: Dodatkowy tytuł
-  fields:
-    a:
-      label:
-        it: Titolo uniforme alternativo
-        fr: Titres uniformes additionnels
-        de: Alternativer Titel
-        en: Additional title
-        pt: "Título adicional"
-        es: "Título adicional"
-        pl: Dodatkowy tytuł
-    g:
-      label:
-        it: Regole di cat.
-        fr: Règle de cat.
-        de: Regelwerk
-        en: Rule type
-        pt: "Regras de catalogação"
-        es: "Tipo de regla"
-        pl: Standard
-    k:
-      label:
-        it: Suddivisione formale
-        fr: Sous-vedette de forme
-        de: Unterteilung nach der Form
-        en: Subheading
-        pt: "Subdivisão de forma"
-        es: Tipo especial de fuente
-        pl: Pod-nagłówek
-    m:
-      label:
-        it: Organico sintetico
-        fr: Distribution
-        de: Besetzungshinweis
-        en: Scoring summary
-        pt: "Sintese da formação instrumental"
-        es: "Resumen de plantilla/orgánico"
-        pl: Podsumowanie obsady
-    n:
-      label:
-        it: Catalogo/Numero d'opera
-        fr: "No. de catalogue thématique/Opus"
-        de: Werkverzeichnis/Opus
-        en: Catalogue number/Opus number
-        pt: "Número de catalogo/Número de Opus"
-        pl: Numer katalogu / numer opus
-    o:
-      label:
-        it: Arrangiamento
-        fr: Mention d'arrangement
-        de: Bearbeitung
-        en: Arrangement statement
-        pt: "Menção de arranjo"
-        es: "Declaración de arreglo"
-        pl: Uwaga do aranżacji
-    r:
-      label:
-        it: "Tonalità"
-        fr: "Tonalité"
-        de: Tonart
-        en: Key
-        pt: Tonalidade
-        es: Tonalidad
-        pl: Tonacja
-"774":
-  label:
-    it: Singoli oggetti nella fonte
-    fr: Contenu de la source
-    de: Untergeordnete Einträge
-    en: Items in this source
-    pt: Itens nesta fonte
-    es: "Ítems en esta fuente"
-    pl: Pozycje w tym źródle
-  fields:
-    w:
-      label:
-        it: Singolo oggetto nella fonte
-        fr: Source dans cette collection
-        de: Untergeordneter Eintrag
-        en: Item in this collection
-        pt: Itens nesta fonte
-        es: "Ítems en esta fuente"
-        pl: Pozycja w tej kolekcji
-      edit_label:
-        en: ""
-"773":
-  label:
-    it: Notizia principale
-    fr: Source principale
-    de: Übergeordneter Eintrag
-    en: Parent record
-    pt: "Registro principal"
-    es: Registro madre
-    pl: Rekord macierzysty
-  fields:
-    w:
-      label:
-        it: Notizia principale
-        fr: Source principale
-        de: Übergeordneter Eintrag
-        en: Parent record
-        pt: "Registro principal"
-        es: Registro madre
-        pl: Rekord macierzysty
-      edit_label:
-        en: ""
-"775":
-  label:
-    it: Prima notizia
-    fr: "Première entrée"
-    de: Ersteintrag
-    en: Initial entry
-    pt: Entrada inicial
-    es: Entrada inicial
-    pl: Początkowy wpis
-  fields:
-    w:
-      label:
-        it: Prima notizia
-        fr: "Première entrée"
-        de: Ersteintrag
-        en: Initial entry
-        pt: Entrada inicial
-        es: Entrada inicial
-        pl: Początkowy wpis
-      edit_label:
-        en: ""
-"787":
-  label:
-    it: Inserimenti
-    fr: Insertions
-    de: Einlagen
-    en: Insertions
-    pt: "Inserções"
-    es: Inserciones
-    pl: Wstawienia
-  fields:
-    w:
-      label:
-        it: Numero RISM dell'opera principale
-        fr: "Numéro RISM de la source"
-        de: RISM Dokumentnummer des Hauptwerks
-        en: RISM ID number
-        pt: "Número ID RISM"
-        es: "Número de ID de RISM"
-        pl: RISM ID
-    n:
-      label:
-        it: Collocazione dell'inserimento nell'opera principale
-        fr: Remarque sur l'endroit de l'insertion
-        de: Stelle der Einlage im Hauptwerk
-        en: Location of insertion
-        pt: "Localização da inserção"
-        es: "Ubiación de la inserción"
-        pl: Lokalizacja wstawienia
-    g:
-      label:
-        it: N.o dell'incipit
-        fr: No. d'incipit
-        de: Incipitnummer
-        en: Incipit number
-        pt: "Número de incipit"
-        es: "Número de íncipit"
-        pl: Numer incipitu
-    s:
-      label:
-        it: Titolo uniforme
-        fr: Titre uniforme
-        de: Einordnungstitel des Hauptwerks
-        en: Standardized title
-        pt: "Título uniforme"
-        es: "Título uniforme"
-        pl: Znormalizowany tytuł
-"852":
-  label:
-    it: Sigla della biblioteca
-    fr: "Sigle de bibliothèque"
-    de: Bibliothekssigel
-    en: Library siglum
-    pt: "Sigla da Instituição"
-    es: "Sigla del repositorio"
-    pl: Siglum
-  fields:
-    a:
-      label:
-        it: Sigla della biblioteca
-        fr: "Sigle de bibliothèque"
-        de: Bibliothekssigel
-        en: Library siglum
-        pt: "Sigla da Instituição"
-        es: "Sigla del repositorio"
-        pl: Siglum
-    b:
-      label:
-        it: Dipartimento
-        fr: Section
-        de: Abteilung
-        en: Department
-        pt: Departamento
-        es: Departamento
-        pl: Wydział
-    c:
-      label:
-        it: Segnatura
-        fr: Cote
-        de: Signatur
-        en: Shelfmark
-        pt: "Código"
-        es: "Signatura"
-        pl: Sygnatura
-    d:
-      label:
-        it: Segnatura vecchia (olim)
-        fr: Ancienne cote (olim)
-        de: Alte Signatur (olim)
-        en: Shelfmark (olim)
-        pt: "Código antigo (olim)"
-        es: Signatura antigua (olim)
-        pl: Sygnatura (wcześniejsza)
-    e:
-      label:
-        it: Biblioteca
-        fr: "Bibliothèque"
-        de: Bibliothek
-        en: Library
-        pt: "Instituição"
-        es: "Repositorio"
-        pl: Biblioteka
-    q:
-      label:
-        it: Materiale conservato
-        fr: Matériaux préservées
-        de: Erhaltenes Material
-        en: Material held
-        pt: Material existente
-        es: Material conservado
-        pl: Posiadany materiał
-    u:
-      label:
-        it: URI
-        fr: URI
-        de: URI
-        en: URI
-        pt: URI
-        es: URI
-        pl: URI
-    z:
-      label:
-        it: Nome del fondo
-        fr: Fonds
-        de: Bestandsname
-        en: Provenance
-        pt: "Proveniência"
-        es: Procedencia
-        pl: Pochodzenie
-"856":
-  label:
-    it: Localizzazione e accesso elettronico
-    fr: "Ressource électronique externe"
-    de: Elektronische Lokalisierung und Zugriff
-    en: External resource
-    pt: Recurso externo
-    es: Recurso externo
-    pl: Zasób zewnętrzny
-  fields:
-    z:
-      label:
-        it: Nota destinata al pubblico
-        fr: Remarque sur la ressource externe
-        de: "Für das Publikum bestimmte Fussnote"
-        en: Note about external resource
-        pt: Nota sobre recurso externo
-        es: Nota sobre el recurso externo
-        pl: Uwaga o zasobie zewnętrznym
-    u:
-      label:
-        it: Risorsa esterna
-        fr: Ressource externe
-        de: Uniform Resource Identifier
-        en: External resource
-        pt: Recurso externo
-        es: Nota sobre recurso externo
-        pl: Zasób zewnętrzny
-    x:
-      label:
-        it: Tipo di collegamento
-        fr: Type de lien
-        de: Linktyp
-        en: Link type
-        pt: Tipo de Link
-        es: Tipo de enlace
-        pl: Typ odsyłacza
-"930":
-  label:
-    it: Composizione
-    fr: Oeuvre
-    de: Werktitel
-    en: Work
-    pt: Obra
-    es: Obra
-    pl: Dzieło
-  fields:
-    a:
-      label:
-        it: Composizione
-        de: Werktitel
-        fr: Oeuvre
-        en: Work
-        pt: Obra
-        es: Obra
-        pl: Dzieło
-      edit_label:
-        en: ""
-      comment: "NEW IN 2018; experimental stage"
-"980":
-  label:
-    it: Origine della scheda
-    fr: RECORD ORIGIN
-    de: Herkunft
-    en: Record origin
-    pt: "Origem do registro"
-    es: Origen del registro
-    pl: Pochodzenie rekordu
-  fields:
-    a:
-      label:
-        it: Origine
-        fr: ORIGIN
-        de: Herkunft
-        en: Origin
-        pt: Origem
-        es: Origen
-        pl: Pochodzenie
-      comment: "NEW IN 2018"
-    b:
-      label:
-        it: Livello di catalogazione
-        fr: CATALOGING LEVEL
-        de: Erfassungstiefe
-        en: Cataloging level
-        es: Nivel de catalogación
-        pt: "Nível de catalogação"
-        pl: Poziom katalogowania
-      comment: "NEW IN 2018"
-    c:
-      label:
-        it: Materiale esaminato
-        fr: MATERIAL EXAMINED
-        de: Autopsie
-        en: Material examined
-        es: Material examinado
-        pl: Zbadany materiał
-      comment: "NEW IN 2018"
-
-################
-
-show_admin:
-  label:
-    it: Amministrazione
-    fr: Administration
-    de: Administration
-    en: Administration
-    pt: "Administração"
-    es: "Administración"
-    pl: Administracja
-show_content:
-  label:
-    it: Contenuto
-    fr: Contenu
-    de: Inhalt
-    en: Content
-    es: Contenido
-    pl: Zawartość
-show_distribution:
-  label:
-    it: Organico
-    fr: Distribution
-    de: Besetzung
-    en: Distribution
-    es: Distribución
-    pl: Dystrybucja
-show_information:
-  label:
-    it: Note
-    fr: "Information supplémentaire"
-    de: Anmerkungen
-    en: Further information
-    es: "Más información"
-    pl: Dalsze informacje
-show_library:
-  label:
-    it: Biblioteca
-    fr: "Bibliothèque"
-    de: Besitzerangaben
-    en: Library information
-    pt: "Informação da instituição"
-    es: "Información del repositorio"
-    pl: Informacje o bibliotece
-show_links:
-  label:
-    it: Titoli connessi
-    fr: Titres connexes
-    de: Verlinkungen
-    en: Related Titles
-    es: "Títulos relacionados"
-    pl: Powiązane tytuły
-show_material:
-  label:
-    it: Descrizione del materiale
-    fr: "Description du matériel"
-    de: Materialbeschreibung
-    en: Material description
-    pt: "Descrição de material"
-    es: "Descripción del material"
-    pl: Opis materiału
-show_references:
-  label:
-    it: Bibliografia
-    fr: "Références"
-    de: Literatur
-    en: References
-    pt: "Referências"
-    es: "Referencias"
-    pl: Odniesienia
-show_resources:
-  label:
-    it: Collegamenti
-    fr: Liens
-    de: Links
-    en: Related resources
-    es: Recursos relacionados
-    pl: Powiązane zasoby
-show_summary:
-  label:
-    it: Riassunto
-    fr: "Résumé"
-    de: Zusammenfassung
-    en: Summary
-    es: Resumen
-    pl: Podsumowanie
-show_terms:
-  label:
-    it: Descrittori
-    fr: Termes
-    de: Deskriptoren
-    en: Index terms
-    es: "Términos de indexación"
-    pl: Pojęcia indeksowane
-
-################
-
-edit_administration:
-  label:
-    it: Amministrazione
-    fr: Administration
-    de: Administration
-    en: Administration
-    pt: "Administração"
-    es: "Administración"
-    pl: Administracja
-edit_content:
-  label:
-    it: Titolo e descrizione del contenuto
-    fr: Titre et description du contenu
-    de: Titel und Inhaltsangaben
-    en: Title and content description
-    pt: "Título e descrição do conteúdo"
-    es: "Título y descripción del contenido"
-    pl: Tytuł i opis źródła
-edit_incipits:
-  label:
-    it: Incipit
-    fr: Incipits
-    de: Incipits
-    en: Incipits
-    pt: Incipit
-    es: "Íncipits"
-    pl: Incipity
-edit_library:
-  label:
-    it: Biblioteca e relazione
-    fr: "Bibliothèque et relations"
-    de: Besitzerangaben und Verlinkung
-    en: Library information and relations
-    pt: "Informação da instituição e relações"
-    es: "Información del repositorio y sus relaciones"
-    pl: Informacje o bibliotece i powiązaniach
-edit_material:
-  label:
-    it: Descrizione del materiale
-    fr: "Description du matériel"
-    de: Materialbeschreibung
-    en: Material description
-    pt: "Descrição de material"
-    es: "Descripción del material"
-    pl: Opis materiału
-
-edit_names:
-  label:
-    it: Persone e istituzione
-    fr: Personnes et institutions
-    de: Personen und Körperschaften
-    en: People and institutions
-    pt: "Pessoas e instituições"
-    es: "Personas e instituciones"
-    pl: Osoby i instytucje
-edit_references:
-  label:
-    it: Bibliografia e note
-    fr: "Références et notes"
-    de: Literatur und Fussnoten
-    en: References and notes
-    pt: "Notas e referências"
-    es: "Notas y referencias"
-    pl: Odniesienia i uwagi
-edit_works:
-  label:
-    it: Composizione
-    fr: Oeuvre
-    de: Werk
-    en: Work
-    pt: Obra
-    es: Obra
-    pl: Dzieło
-
-unmatched:
-  label:
-    it: Campi sconoscuti
-    fr: Champs non reconnus
-    de: Unbekannte Felder
-    en: Unknown fields
-    es: Campos desconocidos
-    pl: Pola nieznane
-
-ungrouped:
-  label:
-    it: Campi non raggruppati
-    fr: "Champs non rgroupés"
-    de: Nicht zugeteilte Felder
-    en: Ungrouped fields
-    es: Campos no agrupados
-    pl: Pola niezgrupowane
-
-################
-
-arr:
-  label:
-    it: Arrangiatore
-    fr: Arrangeur
-    de: Bearbeiter
-    en: Arranger
-    pt: "Arranjador [arr]"
-    es: Arreglador
-    pl: Aranżer
-art:
-  label:
-    it: Scenografo
-    fr: "Metteur en scène"
-    de: "Bühnenbildner"
-    en: Artist
-    es: Puestista
-    pl: Artysta
-asg:
-  label:
-    it: Incaricato
-    fr: Cessionnaire
-    de: Lizenznehmer
-    en: Assignee
-    es: Asignatario
-    pt: "Cessionário [asg]"
-    pl: Cesjonariusz
-aut:
-  label:
-    it: Autore
-    fr: Auteur
-    de: Autor
-    en: Author
-    pt: "Autor [aut]"
-    es: Autor
-    pl: Autor
-bnd:
-  label:
-    it: Rilegatore
-    fr: Relieur
-    de: Buchbinder
-    en: Binder
-    es: Encuadernador
-    pl: Introligator
-bsl:
-  label:
-    it: Libraio musicale
-    fr: Libraire
-    de: "Musikalienhändler"
-    en: Bookseller
-    pt: "Livreiro [bsl]"
-    es: Librero
-    pl: Księgarz
-ccp:
-  label:
-    it: Autore della fonte letteraria
-    fr: Auteur du texte
-    de: Autor der Textvorlage
-    en: Conceptor
-    pt: "Criador [ccp]"
-    es: Autor del concepto
-    pl: Autor koncepcji
-chr:
-  label:
-    it: Coreografo
-    fr: "Chorégraphe"
-    de: Choreograph
-    en: Choreographer
-    es: "Coreógrafo"
-    pl: Choreograf
-clb:
-  label:
-    it: Autore secondario
-    fr: Collabarateur
-    de: Mitverfasser
-    en: Contributor
-    es: Colaborador
-    pl: Kontrybutor
-cmp:
-  label:
-    it: Rimando ad altro compositore
-    fr: Compositeur / Co-compositeur
-    de: Komponistenquerverweis
-    en: Composer cross-reference
-    pt: "Referência cruzada de compositor [cmp]"
-    es: Referencia cruzada de compositor
-    pl: Odniesienie do innego kompozytora
-cnd:
-  label:
-    it: Direttore d'orchestra
-    fr: Chef d'orchestre
-    de: Dirigent
-    en: Conductor
-    es: Director musical
-    pl: Dyrygent
-cns:
-  label:
-    it: Censore
-    fr: Censeur
-    de: Zensor
-    en: Censor
-    pt: "Censor [cns]"
-    es: Censor
-    pl: Cenzor
-com:
-  label:
-    it: Compilatore
-    fr: Compilateur
-    de: Kompilator
-    en: Compiler
-    es: Compilador
-    pl: Kompilator
-cph:
-  label:
-    it: Titolare dei diritti d'autore
-    fr: Titulaire du droit d'auteur
-    de: Rechteinhaber
-    en: Copyright holder
-    es: Titular de los derechos de copia
-    pt: "Detentor dos direitos de cópia/reprodução [cph]"
-    pl: Posiadacz praw autorskich
-cst:
-  label:
-    it: Costumista
-    fr: Costumier
-    de: "Kostümbildner"
-    en: Costume designer
-    es: Vestuarista
-    pl: Projektant kostiumów
-ctb:
-  label:
-    it: Compositore secondario
-    fr: Contributeur
-    de: Mitkomponist
-    en: Co-composer
-    pt: "Co-compositor [ctb]"
-    es: "Co-compositor"
-    pl: Współkompozytor
-ccp:
-  label:
-    it: Ideatore
-    fr: Concepteur
-    de: Autor der Textvorlage
-    en: Conceptor
-    pt: "Conceptor [ccp]"
-    es: Autor del concepto
-    pl: Autor koncepcji
-dnc:
-  label:
-    it: Ballerino
-    fr: Danceur
-    de: "Tänzer"
-    en: Dancer
-    es: "Bailarín(a)"
-    pl: Tancerz
-dnr:
-  label:
-    it: Donatore
-    fr: Donateur
-    de: Donator
-    en: Donor
-    es: Donante
-    pl: Donator
-dpt:
-  label:
-    it: Depositante
-    fr: Dépositeur
-    de: Depositor
-    en: Depositor
-    pt: "Depositante [dpt]"
-    es: Depositario
-    pl: Deponent
-dsr:
-  label:
-    it: Progettista
-    fr: Décorateur
-    de: Designer
-    en: Designer
-    es: "Diseñador"
-    pl: Projektant
-dte:
-  label:
-    it: Dedicatario
-    fr: "Dédicataire"
-    de: "Widmungsträger"
-    en: Dedicatee
-    pt: "Dedicatário(a) [dte]"
-    es: "Dedicatario(a)"
-    pl: Adresat dedykacji
-dst:
-  label:
-    it: Distributore
-    fr: "Distributeur"
-    de: "Vertrieb"
-    en: Distributor
-    pt: "Distribuidor [dst]"
-    es: Distribuidor
-    pl: Dystrybutor
-asn:
-  label:
-    it: Nome associato
-    fr: Nom associé
-    de: Zugehöriger Name
-    en: Associated name
-    es: Nombre asociado
-    pt: "Nome associado [asn]"
-    pl: Powiązana osoba
-edt:
-  label:
-    it: Curatore
-    fr: Editeur
-    de: Herausgeber
-    en: Editor
-    pt: "Editor [edt]"
-    es: "Editor (curador)/Editorial"
-    pl: Edytor
-egr:
-  label:
-    it: Incisore
-    fr: Graveur
-    de: Stecher
-    en: Engraver
-    pt: "Gravador [egr]"
-    es: Grabador
-    pl: Rytownik
-evp:
-  label:
-    it: "Luogo dell’evento"
-    fr: "Lieu de l'événement"
-    de: Veranstaltungsort
-    en: Event place
-    pt: "Local do evento [evp]"
-    es: Lugar del evento
-    pl: Miejsce wydarzenia
-fmo:
-  label:
-    it: Proprietario precedente
-    fr: "Propriétaire précédent"
-    de: Vorbesitzer
-    en: Former owner
-    pt: "Proprietário anterior [fmo]"
-    es: Propietario anterior
-    pl: Poprzedni właściciel
-ill:
-  label:
-    it: Disegnatore
-    fr: Illustrateur
-    de: Illustrator
-    en: Illustrator
-    pt: "Ilustrador [ill]"
-    es: Ilustrador
-    pl: Ilustrator
-itr:
-  label:
-    it: Strumentista
-    fr: Instrumentiste
-    de: Instrumentalist
-    en: Instrumentalist
-    es: Instrumentista
-    pl: Instrumentalista
-lbt:
-  label:
-    it: Librettista
-    fr: Librettiste
-    de: Librettist
-    en: Librettist
-    pt: "Libretista [lbt]"
-    es: Libretista
-    pl: Autor libretta
-lse:
-  label:
-    it: Licenziatario
-    fr: Licencié
-    de: Lizenzinhaber
-    en: Licensee
-    es: Licenciatario
-    pt: "Titular [lse]"
-    pl: Licencjobiorca
-ltg:
-  label:
-    it: Litografo
-    fr: Litographe
-    de: Lithograph
-    en: Lithographer
-    pt: "Litógrafo [ltg]"
-    es: "Litógrafo"
-    pl: Litograf
-lyr:
-  label:
-    it: Poeta
-    fr: Parolier
-    de: Textdichter
-    en: Text author
-    pt: "Autor literário [lyr]"
-    es: Autor del texto
-    pl: Autor tekstu
-oth:
-  label:
-    it: Altra funzione
-    fr: Autre function
-    de: Sonstige Funktion
-    en: Other
-    pt: "Outro(a) [oth]"
-    es: Otro
-    pl: Pozostałe
-otm:
-  label:
-    it: Organizzatore
-    fr: Organisateur
-    de: Veranstalter
-    en: Event organizer
-    es: Organizador de evento
-    pl: Organizator wydarzenia
-pat:
-  label:
-    it: Committente
-    fr: "Mécène"
-    de: "Mäzen/Auftraggeber"
-    en: Patron
-    es: Comitente
-    pl: Sponsor
-pbl:
-  label:
-    it: Editore
-    fr: Editeur
-    de: Verleger
-    en: Publisher
-    pt: "Casa editora [pbl]"
-    es: "Editor (publicador)/Editorial (publicadora)"
-    pl: Wydawca
-ppm:
-  label:
-    it: Fabbricante di carta
-    fr: Papetier
-    de: Papierhersteller
-    en: Papermaker
-    es: Fabricante de papel
-    pt: "Fabricante de papel [ppm]"
-    pl: Producent papieru
-prd:
-  label:
-    it: Personale alla produzione
-    fr: "Personnel de réalisation"
-    de: Produktionspersonal
-    en: Production personnel
-    es: "Personal de producción"
-    pl: Personel produkcyjny
-prf:
-  label:
-    it: Interprete
-    fr: "Interprète"
-    de: Interpret
-    en: Performer
-    pt: "Intérprete [prf]"
-    es: "Intérprete"
-    pl: Wykonawca
-prt:
-  label:
-    it: Stampatore
-    fr: Imprimeur
-    de: Drucker
-    en: Printer
-    pt: "Impressor(a) [prt]"
-    es: Impresor
-    pl: Drukarnia
-pub:
-  label:
-    it: Editore
-    fr: Editeur
-    de: Verleger
-    en: Publisher
-    pt: "Publicador [pub]"
-    es: Editor
-    pl: Wydawca
-scr:
-  label:
-    it: Copista
-    fr: Copiste / Scribe
-    de: Schreiber
-    en: Copyist
-    pt: "Copista [scr]"
-    es: Copista
-    pl: Kopista
-trl:
-  label:
-    it: Traduttore
-    fr: Traducteur
-    de: "Übersetzer"
-    en: Translator
-    pt: "Tradutor [trl]"
-    es: Traductor
-    pl: Tłumacz
-voc:
-  label:
-    it: Cantante
-    fr: Vocaliste
-    de: "Sänger"
-    en: Vocalist
-    es: Cantante
-    pl: Wokalista
-#Attribution qualifier for 100/700$j
-"Verified":
-  label:
-    it: Verificata
-    fr: "Vérifié"
-    de: Gesichert
-    en: Verified
-    es: Verificada
-    pt: Verificada
-    pl: Zweryfikowane
-"Ascertained":
-  label:
-    it: Accertata
-    fr: "Authentifié"
-    de: Ermittelt
-    en: Ascertained
-    es: Certificada
-    pt: Certificada
-    pl: Stwierdzone
-"Alleged":
-  label:
-    it: Presunta
-    fr: "Présumé"
-    de: Angeblich
-    en: Alleged
-    es: Supuesta
-    pt: Suposta
-    pl: Domniemane
-"Doubtful":
-  label:
-    it: Dubbia
-    fr: "Douteux"
-    de: Zweifelhaft
-    en: Doubtful
-    es: Dudosa
-    pt: Duvidosa
-    pl: Wątpliwe
-"Misattributed":
-  label:
-    it: Erronea
-    fr: "Erroné"
-    de: Fälschlich
-    en: Misattributed
-    es: Mal atribuida
-    pt: Equivocada
-    pl: Błędnie przypisane
-"Conjectural":
-  label:
-    it: Congetturale
-    fr: Conjectural
-    de: Mutmaßlich
-    en: Conjectural
-    es: Conjetural
-    pt: Conjetural
-    pl: Spekulatywne
-# Marc Language codes
-afr:
-  label:
-    IT: Afrikaans
-    FR: Afrikaans
-    de: Afrikaans
-    en: Afrikaans
-    pt: "Africânder"
-    es: "Afrikáans"
-    pl: Afrykanerski
-ara:
-  label:
-    IT: Arabo
-    FR: Arabe
-    de: Arabisch
-    en: Arabic
-    pt: "Árabe"
-    es: "Árabe"
-    pl: Arabski
-arg:
-  label:
-    IT: Aragonese
-    FR: Aragonais
-    de: Aragonesisch
-    en: Aragonese
-    pt: "Aragonês"
-    es: "Aragonés"
-    pl: Aragoński
-arm:
-  label:
-    it: Armeno
-    fr: Arménien
-    de: Armenische
-    en: Armenian
-    pt: Arménio
-    es: Armenio
-    pl: Armeński
-art:
-  label:
-    it: Artificial (Other)
-    fr: Artificial (Other)
-    de: Artificial (Other)
-    en: Artificial (Other)
-    pt: Artificial (Other)
-    es: Artificial (otros)
-    pl: Sztuczny (inny)
-baq:
-  label:
-    it: Basco
-    fr: Basque
-    de: Baskisch
-    en: Basque
-    pt: Basco
-    es: Vasco
-    pl: Baskijski
-bos:
-  label:
-    it: Bosniaco
-    fr: Bosnien
-    de: Bosnisch
-    en: Bosnian
-    pt: Bósnio
-    es: Bosnio
-    pl: Bośniacki
-bul:
-  label:
-    it: Bulgaro
-    fr: Bulgare
-    de: Bulgarisch
-    en: Bulgarian
-    pt: "Búlgaro"
-    es: "Búlgaro"
-    pl: Bułgarski
-cat:
-  label:
-    it: Catalano
-    fr: Catalan
-    de: Katalanisch
-    en: Catalan
-    pt: "Catalão"
-    es: "Catalán"
-    pl: Kataloński
-cel:
-  label:
-    it: Celtic (Other)
-    fr: Celtic (Other)
-    de: Celtic (Other)
-    en: Celtic (Other)
-    pt: Celtic (Other)
-    es: Céltico (otros)
-    pl: Celtycki (inny)
-chi:
-  label:
-    it: Cinese
-    fr: Chinois
-    de: Chinesisch
-    en: Chinese
-    pt: "Chinês"
-    es: Chino
-    pl: Chiński
-chu:
-  label:
-    it: Lingua slava ecclesiastica antica
-    fr: "Slave ancien ecclésiastique"
-    de: Altkirchenslawisch
-    en: Old Church Slavonic
-    pt: "Antigo eslavo eclesiástico"
-    es: "Antiguo eslavo eclesiástico"
-    pl: Starocerkiewny
-crp:
-  label:
-    it: Creoles and Pidgins (Other)
-    fr: Creoles and Pidgins (Other)
-    de: Creoles and Pidgins (Other)
-    en: Creoles and Pidgins (Other)
-    pt: Creoles and Pidgins (Other)
-    es: Creoles y Pidgins (otros)
-    pl: Kreolski i Pidgin (inne)
-cze:
-  label:
-    it: Ceco
-    fr: Tchèque
-    de: Tschechisch
-    en: Czech
-    pt: Tcheco
-    es: Checo
-    pl: Czeski
-dan:
-  label:
-    it: Danese
-    fr: Danois
-    de: Dänisch
-    en: Danish
-    pt: "Dinamarquês"
-    es: "Danés"
-    pl: Duński
-dut:
-  label:
-    it: Olandese
-    fr: Néerlandais
-    de: Niederländisch
-    en: Dutch
-    pt: "Holandês"
-    es: "Holandés"
-    pl: Holenderski
-eng:
-  label:
-    it: Inglese
-    fr: Anglais
-    de: Englisch
-    en: English
-    pt: "Inglês"
-    es: "Inglés"
-    pl: Angielski
-enm:
-  label:
-    IT: Lingua inglese medievale
-    FR: Anglais médiéval
-    de: Mittelenglisch
-    en: Middle English
-    pt: "Inglês médio"
-    es: "Inglés medio"
-    pl: Środkowoangielski
-est:
-  label:
-    IT: Estone
-    FR: Estonien
-    de: Estnisch
-    en: Estonian
-    pt: Estoniano
-    es: Estonio
-    pl: Estoński
-fas:
-  label:
-    IT: Persiano
-    FR: PERSIAN
-    de: Persisch
-    en: Persian
-    pt: Persa
-    es: Persa
-    pl: Perski
-fij:
-  label:
-    it: Figi
-    fr: Fidjien
-    de: Fidschianisch
-    en: Fijian
-    pt: Fijianas
-    es: Fijiano
-    pl: Fidżyjski
-fin:
-  label:
-    IT: Finlandese
-    FR: Finlandais
-    de: Finnisch
-    en: Finnish
-    pt: "Finlandês"
-    es: "Finés"
-    pl: Fiński
-frm:
-  label:
-    it: "Francese, medio (ca. 1300-1600)"
-    fr: "Français, Moyen (env. 1300-1600)"
-    de: "Französisch, Mitte (ca. 1300-1600)"
-    en: "French, Middle (ca. 1300-1600)"
-    pt: "Francês, Médio (ca. 1300-1600)"
-    es: "Francés, Medio (ca. 1300-1600)"
-    pl: Średniofrancuski (ok. 1300-1600)
-fro:
-  label:
-    it: "Francese, antico (ca. 842-1300)"
-    fr: "Français, ancien (ca. 842-1300)"
-    de: "Französisch, alt (ca. 842-1300)"
-    en: "French, Old (ca. 842-1300)"
-    pt: "Francês, antigo (ca. 842-1300)"
-    es: "Francés, antiguo (ca. 842-1300)"
-    pl: Starofrancuski (ok. 842-1300)
-frr:
-  label:
-    IT: Dialetto frisone settentrionale
-    FR: Frison du Nord
-    de: Nordfriesisch
-    en: North Frisian
-    pt: "Frisão setentrional"
-    es: "Frisón septentrional"
-    pl: Północnofryzyjski
-fry:
-  label:
-    IT: Dialetto frisone occidentale
-    FR: Frison occidental
-    de: Westfriesisch
-    en: West Frisian
-    pt: "Frisão ocidental"
-    es: "Frisón occidental"
-    pl: Zchodniofryzyjski
-fre:
-  label:
-    it: Francese
-    fr: Français
-    de: Französisch
-    en: French
-    pt: "Francês"
-    es: "Francés"
-    pl: Francuski
-fur:
-  label:
-    it: Friulano
-    fr: Friulano
-    de: Friulano
-    en: Friulano
-    pt: Friulano
-    es: Friulano
-    pl: Friulijski
-gem:
-  label:
-    IT: Germanico
-    FR: Germanique
-    de: Germanisch
-    en: Germanic
-    es: "Germánico"
-    pl: Germański
-ger:
-  label:
-    it: Tedesco
-    fr: Allemand
-    de: Deutsch
-    en: German
-    pt: "Alemão"
-    es: "Alemán"
-    pl: Niemiecki
-gez:
-  label:
-    it: Etiope
-    fr: "Éthiopien"
-    de: "Äthiopisch"
-    en: Ethiopic
-    pt: "Etíope"
-    es: "Etiópico"
-    pl: Etiopski
-gle:
-  label:
-    IT: Irlandese
-    FR: Irlandais
-    de: Irisch
-    en: Irish
-    pt: "Irlandês"
-    es: "Irlandés"
-    pl: Irlandzki
-glg:
-  label:
-    IT: Galiziano
-    FR: Galician
-    de: Galizisch
-    en: Galician
-    pt: Galego
-    es: Galego
-    pl: Galicyjski
-gmh:
-  label:
-    IT: Tedesco medievale
-    FR: Allemand médiéval
-    de: Mittelhochdeutsch
-    en: Middle High German
-    pt: "Alto-alemão médio"
-    es: "Alto alemán medio"
-    pl: Średniowysokoniemiecki
-goh:
-  label:
-    it: German, Old High (ca. 750-1050)
-    fr: German, Old High (ca. 750-1050)
-    de: German, Old High (ca. 750-1050)
-    en: German, Old High (ca. 750-1050)
-    pt: German, Old High (ca. 750-1050)
-    es: Alemán culto antiguo (aprox. 750-1050)
-    pl: Staro-wysoko-niemiecki (ok. 750-1050)
-grc:
-  label:
-    it: Greco antico (fino al 1453)
-    fr: Grec ancien (jusqu'en 1453)
-    de: Altgriechisch (bis 1453)
-    en: Greek, Ancient (to 1453)
-    pt: Grego antigo (até 1453)
-    es: Griego, Antiguo (hasta 1453)
-    pl: Grecki, historyczny (do 1453 r.)
-gre:
-  label:
-    it: Greco moderno (1453-)
-    fr: Grec moderne (1453-)
-    de: Neugriechisch (1453-)
-    en: Greek, Modern (1453-)
-    pt: Grego moderno (1453-)
-    es: Griego moderno (1453-)
-    pl: Grecki, współczesny (1453-)
-gsw:
-  label:
-    it: Svizzero tedesco
-    fr: Suisse allemand
-    de: Schweizerdeutsch
-    en: Swiss German
-    pt: "Suíço-alemão"
-    es: "Suizo-alemán"
-    pl: Niemiecki szwajcarski
-heb:
-  label:
-    it: Ebreo
-    fr: "Hébraïque"
-    de: Hebräisch
-    en: Hebrew
-    pt: Hebraico
-    es: Hebreo
-    pl: Hebrajski
-hrv:
-  label:
-    it: Croato
-    fr: Croate
-    de: Kroatisch
-    en: Croatian
-    pt: Croata
-    es: Croata
-    pl: Chorwacki
-hun:
-  label:
-    it: Ungherese
-    fr: Hongrois
-    de: Ungarisch
-    en: Hungarian
-    pt: "Húngaro"
-    es: "Húngaro"
-    pl: Węgierski
-ice:
-  label:
-    it: Islandese
-    fr: Islandais
-    de: Isländisch
-    en: Icelandic
-    pt: Islandês
-    es: Islandés
-    pl: Islandzki
-iii:
-  label:
-    it: Sichuan Yi
-    fr: Sichuan Yi
-    de: Sichuan Yi
-    en: Sichuan Yi
-    pt: Sichuan Yi
-    es: Sichuan Yi
-    pl: Syczuański Yi
-ita:
-  label:
-    it: Italiano
-    fr: Italien
-    de: Italienisch
-    en: Italian
-    pt: Italiano
-    es: Italiano
-    pl: Włoski
-jpn:
-  label:
-    it: Giapponese
-    fr: Japonais
-    de: Japanisch
-    en: Japanese
-    pt: "Japonês"
-    es: "Japonés"
-    pl: Japoński
-kor:
-  label:
-    it: Coreano
-    fr: "Coréen"
-    de: Koreanisch
-    en: Korean
-    pt: Coreano
-    es: Coreano
-    pl: Koreański
-lat:
-  label:
-    it: Latino
-    fr: Latin
-    de: Lateinisch
-    en: Latin
-    pt: Latim
-    es: "Latín"
-    pl: Łaciński
-lav:
-  label:
-    IT: Lettone
-    FR: Letton
-    de: Lettisch
-    en: Latvian
-    pt: "Letão"
-    es: "Letón"
-    pl: Łotewski
-lit:
-  label:
-    IT: Lituano
-    FR: Lituanien
-    de: Litauisch
-    en: Lithuanian
-    pt: Lituano
-    es: Lituano
-    pl: Litewski
-ltz:
-  label:
-    IT: Lussemburghese
-    FR: Luxembourgeois
-    de: Luxemburgisch
-    en: Luxembourgish
-    pt: "Luxemburguês"
-    es: "Luxemburgués"
-    pl: Luksemburski
-mac:
-  label:
-    IT: Macedone
-    FR: Macédonien
-    de: Mazedonisch
-    en: Macedonian
-    pt: "Macedônio"
-    es: Macedonio
-    pl: Macedoński
-mao:
-  label:
-    it: Māori
-    fr: Maori
-    de: Māori
-    en: Maori
-    pt: Maori
-    es: Maorí
-    pl: Maoryski
-mon:
-  label:
-    IT: Mongolo
-    FR: Mongole
-    de: Mongolisch
-    en: Mongolian
-    pt: Mongol
-    es: Mongol
-    pl: Mongolski
-mul:
-  label:
-    it: Multiple
-    fr: Multiple
-    de: Mehrere
-    en: Multiple
-    pt: Múltiplos
-    es: Múltiples
-    pl: Wielojęzyczny
-nap:
-  label:
-    it: Napoletano
-    fr: Néapolitain
-    de: Neapolitanisch
-    en: Neapolitan
-    pt: Napolitano
-    es: Napolitano
-    pl: Neapolitański
-nds:
-  label:
-    it: Basso sassone
-    fr: Bas allemand
-    de: Niederdeutsch
-    en: Low German
-    pt: "Baixo alemão"
-    es: "Bajo alemán"
-    pl: Dolnoniemiecki
-nor:
-  label:
-    IT: Norvegese
-    FR: Norvégien
-    de: Norwegisch
-    en: Norwegian
-    pt: "Norueguês"
-    es: "Noruego"
-    pl: Norweski
-oci:
-  label:
-    IT: Occitano
-    FR: Occitan
-    de: Okzitanisch
-    en: Occitan
-    pt: Occitano
-    es: Occitano
-    pl: Prowansalski
-per:
-  label:
-    it: Persiano
-    fr: Persan
-    de: Persisch
-    en: Persian
-    pt: Persa
-    es: Persa
-    pl: Perski
-pol:
-  label:
-    it: Polacco
-    fr: Polonais
-    de: Polnisch
-    en: Polish
-    pt: Polaco
-    es: Polaco
-    pl: Polski
-por:
-  label:
-    it: Portoghese
-    fr: Portugais
-    de: Portugiesisch
-    en: Portuguese
-    pt: "Português"
-    es: "Portugués"
-    pl: Portugalski
-roh:
-  label:
-    it: Romancio
-    fr: Rhéto-roman
-    de: Bündnerromanisch (Rätoromanisch)
-    en: Romansh
-    pt: "Reto-romano"
-    es: "Reto-romano"
-    pl: Retoromański
-rom:
-  label:
-    IT: Romani
-    FR: Romani
-    de: Romani
-    en: Romani
-    pt: Romani
-    es: "Romaní"
-    pl: Romski
-rum:
-  label:
-    IT: Romeno
-    FR: Roumain
-    de: Rumänisch
-    en: Romanian
-    pt: Romeno
-    es: Rumano
-    pl: Rumuński
-rus:
-  label:
-    it: Russo
-    fr: Russe
-    de: Russisch
-    en: Russian
-    pt: Russo
-    es: Ruso
-    pl: Rosyjski
-san:
-  label:
-    it: Sanscrito
-    fr: SANSKRIT
-    de: Sanskrit
-    en: Sanskrit
-    pt: "Sânscrito"
-    es: "Sánscrito"
-    pl: Sanskryt
-sco:
-  label:
-    it: Scozzese
-    fr: Écosse
-    de: Schottisch
-    en: Scots
-    pt: Escocês
-    es: Scozzese
-    pl: Szkocki
-scn:
-  label:
-    IT: Siciliano
-    FR: Sicilien
-    de: Sizilianisch
-    en: Sicilian
-    pt: Siciliano
-    es: Siciliano
-    pl: Sycylijski
-sla:
-  label:
-    IT: Slavico
-    FR: Slave
-    de: Slawisch
-    en: Slavic
-    pt: Eslava
-    es: Eslavo
-    pl: Słowiański
-slo:
-  label:
-    it: Slovacco
-    fr: Slovaque
-    de: Slowakisch
-    en: Slovak
-    pt: Eslovaco
-    es: Eslovaco
-    pl: Słowacki
-slv:
-  label:
-    it: Sloveno
-    fr: "Slovène"
-    de: Slowenisch
-    en: Slovenian
-    pt: Esloveno
-    es: Esloveno
-    pl: Słoweński
-smn:
-  label:
-    it: Inari Sami
-    fr: Inari Sami
-    de: Inari Sami
-    en: Inari Sami
-    pt: Inari Sami
-    es: Inari Sami
-    pl: Samski inarski
-dsb:
-  label:
-    it: Sorabo inferiore
-    fr: Sorabe, Sorabe inférieur
-    de: Sorbisch, Niedersorbisch
-    en: Sorbian, Lower Sorbian
-    pt: "Sorábio, Baixo Sorábio"
-    es: Sorbio, Bajo Sorbio
-    pl: Dolnołużycki
-hsb:
-  label:
-    it: Sorabo superiore
-    fr: Sorabe, Sorabe supérieur
-    de: Sorbisch, Obersorbisch
-    en: Sorbian, Upper Sorbian
-    pt: "Sorábio, Alto Sorábio"
-    es: Sorbio, Alto Sorbio
-    pl: Gbórnołużycki
-spa:
-  label:
-    it: Spagnolo
-    fr: Espagnol
-    de: Spanisch
-    en: Spanish
-    pt: Castelhano
-    es: Español
-    pl: Hiszpański
-srp:
-  label:
-    it: Serbo
-    fr: Serbe
-    de: Serbisch
-    en: Serbian
-    pt: "Sérvio"
-    es: Serbio
-    pl: Serbski
-swe:
-  label:
-    it: Svedese
-    fr: "Suédois"
-    de: Schwedisch
-    en: Swedish
-    pt: Sueco
-    es: Sueco
-    pl: Szwedzki
-tat:
-  label:
-    it: Tataro
-    fr: Tatar
-    de: Tatarische
-    en: Tatar
-    pt: Tártaro
-    es: Tártaro
-    pl: Tatarski
-tha:
-  label:
-    it: Thailandese
-    fr: Thaï
-    de: Thailändisch
-    en: Thai
-    pt: Tailandês
-    es: Tailandés
-    pl: Tajski
-tgl:
-  label:
-    it: Tagalog
-    fr: Tagalog
-    de: Tagalog
-    en: Tagalog
-    pt: Tagalog
-    es: Tagalog
-    pl: Tagalski
-tib:
-  label:
-    it: Tibetano
-    fr: TIBETAN
-    de: Tibetanisch
-    en: Tibetan
-    pt: Tibetano
-    es: Tibetano
-    pl: Tybetański
-tsi:
-  label:
-    it: Tsimshian
-    fr: Tsimshian
-    de: Tsimshian
-    en: Tsimshian
-    pt: Tsimshian
-    es: Tsimshian
-    pl: Tsimshiański
-tur:
-  label:
-    IT: Turco
-    FR: Turque
-    de: Türkisch
-    en: Turkish
-    pt: Turco
-    es: Turco
-    pl: Turecki
-und:
-  label:
-    it: Indeterminato
-    fr: "Indéterminé"
-    de: Unbestimmt
-    en: Undetermined
-    pt: Indeterminado
-    es: Indeterminado
-    pl: Nieokreślony
-ukr:
-  label:
-    IT: Ucraino
-    FR: Ukrainien
-    de: Ukrainisch
-    en: Ukrainian
-    pt: Ucraniano
-    es: Ucraniano
-    pl: Ukraiński
-vie:
-  label:
-    IT: Vietnamita
-    FR: Vietnamien
-    de: Vietnamesisch
-    en: Vietnamese
-    pt: Vietnamita
-    es: Vietnamita
-    pl: Wietnamska
-wel:
-  label:
-    IT: Gallese
-    FR: Gallois
-    de: Walisisch
-    en: Welsh
-    pt: "Galês"
-    es: "Galés"
-    pl: Walijski
-wen:
-  label:
-    it: Sorabo
-    fr: Sorabe
-    de: Sorbisch
-    en: Sorbian
-    pt: "Sorábio"
-    es: Sorbio
-    pl: Łużycki
-xal:
-  label:
-    it: Oirato
-    fr: Oïrate
-    de: Oiratische
-    en: Oirat
-    pt: Oirato
-    es: Oirato
-    pl: Ojracki
-yid:
-  label:
-    IT: Yiddish
-    FR: Yiddish
-    de: Jiddisch
-    en: Yiddish
-    pt: "Iídiche"
-    es: Yidis
-    pl: Jidysz
-zxx:
-  label:
-    it: Nessun contenuto linguistico
-    fr: Sans contenu linguistique
-    de: ohne Sprache
-    en: No linguistic content
-    pt: "Sem conteúdo linguístico"
-    es: "Sin contenido linguístico"
-    pl: Brak zawartości językowej
-#Subheading 240k / 730k
-Excerpts:
-  label:
-    it: Estratti
-    fr: Extraits
-    de: Ausschnitte
-    en: Excerpts
-    es: Extractos
-    pt: Excertos
-    pl: Wyjątki
-Sketches:
-  label:
-    it: Schizzi
-    fr: Esquisses
-    de: Skizzen
-    en: Sketches
-    es: Bosquejos
-    pt: "Esboços"
-    pl: Szkice
-Fragments:
-  label:
-    it: Frammenti
-    fr: Fragments
-    de: Fragmente
-    en: Fragments
-    es: Fragmentos
-    pt: Fragmentos
-    pl: Fragmenty
-Inserts:
-  label:
-    it: Inserimenti
-    fr: Insertions
-    de: Einlagen
-    en: Inserts
-    pt: "Inserções"
-    es: Inserciones
-    pl: Wstawienia
-#Arrangement statement 240o / 730o
-Arr:
-  label:
-    it: Arrangiamento
-    fr: Arrangement
-    de: Bearbeitung
-    en: Arrangement
-    pt: Arranjo
-    es: Arreglo
-    pl: Aranżacja
-Var:
-  label:
-    it: Variazioni
-    fr: Variations
-    de: Variationen
-    en: Variations
-    es: Variaciones
-    pl: Wariacje
-#Keys
-A:
-  label:
-    it: "La maggiore"
-    fr: "La majeur"
-    de: "A-Dur"
-    en: "A major"
-    pt: "Lá  maior"
-    es: "La Mayor"
-    pl: A-dur
-a:
-  label:
-    it: "La minore"
-    fr: "La mineur"
-    de: "a-Moll"
-    en: "A minor"
-    pt: "Lá menor"
-    es: "La menor"
-    pl: a-moll
-A|x:
-  label:
-    it: "La♯ maggiore"
-    fr: "La♯ majeur"
-    de: "Ais-Dur"
-    en: "A♯ major"
-    pt: "Lá sustenido maior"
-    es: "La sostenido Mayor"
-    pl: Ais-dur
-a|x:
-  label:
-    it: "La♯ minore"
-    fr: "La♯ mineur"
-    de: "ais-Moll"
-    en: "A♯ minor"
-    pt: "Lá sustenido menor"
-    es: "La sostenido menor"
-    pl: ais-moll
-A|b:
-  label:
-    it: "La♭ maggiore"
-    fr: "La♭ majeur"
-    de: "As-Dur"
-    en: "A♭ major"
-    pt: "Lá bemol maior"
-    es: "La bemol Mayor"
-    pl: As-Dur
-a|b:
-  label:
-    it: "La♭ minore"
-    fr: "La♭ mineur"
-    de: "as-Moll"
-    en: "A♭ minor"
-    pt: "Lá bemol menor"
-    es: "La bemol menor"
-    pl: as-moll
-B:
-  label:
-    it: "Si maggiore"
-    fr: "Si majeur"
-    de: "H-Dur"
-    en: "B major"
-    pt: Si maior
-    es: "Si Mayor"
-    pl: H-dur
-b:
-  label:
-    it: "Si minore"
-    fr: "Si mineur"
-    de: "h-Moll"
-    en: "B minor"
-    pt: Si menor
-    es: "Si menor"
-    pl: h-moll
-B|b:
-  label:
-    it: "Si♭ maggiore"
-    fr: "Si♭ majeur"
-    de: "B-Dur"
-    en: "B♭ major"
-    pt: Si bemol maior
-    es: "Si bemol Mayor"
-    pl: B-dur
-b|b:
-  label:
-    it: "Si♭ minore"
-    fr: "Si♭ mineur"
-    de: "b-Moll"
-    en: "B♭ minor"
-    pt: Si bemol menor
-    es: "Si bemol menor"
-    pl: b-moll
-C:
-  label:
-    it: "Do maggiore"
-    fr: "Do majeur"
-    de: "C-Dur"
-    en: "C major"
-    pt: "Dó maior"
-    es: "Do Mayor"
-    pl: C-dur
-c:
-  label:
-    it: "Do minore"
-    fr: "Do mineur"
-    de: "c-Moll"
-    en: "C minor"
-    pt: "Dó menor"
-    es: "Do menor"
-    pl: c-moll
-C|x:
-  label:
-    it: "Do♯ maggiore"
-    fr: "Do♯ majeur"
-    de: "Cis-Dur"
-    en: "C♯ major"
-    pt: "Dó sustenido maior"
-    es: "Do sostenido Mayor"
-    pl: Cis-dur
-c|x:
-  label:
-    it: "Do♯ minore"
-    fr: "Do♯ mineur"
-    de: "cis-Moll"
-    en: "C♯ minor"
-    pt: "Dó sustenido menor"
-    es: "Do sostenido menor"
-    pl: cis-moll
-C|b:
-  label:
-    it: "Do♭ maggiore"
-    fr: "Do♭ majeur"
-    de: "Ces-Dur"
-    en: "C♭ major"
-    pt: "Dó bemol maior"
-    es: "Do bemol Mayor"
-    pl: Ces-dur
-c|b:
-  label:
-    it: "Do♭ minore"
-    fr: "Do♭ mineur"
-    de: "ces-Moll"
-    en: "C♭ minor"
-    pt: "Dó bemol menor"
-    es: "Do bemol menor"
-    pl: ces-moll
-D:
-  label:
-    it: "Re maggiore"
-    fr: "Ré majeur"
-    de: "D-Dur"
-    en: "D major"
-    pt: "Ré maior"
-    es: "Re Mayor"
-    pl: D-dur
-d:
-  label:
-    it: "Re minore"
-    fr: "Ré minor"
-    de: "d-Moll"
-    en: "D minor"
-    pt: "Ré menor"
-    es: "Re menor"
-    pl: d-moll
-D|x:
-  label:
-    it: "Re♯ maggiore"
-    fr: "Ré♯ majeur"
-    de: "Dis-Dur"
-    en: "D♯ major"
-    pt: "Ré sustenido maior"
-    es: "Re sostenido Mayor"
-    pl: Dis-dur
-d|x:
-  label:
-    it: "Re♯ minore"
-    fr: "Ré♯ mineur"
-    de: "dis-Moll"
-    en: "D♯ minor"
-    pt: "Ré sustenido menor"
-    es: "Re sostenido menor"
-    pl: dis-moll
-D|b:
-  label:
-    it: "Re♭ maggiore"
-    fr: "Ré♭ majeur"
-    de: "Des-Dur"
-    en: "D♭ major"
-    pt: "Ré bemol maior"
-    es: "Re bemol Mayor"
-    pl: Des-dur
-d|b:
-  label:
-    it: "Re♭ minore"
-    fr: "Ré♭ mineur"
-    de: "des-Moll"
-    en: "D♭ minor"
-    pt: "Ré bemol menor"
-    es: "Re bemol menor"
-    pl: des-moll
-E:
-  label:
-    it: "Mi maggiore"
-    fr: "Mi majeur"
-    de: "E-Dur"
-    en: "E major"
-    pt: "Mi maior"
-    es: "Mi Mayor"
-    pl: E-dur
-e:
-  label:
-    it: "Mi minore"
-    fr: "Mi mineur"
-    de: "e-Moll"
-    en: "E minor"
-    pt: "Mi menor"
-    es: "Mi menor"
-    pl: e-moll
-E|b:
-  label:
-    it: "Mi♭ maggiore"
-    fr: "Mi♭ majeur"
-    de: "Es-Dur"
-    en: "E♭ major"
-    pt: "Mi bemol maior"
-    es: "Mi bemol Mayor"
-    pl: Es-dur
-e|b:
-  label:
-    it: "Mi♭ minore"
-    fr: "Mi♭ mineur"
-    de: "es-Moll"
-    en: "E♭ minor"
-    pt: "Mi bemol menor"
-    es: "Mi bemol menor"
-    pl: es-moll
-F:
-  label:
-    it: "Fa maggiore"
-    fr: "Fa majeur"
-    de: "F-Dur"
-    en: "F major"
-    pt: "Fá maior"
-    es: "Fa Mayor"
-    pl: F-dur
-f:
-  label:
-    it: "Fa minore"
-    fr: "Fa mineur"
-    de: "f-Moll"
-    en: "F minor"
-    pt: "Fá menor"
-    es: "Fa menor"
-    pl: f-moll
-F|x:
-  label:
-    it: "Fa♯ maggiore"
-    fr: "Fa♯ majeur"
-    de: "Fis-Dur"
-    en: "F♯ major"
-    pt: "Fá sustenido maior"
-    es: "Fa sostenido menor"
-    pl: Fis-dur
-f|x:
-  label:
-    it: "Fa♯ minore"
-    fr: "Fa♯ mineur"
-    de: "fis-Moll"
-    en: "F♯ minor"
-    pt: "Fá sustenido menor"
-    es: "Fa sostenido Mayor"
-    pl: fis-moll
-G:
-  label:
-    it: "Sol maggiore"
-    fr: "Sol majeur"
-    de: "G-Dur"
-    en: "G major"
-    pt: "Sol maior"
-    es: "Sol Mayor"
-    pl: G-dur
-g:
-  label:
-    it: "Sol minore"
-    fr: "Sol mineur"
-    de: "g-Moll"
-    en: "G minor"
-    pt: "Sol menor"
-    es: "Sol menor"
-    pl: g-moll
-G|x:
-  label:
-    it: "Sol♯ maggiore"
-    fr: "Sol♯ majeur"
-    de: "Gis-Dur"
-    en: "G♯ major"
-    pt: "Sol sustenido maior"
-    es: "Sol sostenido menor"
-    pl: Gis-dur
-g|x:
-  label:
-    it: "Sol♯ minore"
-    fr: "Sol♯ mineur"
-    de: "gis-Moll"
-    en: "G♯ minor"
-    pt: "Sol sustenido menor"
-    es: "Sol sostenido menor"
-    pl: gis-moll
-G|b:
-  label:
-    it: "Sol♭ maggiore"
-    fr: "Sol♭ majeur"
-    de: "Ges-Dur"
-    en: "G♭ major"
-    pt: "Sol bemol maior"
-    es: "Sol bemol Mayor"
-    pl: Ges-dur
-g|b:
-  label:
-    it: "Sol♭ minore"
-    fr: "Sol♭ mineur"
-    de: "ges-Moll"
-    en: "G♭ minor"
-    pt: "Sol bemol menor"
-    es: "Sol bemol menor"
-    pl: ges-moll
-# modes
-1t:
-  label:
-    it: "Mode:  1t – Dorian"
-    fr: "Mode:  1t – Dorian"
-    de: "Mode:  1t – Dorian"
-    en: "Mode:  1t – Dorian"
-    pt: "Modo:  1º tom (Dórico)"
-    es: "Modo: 1º tono (Dórico)"
-    pl: "Skala: 1t – dorycka"
-2t:
-  label:
-    it: "Mode:  2t – Hypodorian"
-    fr: "Mode:  2t – Hypodorian"
-    de: "Mode:  2t – Hypodorian"
-    en: "Mode:  2t – Hypodorian"
-    pt: "Modo:  2º tom (Hipodórico)"
-    es: "Modo:  2º tono (Hipodórico)"
-    pl: "Skala: 2t – hypodorycka"
-3t:
-  label:
-    it: "Mode:  3t – Phrygian"
-    fr: "Mode:  3t – Phrygian"
-    de: "Mode:  3t – Phrygian"
-    en: "Mode:  3t – Phrygian"
-    pt: "Modo:  3º tom (Frígio)"
-    es: "Modo:  3º tono (Frigio)"
-    pl: "Skala: 3t – frygijska"
-4t:
-  label:
-    it: "Mode:  4t – Hypophrygian"
-    fr: "Mode:  4t – Hypophrygian"
-    de: "Mode:  4t – Hypophrygian"
-    en: "Mode:  4t – Hypophrygian"
-    pt: "Modo:  4º tom (Hipofrígio)"
-    es: "Modo:  4º tono (Hipofrigio)"
-    pl: "Skala: 4t – hypofrygijska"
-5t:
-  label:
-    it: "Mode:  5t – Lydian"
-    fr: "Mode:  5t – Lydian"
-    de: "Mode:  5t – Lydian"
-    en: "Mode:  5t – Lydian"
-    pt: "Modo:  5º tom (Lídio)"
-    es: "Modo:  5º tono (Lidio)"
-    pl: "Skala: 5t – lidyjska"
-6t:
-  label:
-    it: "Mode:  6t – Hypolydian"
-    fr: "Mode:  6t – Hypolydian"
-    de: "Mode:  6t – Hypolydian"
-    en: "Mode:  6t – Hypolydian"
-    pt: "Modo:  6º tom (Hipolídio)"
-    es: "Modo:  6º tono (Hipolidio)"
-    pl: "Skala: 6t – hypolidyjska"
-7t:
-  label:
-    it: "Mode:  7t – Mixolydian"
-    fr: "Mode:  7t – Mixolydian"
-    de: "Mode:  7t – Mixolydian"
-    en: "Mode:  7t – Mixolydian"
-    pt: "Modo:  7º tom (Mixolídio)"
-    es: "Modo:  7º tono (Mixolidio)"
-    pl: "Skala: 7t – miksolidyjska"
-8t:
-  label:
-    it: "Mode:  8t – Hypomixolydian"
-    fr: "Mode:  8t – Hypomixolydian"
-    de: "Mode:  8t – Hypomixolydian"
-    en: "Mode:  8t – Hypomixolydian"
-    pt: "Modo:  8º tom (Hipomixolídio)"
-    es: "Modo:  8º tono (Hipomixolidio)"
-    pl: "Skala: 8t – hypomiksolidyjska"
-9t:
-  label:
-    it: "Mode:  9t – Aeolian"
-    fr: "Mode:  9t – Aeolian"
-    de: "Mode:  9t – Aeolian"
-    en: "Mode:  9t – Aeolian"
-    pt: "Modo:  9º tom (Eólio)"
-    es: "Modo:  9º tono (Eólico)"
-    pl: "Skala: 9t – eolska"
-10t:
-  label:
-    it: "Mode: 10t – Hypoaeolian"
-    fr: "Mode: 10t – Hypoaeolian"
-    de: "Mode: 10t – Hypoaeolian"
-    en: "Mode: 10t – Hypoaeolian"
-    pt: "Modo: 10º tom (Hipoeólio)"
-    es: "Modo: 10º tono (Hipoeólico)"
-    pl: "Skala: 10t – hypoeolska"
-11t:
-  label:
-    it: "Mode: 11t – Ionian"
-    fr: "Mode: 11t – Ionian"
-    de: "Mode: 11t – Ionian"
-    en: "Mode: 11t – Ionian"
-    pt: "Modo:  11º tom (Jônio)"
-    es: "Modo:  11º tono (Jónico)"
-    pl: "Skala: 11t – jońska"
-12t:
-  label:
-    it: "Mode: 12t – Hypoionian"
-    fr: "Mode: 12t – Hypoionian"
-    de: "Mode: 12t – Hypoionian"
-    en: "Mode: 12t – Hypoionian"
-    pt: "Modo:  12º modo (Hipojônio)"
-    es: "Modo:  12º tono (Hipojónico)"
-    pl: "Skala: 12t – hypojońska"
-1tt:
-  label:
-    it: "Mode:  1tt – Dorian, transposed"
-    fr: "Mode:  1tt – Dorian, transposed"
-    de: "Mode:  1tt – Dorian, transposed"
-    en: "Mode:  1tt – Dorian, transposed"
-    pt: "Modo:  1º tom (Dórico), transposta"
-    es: "Modo: 1º tono (Dórico), transpuesto"
-    pl: "Skala: 1tt – dorycka transponowana"
-2tt:
-  label:
-    it: "Mode:  2tt – Hypodorian, transposed"
-    fr: "Mode:  2tt – Hypodorian, transposed"
-    de: "Mode:  2tt – Hypodorian, transposed"
-    en: "Mode:  2tt – Hypodorian, transposed"
-    pt: "Modo:  2º tom (Hipodórico), transposta"
-    es: "Modo:  2º tono (Hipodórico), transpuesto"
-    pl: "Skala: 2tt – hypodorycka transponowana"
-3tt:
-  label:
-    it: "Mode:  3tt – Phrygian, transposed"
-    fr: "Mode:  3tt – Phrygian, transposed"
-    de: "Mode:  3tt – Phrygian, transposed"
-    en: "Mode:  3tt – Phrygian, transposed"
-    pt: "Modo:  3º tom (Frígio), transposta"
-    es: "Modo:  3º tono (Frigio), transpuesto"
-    pl: "Skala: 3tt – frygijska transponowana"
-4tt:
-  label:
-    it: "Mode:  4tt – Hypophrygian, transposed"
-    fr: "Mode:  4tt – Hypophrygian, transposed"
-    de: "Mode:  4tt – Hypophrygian, transposed"
-    en: "Mode:  4tt – Hypophrygian, transposed"
-    pt: "Modo:  4º tom (Hipofrígio), transposta"
-    es: "Modo:  4º tono (Hipofrigio), transpuesto"
-    pl: "Skala: 4tt – hypofrygijska transponowana"
-5tt:
-  label:
-    it: "Mode:  5tt – Lydian, transposed"
-    fr: "Mode:  5tt – Lydian, transposed"
-    de: "Mode:  5tt – Lydian, transposed"
-    en: "Mode:  5tt – Lydian, transposed"
-    pt: "Modo:  5º tom (Lídio), transposta"
-    es: "Modo:  5º tono (Lidio), transpuesto"
-    pl: "Skala: 5tt – lidyjska transponowana"
-6tt:
-  label:
-    it: "Mode:  6tt – Hypolydian, transposed"
-    fr: "Mode:  6tt – Hypolydian, transposed"
-    de: "Mode:  6tt – Hypolydian, transposed"
-    en: "Mode:  6tt – Hypolydian, transposed"
-    pt: "Modo:  6º tom (Hipolídio), transposta"
-    es: "Modo:  6º tono (Hipolidio), transpuesto"
-    pl: "Skala: 6tt – hypolidyjska transponowana"
-7tt:
-  label:
-    it: "Mode:  7tt – Mixolydian, transposed"
-    fr: "Mode:  7tt – Mixolydian, transposed"
-    de: "Mode:  7tt – Mixolydian, transposed"
-    en: "Mode:  7tt – Mixolydian, transposed"
-    pt: "Modo:  7º tom (Mixolídio), transposta"
-    es: "Modo:  7º tono (Mixolidio), transpuesto"
-    pl: "Skala: 7tt – miksolidyjska transponowana"
-8tt:
-  label:
-    it: "Mode:  8tt – Hypomixolydian, transposed"
-    fr: "Mode:  8tt – Hypomixolydian, transposed"
-    de: "Mode:  8tt – Hypomixolydian, transposed"
-    en: "Mode:  8tt – Hypomixolydian, transposed"
-    pt: "Modo:  8º tom (Hipomixolídio), transposta"
-    es: "Modo:  8º tono (Hipomixolidio), transpuesto"
-    pl: "Skala: 8tt – hypomiksolidyjska transponowana"
-9tt:
-  label:
-    it: "Mode:  9tt – Aeolian, transposed"
-    fr: "Mode:  9tt – Aeolian, transposed"
-    de: "Mode:  9tt – Aeolian, transposed"
-    en: "Mode:  9tt – Aeolian, transposed"
-    pt: "Modo:  9º tom (Eólio), transposta"
-    es: "Modo:  9º tono (Eólico), transpuesto"
-    pl: "Skala: 9tt – eolska transponowana"
-10tt:
-  label:
-    it: "Mode: 10tt – Hypoaeolian, transposed"
-    fr: "Mode: 10tt – Hypoaeolian, transposed"
-    de: "Mode: 10tt – Hypoaeolian, transposed"
-    en: "Mode: 10tt – Hypoaeolian, transposed"
-    pt: "Modo: 10º tom (Hipoeólio), transposta"
-    es: "Modo: 10º tono (Hipoeólico), transpuesto"
-    pl: "Skala: 10tt – hypoeolska transponowana"
-11tt:
-  label:
-    it: "Mode: 11tt – Ionian, transposed"
-    fr: "Mode: 11tt – Ionian, transposed"
-    de: "Mode: 11tt – Ionian, transposed"
-    en: "Mode: 11tt – Ionian, transposed"
-    pt: "Modo:  11º tom (Jônio), transposta"
-    es: "Modo:  11º tono (Jónico), transpuesto"
-    pl: "Skala: 11tt – jońska transponowana"
-12tt:
-  label:
-    it: "Mode: 12tt – Hypoionian, transposed"
-    fr: "Mode: 12tt – Hypoionian, transposed"
-    de: "Mode: 12tt – Hypoionian, transposed"
-    en: "Mode: 12tt – Hypoionian, transposed"
-    pt: "Modo:  12º modo (Hipojônio), transposta"
-    es: "Modo:  12º tono (Hipojónico), transpuesto"
-    pl: "Skala: 12tt – hypojońska transponowana"
-1byz:
-  label:
-    it: "Octoechos 1: Ēchos prōtos (First mode of Byzantine music)"
-    fr: "Octoechos 1: Ēchos prōtos (First mode of Byzantine music)"
-    de: "Octoechos 1: Ēchos prōtos (First mode of Byzantine music)"
-    en: "Octoechos 1: Ēchos prōtos (First mode of Byzantine music)"
-    pt: "Octoechos 1: Ēchos prōtos (Primeiro modo bizantino)"
-    es: "Octoechos 1: Ēchos prōtos (Primer modo bizantino)"
-    pl: "Octoechos 1: Ēchos prōtos (pierwsza skala muzyki bizantyjskiej)"
-2byz:
-  label:
-    it: "Octoechos 2: Ēchos deuteros (Second mode of Byzantine music)"
-    fr: "Octoechos 2: Ēchos deuteros (Second mode of Byzantine music)"
-    de: "Octoechos 2: Ēchos deuteros (Second mode of Byzantine music)"
-    en: "Octoechos 2: Ēchos deuteros (Second mode of Byzantine music)"
-    pt: "Octoechos 2: Ēchos deuteros (Segundo modo bizantino)"
-    es: "Octoechos 2: Ēchos deuteros (Segundo modo bizantino)"
-    pl: "Octoechos 2: Ēchos deuteros (druga skala muzyki bizantyjskiej)"
-3byz:
-  label:
-    it: "Octoechos 3: Ēchos tritos (Third mode of Byzantine music)"
-    fr: "Octoechos 3: Ēchos tritos (Third mode of Byzantine music)"
-    de: "Octoechos 3: Ēchos tritos (Third mode of Byzantine music)"
-    en: "Octoechos 3: Ēchos tritos (Third mode of Byzantine music)"
-    pt: "Octoechos 3: Ēchos tritos (Terceiro modo bizantino)"
-    es: "Octoechos 3: Ēchos tritos (Tercer modo bizantino)"
-    pl: "Octoechos 3: Ēchos tritos (trzecia skala muzyki bizantyjskiej)"
-4byz:
-  label:
-    it: "Octoechos 4: Ēchos tetartos (Fourth mode of Byzantine music)"
-    fr: "Octoechos 4: Ēchos tetartos (Fourth mode of Byzantine music)"
-    de: "Octoechos 4: Ēchos tetartos (Fourth mode of Byzantine music)"
-    en: "Octoechos 4: Ēchos tetartos (Fourth mode of Byzantine music)"
-    pt: "Octoechos 4: Ēchos tetartos (Quarto modo bizantino)"
-    es: "Octoechos 4: Ēchos tetartos (Cuarto modo bizantino)"
-    pl: "Octoechos 4: Ēchos tetartos (czwarta skala muzyki bizantyjskiej)"
-5byz:
-  label:
-    it: "Octoechos 5: Ēchos plagios prōtos (First plagal mode of Byzantine music)"
-    fr: "Octoechos 5: Ēchos plagios prōtos (First plagal mode of Byzantine music)"
-    de: "Octoechos 5: Ēchos plagios prōtos (First plagal mode of Byzantine music)"
-    en: "Octoechos 5: Ēchos plagios prōtos (First plagal mode of Byzantine music)"
-    pt: "Octoechos 5: Ēchos plagios prōtos (Primeiro modo bizantino plagal)"
-    es: "Octoechos 5: Ēchos plagios prōtos (Primer modo bizantino plagal)"
-    pl: "Octoechos 5: Ēchos plagios prōtos (pierwsza skala plagalna muzyki bizantyjskiej)"
-6byz:
-  label:
-    it: "Octoechos 6: Ēchos plagios deuteros (Second plagal mode of Byzantine music)"
-    fr: "Octoechos 6: Ēchos plagios deuteros (Second plagal mode of Byzantine music)"
-    de: "Octoechos 6: Ēchos plagios deuteros (Second plagal mode of Byzantine music)"
-    en: "Octoechos 6: Ēchos plagios deuteros (Second plagal mode of Byzantine music)"
-    pt: "Octoechos 6: Ēchos plagios deuteros (Segundo modo bizantino plagal)"
-    es: "Octoechos 6: Ēchos plagios deuteros (Segundo modo bizantino plagal)"
-    pl: "Octoechos 6: Ēchos plagios deuteros (druga skala plagalna muzyki bizantyjskiej)"
-7byz:
-  label:
-    it: "Octoechos 7: Ēchos barys (Third plagal mode of Byzantine music)"
-    fr: "Octoechos 7: Ēchos barys (Third plagal mode of Byzantine music)"
-    de: "Octoechos 7: Ēchos barys (Third plagal mode of Byzantine music)"
-    en: "Octoechos 7: Ēchos barys (Third plagal mode of Byzantine music)"
-    pt: "Octoechos 7: Ēchos barys (Terceiro modo bizantino plagal)"
-    es: "Octoechos 7: Ēchos barys (Tercer modo bizantino plagal)"
-    pl: "Octoechos 7: Ēchos barys (trzecia skala plagalna muzyki bizantyjskiej)"
-8byz:
-  label:
-    it: "Octoechos 8: Ēchos plagios tetartos (Fourth plagal mode of Byzantine music)"
-    fr: "Octoechos 8: Ēchos plagios tetartos (Fourth plagal mode of Byzantine music)"
-    de: "Octoechos 8: Ēchos plagios tetartos (Fourth plagal mode of Byzantine music)"
-    en: "Octoechos 8: Ēchos plagios tetartos (Fourth plagal mode of Byzantine music)"
-    pt: "Octoechos 8: Ēchos plagios tetartos (Quarto modo bizantino plagal)"
-    es: "Octoechos 8: Ēchos plagios tetartos (Cuarto modo bizantino plagal)"
-    pl: "Octoechos 8: Ēchos plagios tetartos (czwarta skala plagalna muzyki bizantyjskiej)"
-#Clefs (031)
+  label: records.artistic_production
 01_modern_clefs:
-  label:
-    it: "Chiavi comuni"
-    fr: "Clés communes"
-    de: "Common clefs"
-    en: "Common clefs"
-    pt: Claves comuns
-    es: Claves comunes
-    pl: Klucze współczesne
-C-1:
-  label:
-    it: "C-1"
-    fr: "C-1"
-    de: "C-1"
-    en: "C-1"
-    pt: "C-1"
-    es: "C-1"
-    pl: C-1
-C-2:
-  label:
-    it: "C-2"
-    fr: "C-2"
-    de: "C-2"
-    en: "C-2"
-    pt: "C-2"
-    es: "C-2"
-    pl: C-2
-C-3:
-  label:
-    it: "C-3"
-    fr: "C-3"
-    de: "C-3"
-    en: "C-3"
-    pt: "C-3"
-    es: "C-3"
-    pl: C-3
-C-4:
-  label:
-    it: "C-4"
-    fr: "C-4"
-    de: "C-4"
-    en: "C-4"
-    pt: "C-4"
-    es: "C-4"
-    pl: C-4
-C-5:
-  label:
-    it: "C-5"
-    fr: "C-5"
-    de: "C-5"
-    en: "C-5"
-    pt: "C-5"
-    es: "C-5"
-    pl: C-5
-F-1:
-  label:
-    it: "F-1"
-    fr: "F-1"
-    de: "F-1"
-    en: "F-1"
-    pt: "F-1"
-    es: "F-1"
-    pl: F-1
-F-2:
-  label:
-    it: "F-2"
-    fr: "F-2"
-    de: "F-2"
-    en: "F-2"
-    pt: "F-2"
-    es: "F-2"
-    pl: F-2
-F-3:
-  label:
-    it: "F-3"
-    fr: "F-3"
-    de: "F-3"
-    en: "F-3"
-    pt: "F-3"
-    es: "F-3"
-    pl: F-3
-F-4:
-  label:
-    it: "F-4 (chiave di basso)"
-    fr: "F-4 (clé fa)"
-    de: "F-4 (Baß-Schlüssel)"
-    en: "F-4 (bass clef)"
-    pt: "F-4 (clave grave)"
-    es: "F-4 (clave de bajo)"
-    pl: F-4 (klucz basowy)
-F-5:
-  label:
-    it: "F-5"
-    fr: "F-5"
-    de: "F-5"
-    en: "F-5"
-    pt: "F-5"
-    es: "F-5"
-    pl: F-5
-G-1:
-  label:
-    it: "G-1"
-    fr: "G-1"
-    de: "G-1"
-    en: "G-1"
-    pt: "G-1"
-    es: "G-1"
-    pl: G-1
-G-2:
-  label:
-    it: "G-2 (chiave di violino)"
-    fr: "G-2 (clé de sol)"
-    de: "G-2 (Violin-Schlüssel)"
-    en: "G-2 (treble clef)"
-    pt: "G-2 (clave aguda)"
-    es: "G-2(clave aguda estándar)"
-    pl: G-2 (klucz wiolinowy)
-G-3:
-  label:
-    it: "G-3"
-    fr: "G-3"
-    de: "G-3"
-    en: "G-3"
-    pt: "G-3"
-    es: "G-3"
-    pl: G-3
-G-4:
-  label:
-    it: "G-4"
-    fr: "G-4"
-    de: "G-4"
-    en: "G-4"
-    pt: "G-4"
-    es: "G-4"
-    pl: G-4
-G-5:
-  label:
-    it: "G-5"
-    fr: "G-5"
-    de: "G-5"
-    en: "G-5"
-    pt: "G-5"
-    es: "G-5"
-    pl: G-5
-g-2:
-  label:
-    it: "g-2 (Chiave di violino ottavizzata)"
-    fr: "g-2 (octava bassa)"
-    de: "g-2 (oktavierenden Violinschlüssels)"
-    en: "g-2 (octave treble clef)"
-    pt: "g-2 (clave aguda à oitava)"
-    es: "g-2 (clave de sol octava baja)"
-    pl: g-2 (oktawowy klucz wiolinowy)
+  label: records.common_clefs
+'026':
+  fields:
+    a:
+      label: records.first_second_group
+    b:
+      label: records.third_fourth_group
+    c:
+      label: records.date
+    d:
+      label: records.number_volume_part
+    e:
+      label: records.unparsed_fingerprint
+  label: records.fingerprint_identifier
+028:
+  fields:
+    '8':
+      label: records.set
+    a:
+      label: records.plate_number
+  label: records.plate_number
+02_codes_performing:
+  label: records.performance
 02_mensural_clefs:
-  label:
-    it: "Chiavi mensurali"
-    fr: "Clés anciennes"
-    de: "Mensural clefs"
-    en: "Mensural clefs"
-    pt: Claves mensurais
-    es: "Claves mensurales"
-    pl: Klucze menzuralne
-C+1:
-  label:
-    it: "C+1"
-    fr: "C+1"
-    de: "C+1"
-    en: "C+1"
-    pt: "C+1"
-    es: "C+1"
-    pl: C+1
-C+2:
-  label:
-    it: "C+2"
-    fr: "C+2"
-    de: "C+2"
-    en: "C+2"
-    pt: "C+2"
-    es: "C+2"
-    pl: C+2
-C+3:
-  label:
-    it: "C+3"
-    fr: "C+3"
-    de: "C+3"
-    en: "C+3"
-    pt: "C+3"
-    es: "C+3"
-    pl: C+3
-C+4:
-  label:
-    it: "C+4"
-    fr: "C+4"
-    de: "C+4"
-    en: "C+4"
-    pt: "C+4"
-    es: "C+4"
-    pl: C+4
-C+5:
-  label:
-    it: "C+5"
-    fr: "C+5"
-    de: "C+5"
-    en: "C+5"
-    pt: "C+5"
-    es: "C+5"
-    pl: C+5
-F+1:
-  label:
-    it: "F+1"
-    fr: "F+1"
-    de: "F+1"
-    en: "F+1"
-    pt: "F+1"
-    es: "F+1"
-    pl: F+1
-F+2:
-  label:
-    it: "F+2"
-    fr: "F+2"
-    de: "F+2"
-    en: "F+2"
-    pt: "F+2"
-    es: "F+2"
-    pl: F+2
-F+3:
-  label:
-    it: "F+3"
-    fr: "F+3"
-    de: "F+3"
-    en: "F+3"
-    pt: "F+3"
-    es: "F+3"
-    pl: F+3
-F+4:
-  label:
-    it: "F+4"
-    fr: "F+4"
-    de: "F+4"
-    en: "F+4"
-    pt: "F+4"
-    es: "F+4"
-    pl: F+4
-F+5:
-  label:
-    it: "F+5"
-    fr: "F+5"
-    de: "F+5"
-    en: "F+5"
-    pt: "F+5"
-    es: "F+5"
-    pl: F+5
-G+1:
-  label:
-    it: "G+1"
-    fr: "G+1"
-    de: "G+1"
-    en: "G+1"
-    pt: "G+1"
-    es: "G+1"
-    pl: G+1
-G+2:
-  label:
-    it: "G+2"
-    fr: "G+2"
-    de: "G+2"
-    en: "G+2"
-    pt: "G+2"
-    es: "G+2"
-    pl: G+2
-G+3:
-  label:
-    it: "G+3"
-    fr: "G+3"
-    de: "G+3"
-    en: "G+3"
-    pt: "G+3"
-    es: "G+3"
-    pl: G+3
-G+4:
-  label:
-    it: "G+4"
-    fr: "G+4"
-    de: "G+4"
-    en: "G+4"
-    pt: "G+4"
-    es: "G+4"
-    pl: G+4
-G+5:
-  label:
-    it: "G+5"
-    fr: "G+5"
-    de: "G+5"
-    en: "G+5"
-    pt: "G+5"
-    es: "G+5"
-    pl: G+5
-#Physical medium (340 $a) - currently not used by the partial
+  label: records.mensural_clefs
+'031':
+  fields:
+    a:
+      label: records.work_number
+    b:
+      label: records.movement_number
+    c:
+      label: records.incipit_number
+    d:
+      label: records.title_movement_tempo
+    e:
+      label: records.role
+    g:
+      label: records.clef
+    m:
+      label: records.voice_instrument
+    n:
+      label: records.key_signature
+    o:
+      label: records.time_signature
+    p:
+      label: records.music_incipit
+    q:
+      label: records.general_note_incipits
+    r:
+      label: records.key_or_mode
+    s:
+      label: general.validity
+    t:
+      label: records.text_incipit
+    z:
+      label: records.scoring_in_movement
+  label: records.incipit
+'033':
+  fields:
+    0#:
+      label: records.single_date
+    1#:
+      label: records.multiple_single_dates
+    2#:
+      label: records.range_dates
+    a:
+      label: records.coded_date
+    indicator:
+      label: records.date_type
+  label: records.coded_date
+'035':
+  fields:
+    a:
+      label: records.local_number
+  label: records.local_number
+03_codes_technical:
+  label: records.technical_production
+'040':
+  fields:
+    b:
+      label: records.language_of_cataloging
+  label: records.cataloging_agency
+'041':
+  fields:
+    0#:
+      label: general.no
+    1#:
+      label: general.yes
+    a:
+      label: records.language_text
+    e:
+      label: records.language_libretto
+    h:
+      label: records.language_original_text
+    indicator:
+      label: records.translation
+  label: records.language_code
+04_codes_other:
+  label: records.other
+'100':
+  fields:
+    a:
+      label: records.name
+    d:
+      label: records.life_dates
+    j:
+      label: records.attribution_qualifier
+  label: records.composer_author
+10t:
+  label: records.mode_10t
+10tt:
+  label: records.mode_10tt
+11t:
+  label: records.mode_11t
+11tt:
+  label: records.mode_11tt
+12t:
+  label: records.mode_12t
+12tt:
+  label: records.mode_12tt
+1byz:
+  label: records.octoechos1
+1t:
+  label: records.mode_1t
+1tt:
+  label: records.mode_1tt
+'240':
+  fields:
+    a:
+      label: records.standardized_title
+    k:
+      label: records.subheading
+    m:
+      label: records.scoring_summary
+    o:
+      label: records.arrangement_statement
+    p:
+      label: records.title_section_part
+    r:
+      label: records.key_or_mode
+  label: records.standardized_title
+'245':
+  fields:
+    a:
+      label: records.title_on_source
+  label: records.title_on_source
+'246':
+  fields:
+    a:
+      label: records.variant_ms_title
+  label: records.variant_source_title
+'260':
+  fields:
+    '8':
+      label: records.set
+    a:
+      label: records.place
+    b:
+      label: records.publisher_copyist
+    c:
+      label: records.date
+    e:
+      label: records.location_printer
+    f:
+      label: records.name_printer
+  label: records.publishing_printing_production
+2byz:
+  label: records.octoechos2
+2t:
+  label: records.mode_2t
+2tt:
+  label: records.mode_2tt
+'300':
+  fields:
+    '8':
+      label: records.set
+    a:
+      label: records.format_extent
+    b:
+      label: records.other_physical_details
+    c:
+      label: records.dimensions
+  label: records.physical_description
+'340':
+  fields:
+    '8':
+      label: records.set
+    d:
+      label: records.printing_technique
+    m:
+      label: records.book_format
+  label: records.special_production_technique
+'383':
+  fields:
+    b:
+      label: records.opus_number
+  label: records.opus_number
+3byz:
+  label: records.octoechos3
+3t:
+  label: records.mode_3t
+3tt:
+  label: records.mode_3tt
+4byz:
+  label: records.octoechos4
+4t:
+  label: records.mode_4t
+4tt:
+  label: records.mode_4tt
+'500':
+  fields:
+    '8':
+      label: records.set
+    a:
+      label: records.general_note
+  label: records.general_note
+'505':
+  fields:
+    a:
+      label: records.contents_note
+  label: records.contents_note
+'506':
+  fields:
+    a:
+      label: records.access_restrictions
+  label: records.access_restrictions
+'508':
+  fields:
+    a:
+      label: records.creation_production_note
+  label: records.creation_production_note
+'510':
+  fields:
+    a:
+      label: records.series
+  label: general.rism_series
+'518':
+  fields:
+    a:
+      label: records.note_on_performance
+  label: records.note_on_performance
+'520':
+  fields:
+    a:
+      label: records.description_summary
+  label: records.description_summary
+'525':
+  fields:
+    a:
+      label: records.supplementary_material
+  label: records.supplementary_material
+'541':
+  fields:
+    a:
+      label: records.source_of_acquisition_note
+    c:
+      label: records.method_of_acquisition
+    d:
+      label: records.date_of_acquisition
+    e:
+      label: records.accession_number
+  label: records.source_of_acquisition_note
+'546':
+  fields:
+    a:
+      label: records.language_note
+  label: records.language_note
+'561':
+  fields:
+    a:
+      label: records.provenance_notes
+  label: records.provenance_notes
+'563':
+  fields:
+    a:
+      label: records.binding_note
+    u:
+      label: general.unused
+  label: records.binding_note
+'588':
+  fields:
+    a:
+      label: records.copy_examined
+  label: records.source_description
+'590':
+  fields:
+    '8':
+      label: records.set
+    a:
+      label: records.parts_held
+    b:
+      label: records.extent_parts
+  label: records.parts_held_extent
+'591':
+  fields:
+    a:
+      label: records.other_shelfmark
+  label: records.other_shelfmark
+'592':
+  fields:
+    '8':
+      label: records.set
+    a:
+      label: records.watermark_description
+  label: records.watermark_description
+'593':
+  fields:
+    '8':
+      label: records.set
+    a:
+      label: records.type
+  label: records.source_type
+'594':
+  fields:
+    b:
+      label: records.voice_instrument
+    c:
+      label: records.number
+  label: records.total_scoring
+'595':
+  fields:
+    a:
+      label: records.dramatic_roles_standardized
+    u:
+      label: records.dramatic_roles_original
+  label: records.named_dramatic_roles
+'596':
+  fields:
+    a:
+      label: general.rism_series_a_b_references
+    b:
+      label: general.rism_series_number
+    c:
+      label: records.reference_record_id
+  label: general.rism_series_a_b_references
+'597':
+  fields:
+    a:
+      label: records.colophon
+  label: records.colophon
+'598':
+  fields:
+    a:
+      label: records.solo_voice
+    b:
+      label: records.additional_solo_voice
+    c:
+      label: records.choir_voice
+    d:
+      label: records.additional_choir_voice
+    e:
+      label: records.soloist_instrument
+    f:
+      label: records.strings
+    g:
+      label: records.woodwinds
+    h:
+      label: records.brass_instruments
+    i:
+      label: records.plucked_instruments
+    k:
+      label: records.percussion
+    l:
+      label: records.keyboards
+    m:
+      label: records.other_instruments
+    n:
+      label: records.basso_continuo
+  label: records.coded_instrumentation
+'599':
+  fields:
+    a:
+      label: records.internal_note
+    b:
+      label: records.record_audit
+  label: records.internal_note
+5byz:
+  label: records.octoechos5
+5t:
+  label: records.mode_5t
+5tt:
+  label: records.mode_5tt
+'650':
+  fields:
+    a:
+      label: records.subject_heading
+  label: records.subject_heading
+'651':
+  fields:
+    a:
+      label: records.location_performance
+  label: records.location_performance
+'657':
+  fields:
+    a:
+      label: records.liturgical_festival
+  label: records.liturgical_festival
+'690':
+  fields:
+    a:
+      label: records.catalog_works
+    n:
+      label: records.number_page
+  label: records.catalog_works
+'691':
+  fields:
+    a:
+      label: records.bibliographic_reference
+    n:
+      label: records.number_page
+  label: records.bibliographic_reference
+6byz:
+  label: records.octoechos6
+6t:
+  label: records.mode_6t
+6tt:
+  label: records.mode_6tt
+'700':
+  fields:
+    '4':
+      label: records.function
+    '8':
+      label: records.set
+    a:
+      label: records.name
+    d:
+      label: records.life_dates
+    j:
+      label: records.attribution_qualifier
+  label: records.additional_personal_name
+'710':
+  fields:
+    '4':
+      label: records.function
+    '8':
+      label: records.set
+    a:
+      label: records.institution
+    b:
+      label: records.department
+    g:
+      label: records.attribution_qualifier
+  label: records.additional_institution
+'730':
+  fields:
+    a:
+      label: records.additional_title
+    g:
+      label: general.rule_type
+    k:
+      label: records.subheading
+    m:
+      label: records.scoring_summary
+    n:
+      label: records.catalog_opus_number
+    o:
+      label: records.arrangement_statement
+    r:
+      label: records.key
+  label: records.additional_title
+'773':
+  fields:
+    w:
+      label: records.parent_record
+  label: records.parent_record
+'774':
+  fields:
+    w:
+      label: records.item_in_collection
+  label: records.items_in_source
+'775':
+  fields:
+    w:
+      label: records.initial_entry
+  label: records.initial_entry
+'787':
+  fields:
+    g:
+      label: records.incipit_number
+    n:
+      label: records.location_insertion
+    s:
+      label: records.standardized_title
+    w:
+      label: records.rism_id_number
+  label: records.insertions
+7byz:
+  label: records.octoechos7
+7t:
+  label: records.mode_7t
+7tt:
+  label: records.mode_7tt
+'852':
+  fields:
+    a:
+      label: records.library_siglum
+    b:
+      label: records.department
+    c:
+      label: records.shelfmark
+    d:
+      label: records.shelfmark_olim
+    e:
+      label: records.library
+    q:
+      label: records.material_held
+    u:
+      label: general.uri
+    z:
+      label: records.provenance
+  label: records.library_siglum
+'856':
+  fields:
+    u:
+      label: records.external_resource_url
+    x:
+      label: records.link_type
+    z:
+      label: records.note_external_resource
+  label: records.external_resource
+8byz:
+  label: records.octoechos8
+8t:
+  label: records.mode_8t
+8tt:
+  label: records.mode_8tt
+'930':
+  fields:
+    a:
+      label: records.work
+  label: records.work
+'980':
+  fields:
+    a:
+      label: records.origin
+    b:
+      label: records.cataloging_level
+    c:
+      label: records.material_examined
+  label: records.record_origin
+9t:
+  label: records.mode_9t
+9tt:
+  label: records.mode_9tt
+A:
+  label: records.a_major
+Alleged:
+  label: records.alleged
+Arr:
+  label: records.arrangement
+Ascertained:
+  label: records.ascertained
 Autography:
-  label:
-    it: "Autografia"
-    fr: "Autographie"
-    de: "Autographie"
-    en: "Autography"
-    pt: "Autografia"
-    es: "Autografía"
-    pl: Autografia
-"Computer printout":
-  label:
-    it: "Stampata da computer"
-    fr: "Impression informatique"
-    de: "Computerausdruck"
-    en: "Computer printout"
-    pt: "Impressão de computador"
-    es: "Impreso de computadora"
-    pl: Wydruk komputerowy
-Engraving:
-  label:
-    it: "Incisione"
-    fr: "Gravure"
-    de: "Stich"
-    en: "Engraving"
-    pt: "Gravação"
-    es: "Grabado"
-    pl: Sztych
-Facsimile:
-  label:
-    it: "Facsimile"
-    fr: "Facsimile"
-    de: "Faksimile"
-    en: "Facsimile"
-    pt: "Fac-símile"
-    es: "Facsímil"
-    pl: Faksymile
-Lithography:
-  label:
-    it: "Litografia"
-    fr: "Lithographie"
-    de: "Lithographie"
-    en: "Lithography"
-    pt: "Litografia"
-    es: "Litografía"
-    pl: Litografia
-"Photoreproductive process":
-  label:
-    it: "Cianografia"
-    fr: "Reproduction photo (blueprint)"
-    de: "Blaupause"
-    en: "Photoreproductive process (bluprint)"
-    pt: "Processo foto-reprodutivo"
-    es: "Proceso fotoreproductivo"
-    pl: Proces optyczny (światłokopia)
-Reproduction:
-  label:
-    it: "Riproduzione"
-    fr: "Reproduction"
-    de: "Reproduktion"
-    en: "Reproduction"
-    pt: "Reprodução"
-    es: "Reproducción"
-    pl: Reprodukcja
-Transparency:
-  label:
-    it: "Trasparente"
-    fr: "Transparent"
-    de: "Transparentfolie"
-    en: "Transparency"
-    pt: "Transparência"
-    es: "Transparencia"
-    pl: Przezrocze
-Typescript:
-  label:
-    it: "Dattiloscritto"
-    fr: "Tapuscrit"
-    de: "Typescript"
-    en: "Typescript"
-    pt: "Datilografia"
-    es: "Escrito mecanografiado"
-    pl: Maszynopis
-Typography:
-  label:
-    it: "Stampa tipografica"
-    fr: "Typographie"
-    de: "Typendruck"
-    en: "Typography"
-    pt: "Tipografia"
-    es: "Tipografía"
-    pl: Typografia
-# new for 980
-origin:
-  label:
-    it: "Origine"
-    fr: "ORIGIN"
-    de: "Herkunft"
-    en: "Origin"
-    pt: "Origem"
-    es: "Orígen"
-    pl: Pochodzenie
-level:
-  label:
-    it: "Livello di catalogazione"
-    fr: "CATALOGING LEVEL"
-    de: "Erfassungstiefe"
-    en: "Cataloging level"
-    pt: "Nível de catalogação"
-    es: "Nivel de catalogación"
-    pl: Poziom katalogowania
-autopsie:
-  label:
-    it: "Materiale esaminato"
-    fr: "MATERIAL EXAMINED"
-    de: "Autopsie"
-    en: "Material examined"
-    es: "Material examinado"
-    pt: "Material examinado"
-    pl: Zbadany materiał
-RISM:
-  label:
-    it: "RISM"
-    fr: "RISM"
-    de: "RISM"
-    en: "RISM"
-    pt: "RISM"
-    es: "RISM"
-    pl: RISM
-retro:
-  label:
-    it: "Conversione retrospettiva"
-    fr: "RETROSPECTIVE CONVERSION"
-    de: "Retroeinspielung"
-    en: "Retrospective conversion"
-    pt: "Conversão restropectiva"
-    es: "Conversión retrospectiva"
-    pl: Konwersja retrospektywna
-import:
-  label:
-    it: "Dati importati"
-    fr: "IMPORT"
-    de: "Fremddateneinspielung"
-    en: "Import"
-    pt: "Importação"
-    es: "Importación"
-    pl: Import
-full:
-  label:
-    it: "Completo"
-    fr: "FULL"
-    de: "Vollkatalogisat"
-    en: "Full"
-    pt: "Completo"
-    es: "Completo"
-    pl: Pełny
-standard:
-  label:
-    it: "Standard"
-    fr: "STANDARD"
-    de: "Standard"
-    en: "Standard"
-    pt: "Normalizado"
-    es: "Estándar"
-    pl: Standardowy
-brief:
-  label:
-    it: "Breve"
-    fr: "BRIEF"
-    de: "Kurzkatalogisat"
-    en: "Brief"
-    pt: "Breve"
-    pl: Streszczenie
-examined:
-  label:
-    it: "Materiale esaminato"
-    fr: "MATERIAL EXAMINED"
-    de: "Autopsie"
-    en: "Material examined"
-    pt: Material examinado
-    es: Material examinado
-    pl: Zbadany materiał
-not_examined:
-  label:
-    it: "Materiale non esaminato"
-    fr: "MATERIAL NOT EXAMINED"
-    de: "Keine Autopsie"
-    en: "Material not examined"
-    pt: "Material não examinado"
-    es: "Material no examinado"
-    pl: Materiał nie zbadany
-
-
-
-
-
-
-
-
-
-
-
-### Addons for authority guidelines
-in_024:
-  label:
-    en: "Authority reference"
-    it: "Riferimento all'autorità"
-    de: "Normdaten referenz"
-    pt: "Referência de autoridade"
-    es: "Referencia de autoridad"
-    pl: Odniesienie do bazy haseł wzorcowych
-in_040:
-  label:
-    en: "Cataloging agency"
-    it: "Agenzia di catalogazione"
-    de: "Katalogisierungsagentur"
-    pt: "Agência catalogadora"
-    es: "Agencia catalogadora"
-    pl: Jednostka katalogująca
-in_043:
-  label:
-    en: "Country code"
-    it: "Codice paese"
-    de: "Ländercode"
-    pt: "Código de país"
-    es: "Código de país"
-    pl: Kod kraju
-in_034:
-  label:
-    en: "Location"
-    it: "Luogo"
-    de: "Ort"
-    pt: "Local"
-    es: "Lugar"
-    pl: Lokalizacja
-in_110:
-  label:
-    en: "Institution"
-    it: "Istituzione"
-    de: "Körperschaft"
-    pt: "Instituição"
-    es: "Institución"
-    pl: Instytucja
-in_510:
-  label:
-    en: "Paralell form of name"
-    it: "Forma parallela del nome"
-    de: "Paralelle Namensform"
-    pt: "Forma paralela do nome"
-    es: "Forma paralela de nombre"
-    pl: Współistniejąca forma nazwy
-in_410:
-  label:
-    en: "Other form of name"
-    it: "Altre forme del nome"
-    de: "Andere Namensform"
-    pt: "Outra forma do nome"
-    es: "Otra forma de nombre"
-    pl: Wariant nazwy instytucji
-in_373:
-  label:
-    en: "Now in"
-    it: "Ora in"
-    de: "Heute in"
-    pt: "Fontes agora em"
-    es: "Actualmente en"
-    pl: Obecnie w …
-in_368:
-  label:
-    en: "Type of institution"
-    it: "Tipo di istituzione"
-    de: "Körperschaftstyp"
-    pt: "Tipo de instituição"
-    es: "Tipo de institución"
-    pl: Rodzaj instytucji
-in_580:
-  label:
-    en: "Now in"
-    it: "Ora in"
-    de: "Heute in"
-    pt: "Agora em"
-    es: "Actualmente en"
-    pl: Obecnie w …
-in_371:
-  label:
-    en: "Location and address"
-    it: "Luogo ed indirizzo"
-    de: "Lokalisierung und Adresse"
-    pt: "Local e endereço"
-    es: "Ubicación y dirección"
-    pl: Lokalizacja i adres
-in_678:
-  label:
-    en: "History of institution"
-    it: "Storia dell'istituzione"
-    de: "Geschichte der Körperschaft"
-    pt: "História da instituição"
-    es: "Historia de la institución"
-    pl: Historia instytucji
-in_670:
-  label:
-    en: "Literature"
-    it: "Bibliografia"
-    de: "Literatur"
-    pt: "Literatura"
-    es: "Literatura"
-    pl: Literatura
-in_680:
-  label:
-    en: "General note"
-    it: "Nota generale"
-    de: "Allgemeine Bemerkungen"
-    pt: "Nota geral"
-    es: "Nota general"
-    pl: Uwaga ogólna
-in_856:
-  label:
-    en: "Online finding aids"
-    it: "Strumenti di supporto alla ricerca online"
-    de: "ONLINE FINDING AIDS"
-    pt: "Recursos de ajuda on-line"
-    es: "Recursos de ayuda online"
-    pl: Pomoce do wyszukiwania on-line
-in_551:
-  label:
-    en: "Places"
-    it: "Luoghi"
-    de: "Orte"
-    pt: "Locais"
-    es: "Lugares"
-    pl: Miejsca
-in_710:
-  label:
-    en: "Related institution"
-    it: "Istituzione collegata"
-    de: "Zugehörige Körperschaften"
-    pt: "Instituição relacionada"
-    es: "Institución relacionada"
-    pl: Powiązana instytucja
-in_700:
-  label:
-    en: "Person"
-    it: "Persona"
-    de: "Person"
-    pt: "Pessoa"
-    es: "Persona"
-    pl: Osoba
-in_000:
-  label:
-    en: "Leader"
-    it: "Leader"
-    de: "Leader"
-    pt: "Líder"
-    es: "Líder"
-    pl: Leader
-in_001:
-  label:
-    en: "RISM ID Number"
-    it: "Numero RISM"
-    de: "RISM ID NUMBER"
-    pt: "Número de ID RISM"
-    es: "Número de ID de RISM"
-    pl: RISM ID
-in_003:
-  label:
-    en: "Control number identifier"
-    it: "Identificatore del numero di controllo"
-    de: "CONTROL NUMBER IDENTIFIER"
-    pt: "Identificador de número de controle"
-    es: "Identificador del número de control"
-    pl: Identyfikator numeru kontrolnego
-in_005:
-  label:
-    en: "Date and time of last transaction"
-    it: "Data ed ora dell'ultima transazione"
-    de: "Zeitpunkt der letzten Transaktion"
-    pt: "Data e hora da última transação"
-    es: "Fecha y hora de la última transacción"
-    pl: Data i godzina ostatniej operacji
-in_008:
-  label:
-    en: "Date of creation"
-    it: "Data di creazione"
-    de: "Erstellungszeit"
-    pt: "Data de criação"
-    es: "Fecha de creación"
-    pl: Data utworzenia
-in_667:
-  label:
-    en: "Internal notes"
-    it: "Note interne"
-    de: "Interne Bemerkungen"
-    pt: "Notas internas"
-    es: "Notas internas"
-    pl: Uwagi wewnętrzne
-doc_in_identity:
-  label:
-    en: "Identity area"
-    it: "Identità"
-    de: "IDENTITY AREA"
-    pt: "Identidade"
-    es: "Identidad"
-    pl: Obszar tożsamości
-doc_in_contact:
-  label:
-    en: "Contact area"
-    it: "Contatto"
-    de: "Kontakt"
-    pt: "Contato"
-    es: "Contacto"
-    pl: Obszar kontaktu
-doc_in_description:
-  label:
-    en: "Description area"
-    it: "Descrizione"
-    de: "Beschreibung"
-    pt: "Descrição"
-    es: "Descripción"
-    pl: Obszar opisu
-doc_in_control:
-  label:
-    en: "Control fields"
-    it: "Campi di controllo"
-    de: "Kontrollfelder"
-    pt: "Campos de controle"
-    es: "Campos de control"
-    pl: Pola kontrolne
-
-pe_100:
-  label:
-    en: "Heading-Personal name"
-    it: "Nome di persona"
-    de: "Personenname"
-    pt: "Título-Nome de pessoa"
-    es: "Nombre personal principal"
-    pl: Nagłówek – nazwisko
-pe_042:
-  label:
-    en: "Authentication code"
-    it: "Codice di autenticazione"
-    de: "Authentifizierungscode"
-    pt: "Código de autenticação"
-    es: "Código de autenticación"
-    pl: Kod uwierzytelnienia
-pe_375:
-  label:
-    en: "Gender"
-    it: "Genere"
-    de: "Geschlecht"
-    pt: "Gênero"
-    es: "Género"
-    pl: Płeć społeczno-kulturowa
-pe_043:
-  label:
-    en: "Nationality"
-    it: "Nazionalità"
-    de: "Nationalität"
-    pt: "Nacionalidade"
-    es: "Nacionalidad"
-    pl: Narodowość
-pe_024:
-  label:
-    en: "Other standard identifier"
-    it: "Altro identificatore standard"
-    de: "OTHER STANDARD IDENTIFIER"
-    pt: "Outro identificador padronizado"
-    es: "Otro identificador estándar"
-    pl: Identyfikator innego standardu
-pe_400:
-  label:
-    en: "Name variant"
-    it: "Variante del nome"
-    de: "Namensvarianten"
-    pt: "Variante de nome"
-    es: "Variante de nombre"
-    pl: Alternatywna nazwa osoby
-pe_500:
-  label:
-    en: "Related personal name"
-    it: "Nome di persona collegato"
-    de: "Zugehörige Personen"
-    pt: "Nome de pessoa relacionado"
-    es: "Nombre personal relacionado"
-    pl: Powiązana osoba
-pe_510:
-  label:
-    en: "Associated institution"
-    it: "Istitutione associata"
-    de: "Zugehörige Körperschaften"
-    pt: "Instituição associada"
-    es: "Institución asoaciada"
-    pl: Powiązana instytucja
-pe_550:
-  label:
-    en: "Profession or function"
-    it: "Professione o funzione"
-    de: "Beruf oder Funktion"
-    pt: "Profissão ou função"
-    es: "Profesión o función"
-    pl: Zawód lub funkcja
-pe_551:
-  label:
-    en: "Geographic name"
-    it: "Nome geografico"
-    de: "Geographischer Name"
-    pt: "Nome geográfico"
-    es: "Nombre geográfico"
-    pl: Nazwa geograficzna
-pe_667:
-  label:
-    en: "Internal note"
-    it: "Nota interna"
-    de: "Interne Bemerkungen"
-    pt: "Nota interna"
-    es: "Nota interna"
-    pl: Uwaga wewnętrzna
-pe_670:
-  label:
-    en: "Source data found"
-    it: "Fonte dei dati"
-    de: "SOURCE DATA FOUND"
-    pt: "Fonte dos dados encontrados"
-    es: "Datos de fuente encontrados"
-    pl: Odnalezione źródło danych
-pe_678:
-  label:
-    en: "Additional biographical information"
-    it: "Informazioni bibliografiche aggiuntive"
-    de: "zusätzliche biographische Informationen"
-    pt: "Informação biográfica adicional"
-    es: "Información biográfica adicional"
-    pl: Dodatkowe informacje biograficzne
-pe_680:
-  label:
-    en: "General note"
-    it: "Nota generale"
-    de: "Allgemeine Bemerkungen"
-    pt: Nota geral
-    es: Nota general
-    pl: Uwaga ogólna
-pe_856:
-  label:
-    en: "External resource"
-    it: "Risorsa esterna"
-    de: "EXTERNAL RESOURCE"
-    pt: "Recurso externo"
-    es: "Recurso externo"
-    pl: Zasób zewnętrzny
-pe_040:
-  label:
-    en: "Cataloging source"
-    it: "Fonte della catalogazione"
-    de: "Katalogisierungsquelle"
-    pt: "Agência catalogadora"
-    es: "Agencia catalogadora"
-    pl: Katalogowanie źródła
-pe_main_entry_fields:
-  label:
-    de: "Haupteintragungen"
-    it: "Campi principali"
-    en: "Main entry fields"
-    pt: Campos de entrada principal
-    es: Campos principales
-    pl: Główne pola edycji
-pe_numbers:
-  label:
-    de: "Nummern und Codes"
-    it: "Numeri e codici"
-    en: "Numbers and code fields"
-    pt: "Números e campos de código"
-    es: "Números y códigos"
-    pl: Pola liczb i kodów
-pe_name_variants:
-  label:
-    de: "Namensvarianten"
-    it: "Varianti del nome"
-    en: "Name variants"
-    pt: Variante de nome
-    es: "Variantes del nombre"
-    pl: Alternatywne nazwy osoby
-pe_relations:
-  label:
-    de: "Beziehungen"
-    en: "Relations"
-    it: "Relazioni"
-    pt: "Relacionamentos"
-    es: "Relaciones"
-    pl: Relacje
-pe_references:
-  label:
-    it: Bibliografia e note
-    fr: "Références et notes"
-    de: Literatur und Fussnoten
-    en: References and notes
-    pt: "Notas e referências"
-    es: Notas y referencias
-    pl: Odniesienia i uwagi
-pe_control:
-  label:
-    en: "Control fields"
-    it: "Campi di controllo"
-    de: "Kontrollfelder"
-    pt: Campos de controle
-    es: "Campos de control"
-    pl: Pola kontrolne
-doc_places:
-  label:
-    en: "Places"
-    it: "Luoghi"
-    de: "Orte"
-    pt: "Locais"
-    es: "Lugares"
-    pl: Miejsca
-li_100:
-  label:
-    en: "Author / Editor"
-    it: "Autore / curatore"
-    de: "Autor / Herausgeber"
-    pt: Autor/editor
-    es: "Autor/editor"
-    pl: Autor / edytor
-li_700:
-  label:
-    en: "Additional personal name"
-    it: "Persona"
-    de: "Zusätzliche Personen"
-    pt: Nome de pessoa adicional
-    es: Nombre personal adicional
-    pl: Dodatkowa osoba
-li_240:
-  label:
-    en: "Title of item"
-    it: "Titolo"
-    de: "Titel"
-    pt: "Título do item"
-    es: "Título del ítem"
-    pl: Tytuł pozycji
-li_260:
-  label:
-    en: "Imprint"
-    it: "Dati editoriali"
-    de: "IMPRINT"
-    pt: "Carimbo/marca"
-    es: "Datos editoriales"
-    pl: Stopka wydawnicza
-li_300:
-  label:
-    en: "Physical description"
-    it: "Descrizione fisica"
-    de: "Materialbeschreibung"
-    pt: "Descrição física"
-    es: "Descripción del material"
-    pl: Opis fizyczny
-li_337:
-  label:
-    en: "Media type"
-    it: "Mezzo fisico"
-    de: "Medientyp"
-    pt: "Tipo de mídia"
-    es: "Tipo de medio"
-    pl: Rodzaj nośnika
-li_210:
-  label:
-    en: "Short title"
-    it: "Titolo breve"
-    de: "Kurztitel"
-    pt: "Título abreviado"
-    es: "Título breve"
-    pl: Skrócony tytuł
-li_250:
-  label:
-    it: Edizione
-    fr: Édition
-    de: Ausgabe
-    en: Edition statement
-    es: "Declaración de edición"
-    pl: Wydanie
-li_020:
-  label:
-    en: "ISBN"
-    it: "ISBN"
-    de: "ISBN"
-    pt: "ISBN"
-    es: "ISBN"
-    pl: ISBN
-li_022:
-  label:
-    en: "ISSN"
-    it: "ISSN"
-    de: "ISSN"
-    pt: "ISSN"
-    es: "ISSN"
-    pl: ISSN
-li_024:
-  label:
-    en: "ISSN"
-    it: "ISSN"
-    de: "ISSN"
-    pt: "ISSN"
-    es: "ISSN"
-    pl: ISSN
-li_041:
-  label:
-    en: "Language code"
-    it: "Codice della lingua"
-    de: "Sprachcode"
-    pt: "Código de idioma"
-    es: "Código de idioma"
-    pl: Kod języka
-li_044:
-  label:
-    en: "Country of publication"
-    it: "Paese di pubblicazione"
-    de: "Erscheinungsland"
-    pt: "País de publicação"
-    es: "País de publicación"
-    pl: Kraj publikacji
-li_710:
-  label:
-    en: "Additional institution"
-    it: "Istituzione aggiuntiva"
-    de: "Zusätzliche Körperschaften"
-    pt: "Instituição adicional"
-    es: "Institución adicional"
-    pl: Dodatkowa instytucja
-li_760:
-  label:
-    en: "Item part of"
-    it: "Fa parte di"
-    de: "ITEM PART OF"
-    pt: "Item parte de"
-    es: "Ítem integrante de"
-    pl: Jest częścią…
-li_650:
-  label:
-    en: "Subject heading"
-    it: "Parola chiave"
-    de: "Schlagworteintragung"
-    pt: "Assunto"
-    es: "Descriptor"
-    pl: Słowo kluczowe
-li_651:
-  label:
-    en: "Related place"
-    it: "Luogo correlato"
-    de: "Zugehörige Orte"
-    pt: "Local relacionado"
-    es: "Lugar relacionado"
-    pl: Powiązane miejsce
-li_780:
-  label:
-    en: "Preceding entry"
-    it: "Titolo precedente"
-    de: "Ersteintrag"
-    pt: "Registro precedente"
-    es: "Registro precedente"
-    pl: Poprzedzający wpis
-li_785:
-  label:
-    en: "Succeeding entry"
-    it: "Titolo successivo"
-    de: "Folgeeintrag"
-    pt: "Registro subsequente"
-    es: "Registro subsiguiente"
-    pl: Kolejny wpis
-li_500:
-  label:
-    en: "General note"
-    it: "Nota generale"
-    de: "Allgemeine Bemerkungen"
-    pt: "Nota geral"
-    es: "Nota general"
-    pl: Uwaga ogólna
-li_502:
-  label:
-    it: Nota alla dissertazione
-    fr: Note à la thèse
-    de: Hinweis zur Dissertation
-    en: Dissertation note
-    es: "Nota de disertación"
-    pl: Uwaga do dysertacji
-li_599:
-  label:
-    en: "Local note field"
-    it: "Nota locale"
-    de: "Lokale Bemerkungen"
-    pt: "Campo de nota local"
-    es: "Campo de nota local"
-    pl: Pole uwagi lokalnej
-li_856:
-  label:
-    en: "External resource"
-    it: "Risorsa esterna"
-    de: "Elektronische Lokalisierung und Zugriff"
-    pt: "Recurso externo"
-    es: "Recurso externo"
-    pl: Zasób zewnętrzny
-li_520:
-  label:
-    en: "Contents note"
-    it: "Indicazione di contenuto"
-    de: "CONTENTS NOTE"
-    pt: "Nota de Conteúdo"
-    es: "Nota sobre el contenido"
-    pl: Uwaga do zawartości
-li_000:
-  label:
-    en: "Leader"
-    it: "Leader"
-    de: "Leader"
-    pt: "Líder"
-    es: "Líder"
-    pl: Leader
-li_001:
-  label:
-    en: "RISM ID Number"
-    it: "Numero RISM"
-    de: "Zusammenfassende Beschreibung"
-    pt: "Número ID RISM"
-    es: "Número de ID de RISM"
-    pl: RISM ID
-li_003:
-  label:
-    en: "Control number identifier"
-    it: "Identificatore del numero di controllo"
-    de: "CONTROL NUMBER IDENTIFIER"
-    pt: "Identificador de número de controle"
-    es: "Identificador del número de control"
-    pl: Identyfikator numeru kontrolnego
-li_005:
-  label:
-    en: "Date and time of last transaction"
-    it: "Data ed ora dell'ultima transazione"
-    de: "Zeitpunkt der letzten Transaktion"
-    pt: "Data e hora da última transação"
-    es: "Fecha y hora de la última transacción"
-    pl: Data i godzina ostatniej operacji
-li_main_entry_fields:
-  label:
-    de: "Haupteintragungen"
-    it: "Campi principali"
-    en: "Main entry fields"
-    pt: "Campos principales"
-    es: "Campos principales"
-    pl: Główne pola edycji
-li_subject:
-  label:
-    en: "Subject access fields"
-    it: "Campi delle parole chiave"
-    de: "SUBJECT ACCESS FIELDS"
-    pt: "Campos de acesso por assunto"
-    es: "Campos de acceso por asunto"
-    pl: Pola haseł tematycznych
-li_note:
-  label:
-    en: "Note fields"
-    it: "Campi note"
-    de: "Bemerkungsfelder"
-    pt: Campos de notas
-    es: "Campos de notas"
-    pl: Pola uwag
-li_control:
-  label:
-    en: "Control fields"
-    it: "Campi di controllo"
-    de: "Kontrollfelder"
-    pt: Campos de controle
-    es: "Campos de control"
-    pl: Pola kontrolne
-li_lit:
-  label:
-    en: "Secondary literature"
-    it: "Bibliografia di riferimento"
-    de: "Sekundärliteratur"
-    pt: "Literatura secundária"
-    es: "Bibliografía secundaria"
-    pl: Literatura pomocnicza
-doc_titles_and_text:
-  label:
-    en: "Titles / text incipits"
-    it: "Titoli / incipit testuali"
-    de: "Titel und  Texte"
-    pt: "Títulos / incipits literários"
-    es: "Títulos/íncipits literarios"
-    pl: Tytuły / incipity tekstowe
-aid_terms:
-  label:
-    en: "Standard music terms"
-    it: "Terminologia musicale standard"
-    de: "STANDARD MUSIC TERMS"
-    pt: "Termos musicais normalizados"
-    es: "Términos musicales estándar"
-    pl: Standardowe pojęcia muzyczne
-aid_watermarks:
-  label:
-    en: "Standard watermarks"
-    it: "Descrizione standard di filigrane"
-    de: "Wasserzeichen"
-    pt: "Marcas d'água normalizadas"
-    es: "Marcas de agua estándar"
-    pl: Standardowe znaki wodne
-
-aid_general:
-  label:
-    en: "General abbreviations and terms"
-    it: "Terminologia ed abbreviazioni generali"
-    de: "GENERAL ABBREVIATIONS AND TERMS"
-    pt: Abreviaturas e termos gerais
-    es: "Abreviaturas y términos generales"
-    pl: Ogólne skróty i pojęcia
-aid_dates:
-  label:
-    en: "Dates"
-    it: "Date"
-    de: "Datierungen"
-    pt: Datas
-    es: Fechas
-    pl: Daty
-aid_eccl:
-  label:
-    en: "Ecclesiastical modes"
-    it: "Modi ecclesiastici"
-    de: "Kirchentonarten"
-    pt: "Modos eclesiásticos ocidentais"
-    es: "Modos eclesiásticos"
-    pl: Skale kościelne
-aid_keys:
-  label:
-    en: "Keys"
-    it: "Tonalità"
-    de: "Tonarten"
-    es: Tonalidades
-    pt: Tonalidades
-    pl: Tomacje
-aid_language:
-  label:
-    en: "Language codes"
-    it: "Codici lingue"
-    de: "Sprachcodes"
-    pt: "Código de idioma"
-    es: "Código de idioma"
-    pl: Kody języków
-doc_other:
-  label:
-    en: "Other help"
-    it: "Altri aiuti"
-    de: "Weitere Hilfen"
-    pt: "Outra ajuda"
-    es: "Otra Ayuda"
-    pl: Inna pomoc
-aid_titles:
-  label:
-    de: "Einordnungstitel - Schlagworte"
-    en: "Standardized titles - Subject headings"
-    it: "Titolo standard - intestazione del soggetto"
-    pt: "Títulos uniformes – Cabeçalhos de assunto"
-    es: "Títulos uniformes – Descriptores"
-    pl: Znormalizowane tytuły – słowa kluczowe
-aid_texts:
-  label:
-    en: "Standard texts of sacred works"
-    it: "Testi standard di composizioni sacre"
-    de: "Liturgische Texte"
-    pt: "Textos padronizados de obras sacras"
-    es: "Textos estándar de obras sacras"
-    pl: Standardowe teksty utworów sakralnych
-aid_lit:
-  label:
-    en: "Liturgical festivals"
-    it: "Feste liturgiche"
-    de: "Liturgische Feste"
-    pt: "Festa litúrgica"
-    es: "Festividades litúrgicos"
-    pl: Święta liturgiczne
-aid_figured:
-  label:
-    en: "Figured bass in scores and/or other parts"
-    it: "Basso cifrato in partitura e/o in altre parti"
-    de: "Generalbass"
-    pt: "Baixo cifrado"
-    es: "Bajo cifrado"
-    pl: Bas cyfrowany w partyturze i / lub w innych częściach
-aid_transpose:
-  label:
-    en: "Help for transposing instruments"
-    it: "Tabella degli strumenti traspositori"
-    de: "Hilfe zu transponierenden Instrumenten"
-    pt: "Ajuda para instrumentos transpositores"
-    es: "Ayuda para instrumentos transpositores"
-    pl: Pomoc przy transpozycji instrumentów
-aid_opera:
-  label:
-    en: "Opera houses and concert halls"
-    it: "Teatri e sale da concerto"
-    de: "Opernhäuser und Konzerthallen"
-    pt: "Teatros de ópera e salas de concerto"
-    es: "Teatros de ópera y salas de concierto"
-    pl: Opery i sale koncertowe
-aid_faq:
-  label:
-    en: "Frequently asked questions"
-    it: "Domande frequenti"
-    de: "FAQ"
-    pt: "Questões frequentes"
-    es: "Preguntas frecuentes"
-    pl: Odpowiedzi na częste pytania
-aid_tt:
-  label:
-    en: "How do I ... Tips & Tricks"
-    it: "Come faccio ... Suggerimenti e trucchi"
-    de: "Wie kann ich ... Tipps & Tricks"
-    pt: "Como faço ...dicas & truques"
-    es: "¿Cómo hago ...? Sugerencias y trucos"
-    pl: Rady i wskazówki
-aid_best:
-  label:
-    en: "RISM best practices"
-    it: "Miglior pratica RISM"
-    de: "RISM BEST PRACTISES"
-    pt: "Boas práticas no RISM"
-    es: "Mejores prácticas en RISM"
-    pl: Dobre praktyki RISM
-aid_error:
-  label:
-    en: "Technical errors"
-    it: "Errori tecnici"
-    de: "Technische Fehler"
-    pt: "Problemas técnicos"
-    es: "Problemas técnicos"
-    pl: Błędy techniczne
-IIIF:
-  label:
-    it: "Manifesto IIIF"
-    fr: "Manifeste IIIF"
-    de: "IIIF manifest"
-    en: "IIIF manifest"
-    pt: Manifesto IIIF
-    es: Manifiesto IIIF
-    pl: Manifest IIIF
+  label: records.autography
+A|b:
+  label: records.af_major
+A|x:
+  label: records.as_major
+B:
+  label: records.b_major
+B|b:
+  label: records.bf_major
+C:
+  label: records.c_major
+C+1:
+  label: records.c_plus_1
+C+2:
+  label: records.c_plus_2
+C+3:
+  label: records.c_plus_3
+C+4:
+  label: records.c_plus_4
+C+5:
+  label: records.c_plus_5
+C-1:
+  label: records.c_minus_1
+C-2:
+  label: records.c_minus_2
+C-3:
+  label: records.c_minus_3
+C-4:
+  label: records.c_minus_4
+C-5:
+  label: records.c_minus_5
+Computer printout:
+  label: records.computer_printout
+Conjectural:
+  label: records.conjectural
+C|b:
+  label: records.cf_major
+C|x:
+  label: records.cs_major
+D:
+  label: records.d_major
 Digitalization:
-  label:
-    it: "Musica digitalizzata"
-    fr: "Sources numériées"
-    de: "Quellendigitalisat"
-    en: "Digitized source"
-    pt: Fonte digitalizada
-    es: Fuente digitalizada
-    pl: Cyfrowa reprodukcja źródła
+  label: records.digitized_source
+Doubtful:
+  label: records.doubtful
+D|b:
+  label: records.df_major
+D|x:
+  label: records.ds_major
+E:
+  label: records.e_major
+Engraving:
+  label: records.engraving
+Excerpts:
+  label: records.excerpts
+E|b:
+  label: records.ef_major
+F:
+  label: records.f_major
+F+1:
+  label: records.f_plus_1
+F+2:
+  label: records.f_plus_2
+F+3:
+  label: records.f_plus_3
+F+4:
+  label: records.f_plus_4
+F+5:
+  label: records.f_plus_5
+F-1:
+  label: records.f_minus_1
+F-2:
+  label: records.f_minus_2
+F-3:
+  label: records.f_minus_3
+F-4:
+  label: records.f_minus_4_bass
+F-5:
+  label: records.f_minus_5
+Facsimile:
+  label: records.facsimile
+Fragments:
+  label: records.fragments
+F|x:
+  label: records.fs_major
+G:
+  label: records.g_major
+G+1:
+  label: records.g_plus_1
+G+2:
+  label: records.g_plus_2
+G+3:
+  label: records.g_plus_3
+G+4:
+  label: records.g_plus_4
+G+5:
+  label: records.g_plus_5
+G-1:
+  label: records.g_minus_1
+G-2:
+  label: records.g_minus_2_treble
+G-3:
+  label: records.g_minus_3
+G-4:
+  label: records.g_minus_4
+G-5:
+  label: records.g_minus_5
+G|b:
+  label: records.gf_major
+G|x:
+  label: records.gs_major
+IIIF:
+  label: records.iiif_manifest
+Inserts:
+  label: records.inserts
+Lithography:
+  label: records.lithography
+Misattributed:
+  label: records.misattributed
 Other:
-  label:
-    it: "Altro"
-    fr: "Autre"
-    de: "Sonstiges"
-    en: "Other"
-    pt: Outros
-    es: Otros
-    pl: Pozostałe
+  label: records.other
+Photoreproductive process:
+  label: records.photoreproductive_process
+RISM:
+  label: general.rism
+Reproduction:
+  label: records.reproduction
+Sketches:
+  label: records.sketches
+Transparency:
+  label: records.transparency
+Typescript:
+  label: records.typescript
+Typography:
+  label: records.typography
+Var:
+  label: records.variations
+Verified:
+  label: general.verified
+a:
+  label: records.a_minor
+afr:
+  label: languages.afrikaans
+aid_best:
+  label: general.rism_best_practices
+aid_dates:
+  label: records.dates
+aid_eccl:
+  label: records.ecclesiastical_modes
+aid_error:
+  label: records.technical_errors
+aid_faq:
+  label: general.faq
+aid_figured:
+  label: records.figured_bass_scores
+aid_general:
+  label: records.general_abbreviations
+aid_keys:
+  label: records.keys
+aid_language:
+  label: records.language_codes
+aid_lit:
+  label: records.liturgical_festival
+aid_opera:
+  label: records.opera_houses_concert_halls
+aid_terms:
+  label: records.standard_musical_terms
+aid_texts:
+  label: records.standard_texts_sacred_works
+aid_titles:
+  label: records.standardized_titles_subject_headings
+aid_transpose:
+  label: records.help_transposing_instruments
+aid_tt:
+  label: general.how_do_i
+aid_watermarks:
+  label: records.standard_watermarks
+ara:
+  label: languages.arabic
+arg:
+  label: languages.aragonese
+arm:
+  label: languages.armenian
+arr:
+  label: records.arranger
+art:
+  label: records.artist
+asg:
+  label: records.assignee
+asn:
+  label: records.associated_name
+aut:
+  label: records.author
+autopsie:
+  label: records.material_examined
+a|b:
+  label: records.af_minor
+a|x:
+  label: records.as_minor
+b:
+  label: records.b_minor
+baq:
+  label: languages.basque
+bnd:
+  label: records.binder
+bos:
+  label: languages.bosnian
+brief:
+  label: records.brief
+bsl:
+  label: records.bookseller
+bul:
+  label: languages.bulgarian
+b|b:
+  label: records.bf_minor
+c:
+  label: records.c_minor
+cat:
+  label: languages.catalan
+ccp:
+  label: records.conceptor
+cel:
+  label: languages.celtic_other
+chi:
+  label: languages.chinese
+chr:
+  label: records.choreographer
+chu:
+  label: languages.old_church_slavonic
+clb:
+  label: records.contributor
+cmp:
+  label: records.composer_cross_reference
+cnd:
+  label: records.conductor
+cns:
+  label: records.censor
+com:
+  label: records.compiler
+cph:
+  label: records.copyright_holder
+crp:
+  label: languages.creoles_pidgins_other
+cst:
+  label: records.costume_designer
+ctb:
+  label: records.co-composer
+cze:
+  label: languages.czech
+c|b:
+  label: records.cf_minor
+c|x:
+  label: records.cs_minor
+d:
+  label: records.d_minor
+dan:
+  label: languages.danish
+dnc:
+  label: records.dancer
+dnr:
+  label: records.donor
+doc_abbr_dates:
+  label: records.dates
+doc_abbr_general:
+  label: records.general_abbreviations
+doc_abbr_keys:
+  label: records.keys
+doc_abbr_lang:
+  label: records.language_codes
+doc_abbr_modes:
+  label: records.ecclesiastical_modes
+doc_abbr_voices_instr:
+  label: records.terms_voices_instruments
+doc_abbr_voices_instr2:
+  label: general.rism_instrument_abbreviations
+doc_abbreviations:
+  label: records.abbreviations_terminology
+doc_added_entries:
+  label: records.added_entry_name
+doc_administration:
+  label: records.administration
+doc_aid:
+  label: records.aide
+doc_aid_liturgical_feasts:
+  label: records.liturgical_festivals
+doc_aid_locations:
+  label: records.location_on_source
+doc_aid_texts_sacred_works:
+  label: records.standard_texts_sacred_works
+doc_aid_titles_keywords:
+  label: records.subject_headings
+doc_aid_transposing_instruments:
+  label: records.help_transposing_instruments
+doc_bibliographical_reference:
+  label: records.references
+doc_cat_authorities:
+  label: records.authorities
+doc_cat_collections:
+  label: records.cataloging_collections
+doc_cat_language:
+  label: records.cataloging_language
+doc_cat_templates:
+  label: records.templates
+doc_cataloguing:
+  label: records.general_cataloguing_guidelines
+doc_content:
+  label: records.content
+doc_date:
+  label: records.dates
+doc_diplomatic_title:
+  label: records.diplomatic_title
+doc_edit_functions:
+  label: records.basic_functions
+doc_edit_searching:
+  label: general.searching
+doc_edit_workflow:
+  label: general.workflow
+doc_editor:
+  label: general.using_muscat
+doc_images:
+  label: records.images
+doc_in_contact:
+  label: records.contact_area
+doc_in_control:
+  label: records.control_fields
+doc_in_description:
+  label: records.description_area
+doc_in_identity:
+  label: records.identity_area
+doc_incipit:
+  label: records.incipits
+doc_institutions:
+  label: records.institutions
+doc_introduction:
+  label: records.introduction
+doc_library:
+  label: records.library_information
+doc_linkage:
+  label: records.linkage
+doc_main_entry_fields:
+  label: records.main_entry_fields
+doc_masks:
+  label: records.cataloging_musical_sources
+doc_mult_copies:
+  label: records.multiple_copies
+doc_name_variants:
+  label: records.name_variants
+doc_numbers:
+  label: records.numbers_code_fields
+doc_other:
+  label: records.other_help
+doc_people:
+  label: records.people_institutions
+doc_performance:
+  label: records.performances
+doc_personal_names:
+  label: records.personal_names
+doc_physical_description:
+  label: records.material_description
+doc_places:
+  label: records.places
+doc_provenance:
+  label: records.provenance
+doc_record_actions:
+  label: records.record_actions
+doc_record_status:
+  label: records.record_status
+doc_references:
+  label: records.references
+doc_relations:
+  label: records.relations
+doc_scope_printed_music:
+  label: general.scope_printed_music_rism
+doc_standardized_titles_printed_music:
+  label: records.standardized_titles_printed_music
+doc_tag_index:
+  label: general.index_marc_fields
+doc_title:
+  label: records.title_content_description
+doc_titles_and_text:
+  label: records.titles_text_incipits
+doc_when_new_record:
+  label: general.when_to_input_new_record
+dpt:
+  label: records.depositor
+dsb:
+  label: languages.lower_sorbian
+dsr:
+  label: records.designer
+dst:
+  label: records.distributor
+dte:
+  label: records.dedicatee
+dut:
+  label: languages.dutch
+d|b:
+  label: records.df_minor
+d|x:
+  label: records.ds_minor
+e:
+  label: records.e_minor
+edit_administration:
+  label: records.administration
+edit_content:
+  label: records.title_content_description
+edit_incipits:
+  label: records.incipits
+edit_library:
+  label: records.library_information_relations
+edit_material:
+  label: records.material_description
+edit_names:
+  label: records.people_institutions
+edit_references:
+  label: records.references_and_notes
+edit_works:
+  label: records.work
+edt:
+  label: records.editor
+egr:
+  label: records.engraver
+eng:
+  label: languages.english
+enm:
+  label: languages.middle_english
+est:
+  label: languages.estonian
+evp:
+  label: records.event_place
+examined:
+  label: records.material_examined
+e|b:
+  label: records.ef_minor
+f:
+  label: records.f_minor
+fas:
+  label: languages.persian
+fij:
+  label: records.fijian
+fin:
+  label: languages.finnish
+fmo:
+  label: records.former_owner
+fre:
+  label: languages.french
+frm:
+  label: languages.french_middle
+fro:
+  label: languages.french_old
+frr:
+  label: languages.north_frisian
+fry:
+  label: languages.west_frisian
+full:
+  label: records.full
+fur:
+  label: records.friulano
+f|x:
+  label: records.fs_minor
+g:
+  label: records.g_minor
+g-2:
+  label: records.g_minus_2_octave
+gem:
+  label: languages.germanic
+ger:
+  label: languages.german
+gez:
+  label: languages.ethiopic
+gle:
+  label: languages.irish
+glg:
+  label: languages.gallician
+gmh:
+  label: languages.middle_high_german
+goh:
+  label: languages.german_old_high
+grc:
+  label: languages.greek_ancient
+gre:
+  label: languages.greek_modern
+gsw:
+  label: languages.swiss_german
+g|b:
+  label: records.gf_minor
+g|x:
+  label: records.gs_minor
+heb:
+  label: languages.hebrew
+hrv:
+  label: languages.croatian
+hsb:
+  label: languages.upper_sorbian
+hun:
+  label: languages.hungarian
+ice:
+  label: languages.icelandic
+iii:
+  label: languages.sichuan_yi
+ill:
+  label: records.illustrator
+import:
+  label: records.import
+in_000:
+  label: records.leader
+in_001:
+  label: records.rism_id_number
+in_003:
+  label: records.control_number_identifier
+in_005:
+  label: records.date_time_last_transaction
+in_008:
+  label: records.date_of_creation
+in_024:
+  label: records.authority_reference
+in_034:
+  label: records.location
+in_040:
+  label: records.cataloging_agency
+in_043:
+  label: records.country_code
+in_110:
+  label: records.institution
+in_368:
+  label: records.type_institution
+in_371:
+  label: records.location_and_address
+in_373:
+  label: records.now_in
+in_410:
+  label: records.other_form_of_name
+in_510:
+  label: records.parallel_form
+in_551:
+  label: records.places
+in_580:
+  label: records.now_in
+in_667:
+  label: records.internal_note
+in_670:
+  label: records.literature
+in_678:
+  label: records.history_institution
+in_680:
+  label: records.general_note
+in_700:
+  label: records.person
+in_710:
+  label: records.related_institution
+in_856:
+  label: records.online_finding_aids
+ita:
+  label: languages.italian
+itr:
+  label: records.instrumentalist
+jpn:
+  label: records.japanese
+kor:
+  label: languages.korean
+lat:
+  label: languages.latin
+lav:
+  label: languages.latvian
+lbt:
+  label: records.librettist
+level:
+  label: records.cataloging_level
+li_000:
+  label: records.leader
+li_001:
+  label: records.rism_id_number
+li_003:
+  label: records.control_number_identifier
+li_005:
+  label: records.date_time_last_transaction
+li_020:
+  label: records.isbn
+li_022:
+  label: records.issn
+li_024:
+  label: records.issn
+li_041:
+  label: records.language_code
+li_044:
+  label: records.country_of_publication
+li_100:
+  label: records.author_editor
+li_210:
+  label: records.short_title
+li_240:
+  label: records.title_item
+li_250:
+  label: records.edition_statement
+li_260:
+  label: records.imprint
+li_300:
+  label: records.physical_description
+li_337:
+  label: records.media_type
+li_500:
+  label: records.general_note
+li_502:
+  label: records.dissertation_note
+li_520:
+  label: records.contents_note
+li_599:
+  label: records.local_note_field
+li_650:
+  label: records.subject_heading
+li_651:
+  label: records.related_place
+li_700:
+  label: records.additional_personal_name
+li_710:
+  label: records.additional_institution
+li_760:
+  label: records.item_part_of
+li_780:
+  label: records.preceding_entry
+li_785:
+  label: records.succeeding_entry
+li_856:
+  label: records.external_resource
+li_control:
+  label: records.control_fields
+li_lit:
+  label: records.secondary_literature
+li_main_entry_fields:
+  label: records.main_entry_fields
+li_note:
+  label: records.note_fields
+li_subject:
+  label: records.subject_access_fields
+lit:
+  label: languages.lithuanian
+lse:
+  label: records.licensee
+ltg:
+  label: records.lithographer
+ltz:
+  label: languages.luxembourgish
+lyr:
+  label: records.text_author
+mac:
+  label: languages.macedonian
+mao:
+  label: languages.maori
+mon:
+  label: languages.mongolian
+mul:
+  label: records.multiple
+nap:
+  label: languages.neapolitan
+nds:
+  label: languages.low_german
+nor:
+  label: languages.norwegian
+not_examined:
+  label: records.material_not_examined
+oci:
+  label: languages.occitan
+origin:
+  label: records.origin
+oth:
+  label: records.other
+otm:
+  label: records.event_organizer
+pat:
+  label: records.patron
+pbl:
+  label: records.publisher
+pe_024:
+  label: records.other_standard_identifier
+pe_040:
+  label: records.cataloging_source
+pe_042:
+  label: records.authentication_code2
+pe_043:
+  label: records.nationality
+pe_100:
+  label: records.heading_personal_name1
+pe_375:
+  label: records.gender
+pe_400:
+  label: records.name_variant
+pe_500:
+  label: records.related_personal_name
+pe_510:
+  label: records.associated_institution
+pe_550:
+  label: records.profession_or_function
+pe_551:
+  label: records.geographic_name
+pe_667:
+  label: records.internal_note
+pe_670:
+  label: records.source_data_found
+pe_678:
+  label: records.additional_biographical_information
+pe_680:
+  label: records.general_note
+pe_856:
+  label: records.external_resource
+pe_control:
+  label: records.control_fields
+pe_main_entry_fields:
+  label: records.main_entry_fields
+pe_name_variants:
+  label: records.name_variants
+pe_numbers:
+  label: records.numbers_code_fields
+pe_references:
+  label: records.references_and_notes
+pe_relations:
+  label: records.relations
+per:
+  label: languages.persian
+pol:
+  label: languages.polish
+por:
+  label: languages.portugese
+ppm:
+  label: records.papermaker
+prd:
+  label: records.production_personnel
+prf:
+  label: records.performer
+prt:
+  label: records.printer
+pub:
+  label: records.publisher
+retro:
+  label: records.retrospective_conversion
+roh:
+  label: languages.romansh
+rom:
+  label: languages.romani
+rum:
+  label: languages.romanian
+rus:
+  label: languages.russian
+san:
+  label: languages.sanskrit
+scn:
+  label: languages.sicilian
+sco:
+  label: languages.scots
+scr:
+  label: records.copyist
+show_admin:
+  label: records.administration
+show_content:
+  label: records.content
+show_distribution:
+  label: records.distribution
+show_information:
+  label: records.further_information
+show_library:
+  label: records.library_information
+show_links:
+  label: records.related_titles
+show_material:
+  label: records.material_description
+show_references:
+  label: records.references
+show_resources:
+  label: records.related_resources
+show_summary:
+  label: records.summary
+show_terms:
+  label: records.index_terms
+sla:
+  label: languages.slavic
+slo:
+  label: languages.slovak
+slv:
+  label: languages.slovenian
+smn:
+  label: languages.insari_sami
+spa:
+  label: languages.spanish
+srp:
+  label: languages.serbian
+standard:
+  label: records.standard
+swe:
+  label: languages.swedish
+tat:
+  label: languages.tartar
+tgl:
+  label: languages.tagalog
+tha:
+  label: languages.thai
+tib:
+  label: languages.tibetan
+trl:
+  label: records.translator
+tsi:
+  label: languages.tsimshian
+tur:
+  label: languages.turkish
+ukr:
+  label: languages.ukrainian
+und:
+  label: general.undetermined
+ungrouped:
+  label: general.ungrouped_fields
+unmatched:
+  label: general.unknown_fields
+vie:
+  label: languages.vietnamese
+voc:
+  label: records.vocalist
+wel:
+  label: languages.welsh
+wen:
+  label: languages.sorbian
+xal:
+  label: languages.oirat
+yid:
+  label: languages.yiddish
+zxx:
+  label: records.no_linguistic_content

--- a/config/editor_profiles/default/configurations/WorkLabels.yml
+++ b/config/editor_profiles/default/configurations/WorkLabels.yml
@@ -1,2897 +1,698 @@
----  !map:ActiveSupport::HashWithIndifferentAccess 
-doc_abbreviations:
-  label:
-    it: Abbreviazioni
-    de: "Abkürzungen"
-    en: Abbreviations
-    es: Abreviaturas
-    pl: Skróty
-doc_aid:
-  label:
-    it: Aiuti
-    de: Arbeitshilfen
-    en: Aids
-    es: Asistencia
-    pl: Pomoce
-doc_cataloguing_collections:
-  label:
-    it: Catalogazione di raccolte e volumi compositi
-    de: Erfassung von Sammlungen
-    en: Cataloging collection and convoluta
-    es: "Catalogación de colecciones y volúmenes compuestos"
-    pl: Katalogowanie kolekcji i klocka introligatorskiego
-doc_edit_functions:
-  label:
-    it: Funzioni base
-    de: "Grundsätzliche Funktionen"
-    en: Basic functions
-    es: "Funciones básicas"
-    pl: Podstawowe funkcje
-doc_introduction:
-  label:
-    it: Introduzione
-    de: Einleitung
-    en: Introduction
-    es: "Introducción"
-    pl: Wprowadzenie
-doc_masks:
-  label:
-    it: Formulari di catalogazione
-    de: Masken
-    en: Cataloging forms
-    es: "Formularios de catalogación"
-    pl: Formularze katalogowania
-doc_tag_index:
-  label:
-    it: Indice dei campi MARC
-    de: MARC Tag Index
-    en: MARC tag index
-    es: "Índice de etiquetas MARC"
-    pl: Indeks znaczników MARC
-doc_templates:
-  label:
-    it: Template
-    de: Templates
-    en: Templates
-    es: Plantillas
-    pl: Szablony
-
-################
-
-doc_editor: 
-  label: 
-    it: Guida all'editor
-    de: "Editor Hilfe"
-    en: Editor help
-    es: "Ayuda del editor"
-    pl: Pomoc do edycji
-doc_edit_workflow: 
-  label: 
-    it: Workflow
-    de: "Workflow"
-    en: Workflow
-    es: Flujo de trabajo
-    pl: Przepływ pracy
-    
-################
-
-
-"000":
-  label:
-    it: Leader
-    fr: Guide
-    de: Leader
-    en: Leader
-    es: "Líder"
-    pl: Leader
-"001":
-  label:
-    it: Numero documento RISM
-    fr: No. RISM
-    de: RISM Dokumentnummer
-    en: RISM ID number
-    es: "Número de ID de RISM"
-    pl: RISM ID
-"003":
-  label:
-    it: Identificatore del numero di controllo
-    fr: "Identité du numéro de contrôle"
-    de: Kontrollnummer-Bezeichnung
-    en: Control number identifier
-    es: "Identificador de número de control"
-    pl: Identyfikator numeru kontrolnego
-"005":
-  label:
-    it: Data e ora dell'ultima transazione
-    fr: "Date/heure de la dernière transaction"
-    de: Datum und Zeit der letzten Transaktion
-    en: Date and time of last transaction
-    es: "Fecha y hora de la última transacción"
-    pl: Data i godzina ostatniej operacji
-"024":
-  label:
-    it: "Riferimento autorità"
-    fr: "Référence d'authorité"
-    de: Normdatenverweise
-    en: Other standard identifier
-    es: "Otro identificador estándar"
-    pl: Identyfikator innego standardu
-  fields:
-    a:
-      label:
-        it: "Riferimento autorità"
-        fr: "Référence d'authorité"
-        de: Normdatenverweise
-        en: Standard number or code
-        es: "Número o código estándar"
-        pl: Standardowy numer lub kod
-    "2":
-      label:
-        it: "Agenzia autorità"
-        fr: "Agence d'authorité"
-        de: Normdatenagentur
-        en: Source of number or code
-        es: "Fuente de número o código"
-        pl: Źródło numeru lub kodu
-"031": 
-  label: 
-    it: Incipit musicale
-    fr: Incipit musical
-    de: Musikincipit
-    en: Incipit
-    es: Íncipit
-    pl: Incipit
-  fields: 
-    a: 
-      label: 
-        it: Numero dell'incipit
-        fr: "Numéro de l'œuvre"
-        de: Incipitnummer
-        en: Work number
-        es: "Número de obra"
-        pl: Numer dzieła
-      edit_label: 
-        it: Numero
-        fr: "No. de l'œuvre"
-        de: Nummer
-        en: Work number
-        es: "Número de obra"
-        pl: Numer dzieła
-    b: 
-      label: 
-        it: Movimento N.
-        fr: "Numéro du mouvement"
-        de: Satznummer
-        en: Movement number
-        es: "Número de movimiento"
-        pl: Numer części
-      edit_label: 
-        it: Movimento N.
-        fr: "No. du mouvement"
-        de: Satznummer
-        en: Movement number
-        es: "Número de movimiento"
-        pl: Numer części
-    c: 
-      label: 
-        it: Numero dell'estratto
-        fr: "Numéro de l'extrait"
-        de: Abschnitt
-        en: Incipit number
-        es: "Número de íncipit"
-        pl: Numer incipitu
-      edit_label: 
-        it: Estratto No.
-        fr: "No. de l'extrait"
-        de: Nummer Abschnitt
-        en: Incipit number
-        es: "Número de íncipit"
-        pl: Numer incipitu
-    m: 
-      label: 
-        it: Organico
-        fr: Voix/instrument
-        de: Besetzung
-        en: Voice/instrument
-        es: Voz/instrumento
-        pl: Głos / instrument
-    n: 
-      label: 
-        it: Armatura di chiave
-        fr: Armure
-        de: Akzidentien
-        en: Key signature
-        es: "Armadura de clave"
-        pl: Znaki przykluczowe
-      edit_label: 
-        it: Armat.
-        fr: Armure
-        de: Vorzeichen
-        en: Key signature
-        es: "Armadura de clave"
-        pl: Znaki przykluczowe
-    d: 
-      label: 
-        it: Intestazione, Tempo
-        fr: Titre/tempo
-        de: Satztitel, Tempo
-        en: Title of movement, tempo
-        es: "Título del movimiento, tempo"
-        pl: Tytuł części, tempo
-    o: 
-      label: 
-        it: Misura
-        fr: Indication de mesure
-        de: Metrum
-        en: Time signature
-        es: "Indicación de compás"
-        pl: Metrum
-      edit_label: 
-        it: Misura
-        fr: Ind. mesure
-        de: Metrum
-        en: Time signature
-        es: "Indicación de compás"
-        pl: Metrum
-    e: 
-      label: 
-        it: Ruolo
-        fr: "Rôle"
-        de: Rolle
-        en: Role
-        es: Personaje
-        pl: Rola
-    p: 
-      label: 
-        it: Incipit musicale
-        fr: Notation musicale
-        de: Musikincipit
-        en: Music incipit
-        es: "Íncipit musical"
-        pl: Incipit muzyczny
-    q: 
-      label: 
-        it: Commento all'incipit mus.
-        fr: "Note générale"
-        de: Kommentar zum Musikincipit
-        en: General note
-        es: Nota general
-        pl: Uwaga ogólna
-    g: 
-      label: 
-        it: Chiave
-        fr: "Clé"
-        de: "Schlüssel"
-        en: Clef
-        es: Clave
-        pl: Klucz
-      edit_label: 
-        it: Chiave
-        fr: "Clé"
-        de: "Schlüssel"
-        en: Clef
-        es: Clave
-        pl: Klucz
-    r: 
-      label: 
-        it: "Tonalità, modo"
-        fr: "Tonalité, mode"
-        de: Tonart, Modus
-        en: Key or mode
-        es: Tonalidad o modo
-        pl: Tonacja lub modus
-      edit_label: 
-        it: "Tonalità"
-        fr: "Tonalité"
-        de: Tonart
-        en: Key
-        es: Tonalidad
-        pl: Tonacja
-    s: 
-      label: 
-        it: "Validità"
-        fr: "Validité"
-        de: "Gültigkeit"
-        en: Validity
-        es: Validez
-        pl: Ważność
-      edit_label: 
-        it: "Validità"
-        fr: "Validité"
-        de: "Gültigkeit"
-        en: "Validity"
-        es: Validez
-        pl: Ważność
-    t: 
-      label: 
-        it: Incipit testuale
-        fr: Incipit du texte
-        de: Textincipit
-        en: Text incipit
-        es: "Íncipit literario"
-        pl: Incipit tekstowy
-    z: 
-      label: 
-        it: Organico del movimento
-        fr: Distribution du mouvement
-        de: Besetzung Satz
-        en: Scoring in movement
-        es: "Plantilla/orgánico del movimiento"
-        pl: Obsada w części
-
-"040":
-  label:
-    it: Fonte della catalogazione
-    fr: Source du catalogage
-    de: Katalogisierungsquelle
-    en: Cataloging source
-    es: "Fuente de la catalogación"
-    pl: Katalogowanie źródła
-  fields:
-    a:
-      label:
-        it: Agenzia catalografica originale
-        fr: Organisme du catalogage original
-        de: Original-Katalogisierungsstelle
-        en: Original cataloging agency
-        es: "Agencia de catalogación original"
-        pl: Jednostka katalogująca pierwotny rekord
-    b:
-      label:
-        it: Lingua della catalogazione
-        fr: Langue de catalogage
-        de: Katalogisierungssprache
-        en: Language of cataloging
-        es: "Idioma de la catalogación"
-        pl: Język katalogowania
-    c:
-      label:
-        it: Agenzia della trascrizione
-        fr: Organisme de la transcription
-        de: "Übertragende Katalogisierungsstelle"
-        en: Transcribing agency
-        es: "Agencia de la transcripción"
-        pl: Jednostka transkrybująca
-    d:
-      label:
-        it: Agenzia della modifica
-        fr: Organisme de la modification
-        de: Modifizierende Katalogisierungsstelle
-        en: Modifying agency
-        es: "Agencia de la modificación"
-        pl: Jednostka modyfikująca
-"042":
-  label:
-    it: Codice di autenticazione
-    fr: "Code d'authentification"
-    de: Authentication Code
-    en: Authentication Code
-    es: "Código de autenticación"
-    pl: Kod uwierzytelnienia
-  fields:
-    a:
-      label:
-        it: Codice di autenticazione
-        fr: "Code d'authentification"
-        de: Authentication Code
-        en: Authentication Code
-        es: "Código de autenticación"
-        pl: Kod uwierzytelnienia
-"043":
-  label:
-    it: Codice del Paese
-    fr: Code du pays
-    de: Länder-Code
-    en: Nationality
-    es: Nacionalidad
-    pl: Narodowość
-  fields:
-    c:
-      label:
-        it: Codice del Paese
-        fr: Code du pays
-        de: Länder-Code  
-        en: Nationality
-        es: Nacionalidad
-        pl: Narodowość
-"100":
-  label:
-    it: Nome di persona
-    fr: Compositeur/Auteur
-    de: Ansetzungsform
-    en: Heading
-    es: Encabezado
-    pl: Nagłówek
-  fields:
-    a:
-      label:
-        it: Compositore
-        fr: Compositeur
-        de: Komponist
-        en: Composer
-        es: Compositor
-        pl: Kompozytor
-    d:
-      label:
-        it: Data di nascita e di morte
-        fr: Dates de vie
-        de: Geburts- und Todesdaten
-        en: Years of birth and death
-        es: "Años de nacimiento y muerte"
-        pl: Lata urodzenia i śmierci
-    m:
-      label:
-        it: Organico sintetico
-        fr: Distribution
-        de: Besetzungshinweis
-        en: Scoring summary
-        es: "Resumen de Plantilla/Orgánico"
-        pl: Podsumowanie obsady
-    n:
-      label:
-        it: Numero della parte/sezione di una composizione
-        fr: "Numéro de partie / section d'une œuvre"
-        de: "Opus / WV-Nummer"
-        en: "Opus / Thematic index number"
-        es: "Número de Opus/Índice temático"
-        pl: Opus / Numer z katalogu tematycznego 
-    r:
-      label: 
-        it: "Tonalità"
-        fr: "Tonalité"
-        de: Tonart
-        en: Key or mode
-        es: Tonalidad o modo
-        pl: Tonacja lub modus
-      comment: "(rdaw:P10221)"
-    t:
-      label:
-        it: Titolo della composizione
-        fr: Titre de la composition
-        de: Werktitel
-        en: Title of work
-        es: "Título de la obra"
-        pl: Tytuł dzieła
-"370":
-  label:
-    it: Luogo associato
-    fr: Endroit associé
-    de: Associated Place
-    en: Associated Place
-    es: Lugar asociado
-    pl: Powiązane miejsce
-  fields:
-    a:
-      label:
-        it: Luogo di nascita
-        fr: Lieu de naissance
-        de: Geburtsort  
-        en: Place of birth
-        es: Lugar de nacimiento
-        pl: Miejsce urodzenia
-"380": 
-  label: 
-    it: Parola chiave
-    fr: Sujets
-    de: Schlagworteintragung
-    en: Subject heading
-    es: Descriptor
-    pl: Słowo kluczowe
-  fields: 
-    a: 
-      label: 
-        it: Parola chiave
-        de: Sachschlagwort
-        fr: Sujet
-        en: Subject heading
-        es: Descriptor
-        pl: Słowo kluczowe
-      edit_label: 
-      en: ""
-
-"400":
-  label:
-    it: Nome di persona
-    fr: Compositeur/Auteur
-    de: Ansetzungsform
-    en: Heading
-    es: Encabezado
-    pl: Nagłówek
-  fields:
-    a:
-      label:
-        it: Compositore
-        fr: Compositeur
-        de: Komponist
-        en: Heading - composer name
-        es: Compositor
-        pl: Nagłówek – imię i nazwisko kompozytora
-    d:
-      label:
-        it: Data di nascita e di morte
-        fr: Dates de vie
-        de: Geburts- und Todesdaten
-        en: Years of birth and death
-        es: "Años de nacimiento y muerte"
-        pl: Lata urodzenia i śmierci
-    m:
-      label:
-        it: Organico sintetico
-        fr: Distribution
-        de: Besetzungshinweis
-        en: Scoring summary
-        es: "Resumen de plantilla/orgánico"
-        pl: Podsumowanie obsady
-    n:
-      label:
-        it: Numero della parte/sezione di una composizione
-        fr: "uméro de partie / section d'une œuvre"
-        de: Anzahl Teile oder Abschnitte eines Werks
-        en: Number of part/section of a work
-        es: "Número de parte/sección de una obra"
-        pl: Numer części / sekcji dzieła
-    r:
-      label: 
-        it: "Tonalità"
-        fr: "Tonalité"
-        de: Tonart
-        en: Key or mode
-        es: Tonalidad o modo
-        pl: Tonacja lub modus
-    t:
-      label:
-        it: Titolo della composizione
-        fr: Titre de la composition
-        de: Werktitel
-        en: Title of work
-        es: "Título de obra"
-        pl: Tytuł dzieła
-
-"500":
-  label:
-    it: Persone correlate
-    fr: Personnes liées
-    de: Zugehörige Personen
-    en: Related personal name
-    es: Nombre personal relacionado
-    pl: Powiązana osoba
-  fields:
-    a:
-      label:
-        it:  Nome
-        fr:  Nom
-        de:  Name
-        en:  Related personal name
-        es:  Nombre personal relacionado
-        pl: Powiązana osoba
-    y:
-      label:
-        it:  Relazione
-        fr:  Relation
-        de:  Beziehung
-        en:  Type of relationship
-        es:  "Tipo de relación"
-        pl: Rodzaj relacji
-
-"510":
-  label:
-    it: Sigle correlate
-    fr: Sigle de relation
-    de: Zugehörige Sigel 
-    en: Associated institution
-    es: "Institución asociada"
-    pl: Powiązana instytucja
-  fields:
-    a:
-      label:
-        it:  Sigla
-        fr:  Siglum
-        de:  Sigel
-        en:  Associated institution
-        es:  "Institución asociada"
-        pl: Powiązana instytucja
-"548":
-  label:
-    it: Date
-    fr: Datation
-    de: Datierungen 
-    en: Chronological term
-    es: "Término cronológico"
-    pl: Datowanie
-  fields:
-    a:
-      label:
-        it:  Data
-        fr:  DATE
-        de:  Datierung
-        en:  Date
-        es:  Fecha
-        pl: Data
-    i:
-      label:
-        it:  Relazione
-        fr:  Relation
-        de:  Beziehung
-        en:  Type of relationship
-        es:  "Tipo de relación"
-        pl: Rodzaj relacji
- 
-"550":
-  label:
-    it: Professione o funzione
-    fr: Sujet
-    de: Sachbegriff
-    en: Topical Term
-    es: "Término temático"
-    pl: Pojęcie tematyczne
-  fields:
-    a:
-      label:
-        it: Professione o funzione
-        fr: Sujet
-        de: Sachbegriff
-        en: Topical Term
-        es: "Término temático"
-        pl: Pojęcie tematyczne
-    i:
-      label:
-        it:  Relazione
-        fr:  Relation
-        de:  Bedeutung
-        en:  Relation
-        es:  Relación
-        pl: Relacja
-"551":
-  label:
-    it: Nome geografico
-    fr: Lieu
-    de: Orte
-    en: Geographic name
-    es: "Nombre geográfico"
-    pl: Nazwa geograficzna
-  fields:
-    a:
-      label:
-        it:  Nome geografico
-        fr:  Lieu
-        de:  Ort
-        en:  Geographic name
-        es:  "Nombre geográfico"
-        pl: Nazwa geograficzna
-    i:
-      label:
-        it:  Tipo
-        fr:  "Description de l'endroit"
-        de:  Ort Bedeutung
-        en:  Type
-        es:  Tipo
-        pl: Rodzaj
-
-"667":
-  label:
-    it:  Nota interna
-    fr:  Note non publique
-    de:  Non public note
-    en:  Internal note
-    es:  Nota interna
-    pl: Uwaga wewnętrzna
-  fields:
-    a:
-      label:
-        it:  Nota interna
-        fr:  Note non publique
-        de:  Non public note
-        en:  Internal note
-        es:  Nota interna
-        pl: Uwaga wewnętrzna
-"670":
-  label:
-    it: Fonte dei dati 
-    fr: Source des données
-    de: Literaturnachweis
-    en: Source data found 
-    es: "Fuente de los datos encontrados"
-    pl: Odnalezione źródło danych
-  fields:
-    a:
-      label:
-        it: Fonte dei dati
-        fr: Source des données
-        de: Literaturnachweis
-        en: Source data found
-        es: "Fuente de los datos encontrados"
-        pl: Odnalezione źródło danych
-    b:
-      label:
-        it: Informazione rinvenuta
-        fr: "Numéro/page"
-        de: Fundstelle
-        en: Information found
-        es: "Información encontrada"
-        pl: Odnaleziona informacja
-"675":
-  label:
-    it: Fonte consultata senza esito
-    fr: Source consultée sans résultat
-    de: Quelle ohne Ergebnis konsultiert
-    en: Source data not found
-    es: "Fuente de los datos no encontrados"
-    pl: Brak źródła danych
-  fields:
-    a:
-      label:
-        it: Fonte consultata senza esito 
-        fr: Source consultée sans résultat
-        de: Quelle ohne Ergebnis konsultiert
-        en: Source data not found
-        en: "Fuente de los datos no encontrados"
-        pl: Brak źródła danych
-      edit_label: 
-        en: ""
-        de: ""
-
-"678":
-  label:
-    it: Informazioni bibliografiche addizionali 
-    fr: Référence bibliographique additionnelle 
-    de: Weitere bibliographische Angaben
-    en: Additional bibliographical information
-    es: "Información bibliográfica adicional"
-    pl: Dodatkowe informacje bibliograficzne
-  fields:
-    a:
-      label:
-        it: Riferimento bibliografico addizionale 
-        fr: Référence bibliographique additionnelle
-        de: Weitere bibliographische Angaben
-        en: Additional bibliographical information
-        es: "Información bibliográfica adicional"
-        pl: Dodatkowe informacje bibliograficzne
-"680":
-  label:
-    it: Osservazioni
-    fr: Remarque générale
-    de: Allgemeine Bemerkungen
-    en: General note
-    es: Nota general
-    pl: Uwaga ogólna
-  fields:
-    a:
-      label:
-        it: Osservazioni
-        fr: Remarque générale
-        de: Externe Bemerkungen
-        en: General note
-        es: Nota general
-        pl: Uwaga ogólna
-"700": 
-  label: 
-    it: Nomi di persone aggiuntivi
-    fr: Noms de personnes additionnels
-    de: Nebeneintragung Personen
-    en: Additional personal name
-    es: Nombre personal adicional
-    pl: Dodatkowa osoba
-  fields: 
-    a: 
-      label: 
-        it: Nome
-        fr: Nom
-        de: Personenname
-        en: Name
-        es: Nombre
-        pl: Imię i nazwisko 
-    d: 
-      label: 
-        it: Date di nascita e di morte
-        fr: Dates de vie
-        de: Geburts- und Todesdaten
-        en: Life dates
-        es: Fechas de nacimiento y muerte
-        pl: Daty urodzenia i śmierci
-    j: 
-      label: 
-        it: Qualificazione d'attribuzione
-        fr: Qualificatif d'attribution
-        de: Zuschreibungsvermerk
-        en: Attribution qualifier
-        es: "Calificador de atribución"
-        pl: Kwalifikator atrybucji
-      edit_label: 
-        it: Attribuzione
-        fr: Attribution
-        de: Zuschreibung
-        en: Attribution
-        es: "Atribución"
-        pl: Atrybucja
-    "4": 
-      label: 
-        it: Funzione
-        fr: Function
-        de: Funktionsbezeichnung
-        en: Function
-        es: "Función"
-        pl: Funkcja
-"710": 
-  label: 
-    it: Nome di ente collettivo
-    fr: "Nom de la collectivité"
-    de: Nebeneintragung Körperschaften
-    en: Additional institution
-    es: "Institución adicional"
-    pl: Dodatkowa instytucja
-  fields: 
-    a: 
-      label: 
-        it: Nome di ente collettivo
-        fr: "Nom de la collectivité"
-        de: Körperschaftsname
-        en: Institution
-        es: "Institución"
-        pl: Instytucja
-    b: 
-      label: 
-        it: Ente subordinato
-        fr: "Collectivité subordonnée"
-        de: Untergeordnete Körperschaft
-        en: Department
-        es: Departamento
-        pl: Wydział
-    g: 
-      label: 
-        it: Qualificazione d'attribuzione
-        fr: Qualificatif d'attribution
-        de: Zuschreibungsvermerk
-        en: Attribution qualifier
-        es: "Calificador de atribución"
-        pl: Kwalifikator atrybucji
-      edit_label: 
-        it: Attribuzione
-        fr: Attribution
-        de: Zuschreibung
-        en: Attribution
-        es: "Atribución"
-        pl: Atrybucja
-
-    "4": 
-      label: 
-        it: Funzione
-        fr: Fonction
-        de: Funktionsbezeichnung
-        en: Function
-        es: Función
-        pl: Funkcja
-    "8": 
-      label: 
-        it: Gruppo di materiale
-        fr: Documents
-        de: Set
-        en: Set
-        es: Conjunto de materiales
-        pl: Zbiór
-
-"747": 
-  label: 
-    it: Feste liturgiche
-    fr: "Fête liturgique"
-    de: Liturgische Feste
-    en: Liturgical festival
-    es: "Festividad litúrgica"
-    pl: Święto liturgiczne
-  fields: 
-    a: 
-      label: 
-        it: Feste liturgiche
-        fr: "Fête liturgique"
-        de: Liturgische Feste
-        en: Liturgical feasts
-        es: "Festividad litúrgica"
-        pl: Święta liturgiczne
-      edit_label: 
-        en: ""
-"856":
-  label:
-    it: Localizzazione e accesso elettronico
-    fr: "Ressource électronique externe"
-    de: Elektronische Lokalisierung und Zugriff
-    en: External resource URI
-    es: URI de recurso externo
-    pl: URI zasobu zewnętrznego
-  fields:
-    y:
-      label:
-        it: Nota sulla risorsa esterna
-        fr: Remarque sur la ressource externe
-        de: "Für das Publikum bestimmte Fussnote"
-        en: Note about external resource
-        es: Nota sobre recurso externo
-        pl: Uwaga o zasobie zewnętrznym
-    u:
-      label:
-        it: Risorsa esterna
-        fr: Ressource externe
-        de: Uniform Resource Identifier
-        en: External resource
-        es: Recurso externo
-        pl: Zasób zewnętrzny
-"930":
-  label:
-    it: Opera correlata
-    fr: Ouvrage connexe
-    de: zugehörige Werke
-    en: Related work
-    es: Obra relacionada
-    pl: Powiązane dzieło
-  fields:
-    a:
-      label:
-        it:  Opera
-        fr:  Ouvrage
-        de:  Werk
-        en:  WORK
-        es:  Obra
-        pl: Dzieło
-    i:
-      label:
-        it:  Relazione
-        fr:  Relation
-        de:  Beziehung
-        en:  Type of relationship
-        es:  "Tipo de relación"
-        pl: Rodzaj relacji
- 
-main_work:
-  label:
-    it: Campi principali
-    fr: "Entrées principales"
-    de: Haupteintragungen
-    en: Main entry fields
-    es: Campos principales
-    pl: Główne pola edycji
-codes:
-  label:
-    it: Numeri e codici
-    fr: "Numéros et codes"
-    de: Nummern und Codes
-    en: Numbers and code fields
-    es: "Números y códigos"
-    pl: Pola liczb i kodów
-control:
-  label:
-    fr: "Champs de contrôle"
-    de: Kontrollfelder
-    it: Campi di controllo
-    en: Control fields
-    es: Campos de control
-    pl: Pola kontrolne
-notes:
-  label:
-    it: Note
-    fr: Notes
-    de: Bemerkungen
-    en: Note fields
-    es: Notas
-    pl: Pola uwag
-subject:
-  label:
-    it: Soggetti
-    fr: "Entrées de sujets"
-    de: Schlagworteintragungen
-    en: Subject access fields
-    es: Campos de puntos de acceso
-    pl: Pola haseł tematycznych
-incipits: 
-  label: 
-    it: Incipit
-    fr: Incipits
-    de: Incipits
-    en: Incipits
-    es: "Íncipits"
-    pl: Incipity
-places:
-  label:
-    it: Luoghi
-    fr: Lieu
-    de: Länder und Orte
-    en: Countries and Places
-    es: "Países y lugares"
-    pl: Kraje i miejsca
-other:
-  label:
-    it: Varia
-    fr: Divers
-    de: Verschiedenes
-    en: Miscellaneous
-    es: Varios
-    pl: Pozostałe
-references:
-  label:
-    it: Riferimenti
-    fr: "Références"
-    de: Literatur und Bemerkungen
-    en: References and notes
-    es: Notas y referencias
-    pl: Odniesienia i uwagi
-relations:
-  label:
-    it: Relazione
-    fr: Relation
-    de: Beziehungen
-    en: Relations
-    es: Relaciones
-    pl: Relacje
-variants:
-  label:
-    it: Varianti
-    fr: Variantes
-    de: Namensvarianten
-    en: Title variants
-    es: "Variantes del título"
-    pl: Warianty tytułu
-administration:
-  label:
-    it: Amministrazione
-    fr: Administration
-    de: Administration
-    en: Administration
-    es: Administración
-    pl: Administracja
-male:
-  label:
-    it: maschio
-    fr: homme
-    de: männlich
-    en: male
-    es: masculino
-    pl: mężczyzna
-female:
-  label:
-    it: femmina
-    fr: femme
-    de: weiblich
-    en: female
-    es: femenino
-    pl: kobieta
-unknown:
-  label:
-    it: sconosciuto
-    fr: inconnu
-    de: unbekannt
-    en: unknown
-    es: desconocido
-    pl: płeć nieznana
-
-#########################
-go:
-  label:
-    it: Luogo di nascita
-    fr: Lieu de naissance
-    de: Geburtsort
-    en: Place of Birth
-    es: Lugar de nacimiento
-    pl: Miejsce urodzenia
-ha:
-  label:
-    it: Luogo di origine
-    fr: "Lieu d'origine"
-    de: Herkunftsangabe
-    en: Place of Origin
-    es: Lugar de origen
-    pl: Miejsce pochodzenia
-po:
-  label:
-    it: Luogo postale
-    fr: endroit postal
-    de: postalischer Ort
-    en: postal Place
-    es: "Dirección postal"
-    pl: Rejon pocztowy
-so:
-  label:
-    it: Luogo di morte
-    fr: Lieu de décès
-    de: Sterbeort
-    en: Place of Death
-    es: Lugar de fallecimiento
-    pl: Miejsce śmierci
-wl:
-  label:
-    it: "Paese di attività"
-    fr: "Pays d'activité"
-    de: Wirkungsland
-    en: Country of activity
-    es: "País de actividad"
-    pl: Kraj aktywności artystycznej
-wo:
-  label:
-    it: "Luogo di attività"
-    fr: "Lieu d'activité"
-    de: Wirkungsort
-    en: Place of activity
-    es: "Lugar de actividad"
-    pl: Miejsce aktywności artystycznej
-wr:
-  label:
-    it: "Regione di attività"
-    fr: "Région d'activité"
-    de: Wirkungsregion
-    en: Region of activity
-    es: "Región de actividad"
-    pl: Region aktywności artystycznej
-#Country Codes
-"XC-DZ":
-  label:
-    it: "Algeria"
-    fr: "Algeria"
-    de: "Algeria"
-    en: "Algeria"
-    es: "Argelia"
-    pl: Algieria
-"XD-AR":
-  label:
-    it: "Argentina"
-    fr: "Argentina"
-    de: "Argentina"
-    en: "Argentina"
-    es: "Argentina"
-    pl: Argentyna
-"XB-AM":
-  label:
-    it: "Armenia"
-    fr: "Armenia"
-    de: "Armenia"
-    en: "Armenia"
-    es: "Armenia"
-    pl: Armenia
-"XE-AU":
-  label:
-    it: "Australia"
-    fr: "Australia"
-    de: "Australia"
-    en: "Australia"
-    es: "Australia"
-    pl: Australia
-"XA-AT":
-  label:
-    it: "Austria"
-    fr: "Austria"
-    de: "Austria"
-    en: "Austria"
-    es: "Austria"
-    pl: Austria
-"XA-AT-2":
-  label:
-    it: "Austria: Carinzia"
-    fr: "Austria: Carinthia"
-    de: "Austria: Carinthia"
-    en: "Austria: Carinthia"
-    es: "Austria: Carintia"
-    pl: "Austria: Karyntia"
-"XA-AT-3":
-  label:
-    it: "Austria: Austria Inferiore"
-    fr: "Austria: Lower Austria"
-    de: "Austria: Lower Austria"
-    en: "Austria: Lower Austria"
-    es: "Austria: Baja Austria"
-    pl: "Austria: Dolna Austria"
-"XA-AT-5":
-  label:
-    it: "Austria: Salisburgo"
-    fr: "Austria: Salzburg"
-    de: "Austria: Salzburg"
-    en: "Austria: Salzburg"
-    es: "Austria: Salzburgo"
-    pl: "Austria: Salzburg"
-"XA-AT-6":
-  label:
-    it: "Austria: Stiria"
-    fr: "Austria: Styria"
-    de: "Austria: Styria"
-    en: "Austria: Styria"
-    es: "Austria: Estiria"
-    pl: "Austria: Styria"
-"XA-AT-7":
-  label:
-    it: "Austria: Tirolo"
-    fr: "Austria: Tyrol"
-    de: "Austria: Tyrol"
-    en: "Austria: Tyrol"
-    es: "Austria: Tirol"
-    pl: "Austria: Tyrol"
-"XA-AT-4":
-  label:
-    it: "Austria: Austria Superiore"
-    fr: "Austria: Upper Austria"
-    de: "Austria: Upper Austria"
-    en: "Austria: Upper Austria"
-    es: "Austria: Alta Austria"
-    pl: "Austria: Górna Austria"
-"XA-AT-9":
-  label:
-    it: "Austria: Vienna"
-    fr: "Austria: Vienna"
-    de: "Austria: Vienna"
-    en: "Austria: Vienna"
-    es: "Austria: Viena"
-    pl: "Austria: Wiedeń"
-"XA-BE":
-  label:
-    it: "Belgio"
-    fr: "Belgium"
-    de: "Belgium"
-    en: "Belgium"
-    es: "Bélgica"
-    pl: Belgia
-"XC-BJ":
-  label:
-    it: "Benin"
-    fr: "Benin"
-    de: "Benin"
-    en: "Benin"
-    es: "Benín"
-    pl: Benin
-"XD-BR":
-  label:
-    it: "Brasile"
-    fr: "Brazil"
-    de: "Brazil"
-    en: "Brazil"
-    es: "Brasil"
-    pl: Brazylia
-"XA-BG":
-  label:
-    it: "Bulgaria"
-    fr: "Bulgaria"
-    de: "Bulgaria"
-    en: "Bulgaria"
-    es: "Bulgaria"
-    pl: Bułgaria
-"XB-KH":
-  label:
-    it: "Cambogia"
-    fr: "Cambodia"
-    de: "Cambodia"
-    en: "Cambodia"
-    es: "Camboya"
-    pl: Kambodża
-"XD-CA":
-  label:
-    it: "Canada"
-    fr: "Canada"
-    de: "Canada"
-    en: "Canada"
-    es: "Canadá"
-    pl: Kanada
-"XD-CL":
-  label:
-    it: "Cile"
-    fr: "Chile"
-    de: "Chile"
-    en: "Chile"
-    es: "Chile"
-    pl: Chile
-"XB-CN":
-  label:
-    it: "Cina"
-    fr: "China"
-    de: "China"
-    en: "China"
-    es: "China"
-    pl: Chiny
-"XD-CO":
-  label:
-    it: "Colombia"
-    fr: "Colombia"
-    de: "Colombia"
-    en: "Colombia"
-    es: "Colombia"
-    pl: Kolumbia
-"XA-HR":
-  label:
-    it: "Croazia"
-    fr: "Croatia"
-    de: "Croatia"
-    en: "Croatia"
-    es: "Croacia"
-    pl: Chorwacja
-
-"XD-CU":
-  label:
-    it: "Cuba"
-    fr: "Cuba"
-    de: "Cuba"
-    en: "Cuba"
-    es: "Cuba"
-    pl: Kuba
-"XA-CZ":
-  label:
-    it: "Repubblica Ceca"
-    fr: "Czech Republic"
-    de: "Czech Republic"
-    en: "Czech Republic"
-    es: "República Checa"
-    pl: Czechy
-"XA-DK":
-  label:
-    it: "Danimarca"
-    fr: "Denmark"
-    de: "Denmark"
-    en: "Denmark"
-    es: "Dinamarca"
-    pl: Dania
-"XC-EG":
-  label:
-    it: "Egitto"
-    fr: "Egypt"
-    de: "Egypt"
-    en: "Egypt"
-    es: "Egipto"
-    pl: Egipt
-"XA-EE":
-  label:
-    it: "Estonia"
-    fr: "Estonia"
-    de: "Estonia"
-    en: "Estonia"
-    es: "Estonia"
-    pl: Estonia
-"XA-FI":
-  label:
-    it: "Finlandia"
-    fr: "Finland"
-    de: "Finland"
-    en: "Finland"
-    es: "Finlandia"
-    pl: Finlandia
-"XA-FR":
-  label:
-    it: "Francia"
-    fr: "France"
-    de: "France"
-    en: "France"
-    es: "Francia"
-    pl: Francja
-"XA-DE":
-  label:
-    it: "Germania"
-    fr: "Germany"
-    de: "Germany"
-    en: "Germany"
-    es: "Alemania"
-    pl: Niemcy
-"XA-DE-BY":
-  label:
-    it: "Germania: Baviera"
-    fr: "Germany: Bavaria"
-    de: "Germany: Bavaria"
-    en: "Germany: Bavaria"
-    es: "Alemania: Bavaria"
-    pl: "Niemcy: Bawaria"
-"XA-DE-SN":
-  label:
-    it: "Germania: Sassonia"
-    fr: "Germany: Saxony"
-    de: "Germany: Saxony"
-    en: "Germany: Saxony"
-    es: "Alemania: Sajonia"
-    pl: "Niemcy: Saksonia"
-"XA-GR":
-  label:
-    it: "Grecia"
-    fr: "Greece"
-    de: "Greece"
-    en: "Greece"
-    es: "Grecia"
-    pl: Grecja
-"XA-VA":
-  label:
-    it: "Santa Sede"
-    fr: "Holy See"
-    de: "Holy See"
-    en: "Holy See"
-    es: "Santa Sede"
-    pl: Watykan
-"XD-HN":
-  label:
-    it: "Honduras"
-    fr: "Honduras"
-    de: "Honduras"
-    en: "Honduras"
-    es: "Honduras"
-    pl: Honduras
-"XA-HU":
-  label:
-    it: "Ungheria"
-    fr: "Hungary"
-    de: "Hungary"
-    en: "Hungary"
-    es: "Hungría"
-    pl: Węgry
-"XA-IS":
-  label:
-    it: "Islanda"
-    fr: "Iceland"
-    de: "Iceland"
-    en: "Iceland"
-    es: "Islandia"
-    pl: Islandia
-"XB-IN":
-  label:
-    it: "India"
-    fr: "India"
-    de: "India"
-    en: "India"
-    es: "India"
-    pl: Indie
-"XB-IR":
-  label:
-    it: "Iran, Repubblica Islamica dell'"
-    fr: "Iran, Islamic Republic of"
-    de: "Iran, Islamic Republic of"
-    en: "Iran, Islamic Republic of"
-    es: "Irán, República Islámica de"
-    pl: Iran, Republika Islamska
-"XA-IE":
-  label:
-    it: "Irlanda"
-    fr: "Ireland"
-    de: "Ireland"
-    en: "Ireland"
-    es: "Irlanda"
-    pl: Irlandia
-"XB-IL":
-  label:
-    it: "Israele"
-    fr: "Israel"
-    de: "Israel"
-    en: "Israel"
-    es: "Israel"
-    pl: Izrael
-"XA-IT-32":
-  label:
-    it: "Italia: Trentino-Alto Adige"
-    fr: "Italy: Trentino-Alto Adige"
-    de: "Italy: Trentino-Alto Adige"
-    en: "Italy: Trentino-Alto Adige"
-    es: "Italia: Trentino-Alto Adigio"
-    pl: "Włochy: Trentino-Alto Adige"
-"XA-IT":
-  label:
-    it: "Italia"
-    fr: "Italy"
-    de: "Italy"
-    en: "Italy"
-    es: "Italia"
-    pl: Włochy
-"XB-JP":
-  label:
-    it: "Giappone"
-    fr: "Japan"
-    de: "Japan"
-    en: "Japan"
-    es: "Japón"
-    pl: Japonia
-"XB-KR":
-  label:
-    it: "Corea, Repubblica di"
-    fr: "Korea, Republic of"
-    de: "Korea, Republic of"
-    en: "Korea, Republic of"
-    es: "Corea, República de"
-    pl: Korea, Republika
-"XA-LV":
-  label:
-    it: "Lettonia"
-    fr: "Latvia"
-    de: "Latvia"
-    en: "Latvia"
-    es: "Letonia"
-    pl: Łotwa
-"XA-LT":
-  label:
-    it: "Lituania"
-    fr: "Lithuania"
-    de: "Lithuania"
-    en: "Lithuania"
-    es: "Lituania"
-    pl: Litwa
-"XA-LU":
-  label:
-    it: "Lussemburgo"
-    fr: "Luxembourg"
-    de: "Luxembourg"
-    en: "Luxembourg"
-    es: "Luxemburgo"
-    pl: Luksemburg
-"XA-MT":
-  label:
-    it: "Malta"
-    fr: "Malta"
-    de: "Malta"
-    en: "Malta"
-    es: "Malta"
-    pl: Malta
-"XD-MX":
-  label:
-    it: "Messico"
-    fr: "Mexico"
-    de: "Mexico"
-    en: "Mexico"
-    es: "México"
-    pl: Meksyk
-"XA-ME":
-  label:
-    it: "Montenegro"
-    fr: "Montenegro"
-    de: "Montenegro"
-    en: "Montenegro"
-    es: "Montenegro"
-    pl: Czarnogóra
-"XA-NL":
-  label:
-    it: "Paesi Bassi"
-    fr: "Netherlands"
-    de: "Netherlands"
-    en: "Netherlands"
-    es: "Países Bajos"
-    pl: Niderlandy
-"XE-NZ":
-  label:
-    it: "Nuova Zelanda"
-    fr: "New Zealand"
-    de: "New Zealand"
-    en: "New Zealand"
-    es: "Nueva Zelanda"
-    pl: Nowa Zelandia
-"XA-NO":
-  label:
-    it: "Norvegia"
-    fr: "Norway"
-    de: "Norway"
-    en: "Norway"
-    es: "Noruega"
-    pl: Norwegia
-"XD-PY":
-  label:
-    it: "Paraguay"
-    fr: "Paraguay"
-    de: "Paraguay"
-    en: "Paraguay"
-    es: "Paraguay"
-    pl: Paragwaj
-"XA-PL":
-  label:
-    it: "Polonia"
-    fr: "Poland"
-    de: "Poland"
-    en: "Poland"
-    es: "Polonia"
-    pl: Polska
-"XA-PT":
-  label:
-    it: "Portogallo"
-    fr: "Portugal"
-    de: "Portugal"
-    en: "Portugal"
-    es: "Portugal"
-    pl: Portugalia
-"XD-PR":
-  label:
-    it: "Puerto Rico"
-    fr: "Puerto Rico"
-    de: "Puerto Rico"
-    en: "Puerto Rico"
-    es: "Puerto Rico"
-    pl: Portoryko
-"XA-RO":
-  label:
-    it: "Romania"
-    fr: "Romania"
-    de: "Romania"
-    en: "Romania"
-    es: "Rumania"
-    pl: Rumunia
-"XA-RU":
-  label:
-    it: "Federazione Russa"
-    fr: "Russian Federation"
-    de: "Russian Federation"
-    en: "Russian Federation"
-    es: "Federación Rusa"
-    pl: Federacja Rosyjska
-"XA-RS":
-  label:
-    it: "Serbia"
-    fr: "Serbia"
-    de: "Serbia"
-    en: "Serbia"
-    es: "Serbia"
-    pl: Serbia
-"XA-SK":
-  label:
-    it: "Slovacchia"
-    fr: "Slovakia"
-    de: "Slovakia"
-    en: "Slovakia"
-    es: "Eslovaquia"
-    pl: Słowacja
-"XA-SI":
-  label:
-    it: "Slovenia"
-    fr: "Slovenia"
-    de: "Slovenia"
-    en: "Slovenia"
-    es: "Eslovenia"
-    pl: Słowenia
-"XC-ZA":
-  label:
-    it: "Sudafrica"
-    fr: "South Africa"
-    de: "South Africa"
-    en: "South Africa"
-    es: "Sudáfrica"
-    pl: Republika Południowej Afryki
-"XA-ES":
-  label:
-    it: "Spagna"
-    fr: "Spain"
-    de: "Spain"
-    en: "Spain"
-    es: "España"
-    pl: Hiszpania
-"XA-SE":
-  label:
-    it: "Svezia"
-    fr: "Sweden"
-    de: "Sweden"
-    en: "Sweden"
-    es: "Suecia"
-    pl: Szwecja
-"XA-CH-VD":
-  label:
-    it: "Svizzera: Vaud"
-    fr: "Switzerland: Vaud"
-    de: "Switzerland: Vaud"
-    en: "Switzerland: Vaud"
-    es: "Suiza: cantón de Vaud"
-    pl: "Szwajcaria: kanton Vaud"
-"XA-CH":
-  label:
-    it: "Svizzera"
-    fr: "Switzerland"
-    de: "Switzerland"
-    en: "Switzerland"
-    es: "Suiza"
-    pl: Szwajcaria
-"XB-SY":
-  label:
-    it: "Repubblica Araba Siriana"
-    fr: "Syrian Arab Republic"
-    de: "Syrian Arab Republic"
-    en: "Syrian Arab Republic"
-    es: "República Árabe Siria"
-    pl: Syryjska Republika Arabska
-"XD-TT":
-  label:
-    it: "Trinidad e Tobago"
-    fr: "Trinidad and Tobago"
-    de: "Trinidad and Tobago"
-    en: "Trinidad and Tobago"
-    es: "Trinidad y Tobago"
-    pl: Trynidad i Tobago
-"XB-TR":
-  label:
-    it: "Turchia"
-    fr: "Turkey"
-    de: "Turkey"
-    en: "Turkey"
-    es: "Turquía"
-    pl: Turcja
-"XA-UA":
-  label:
-    it: "Ucraina"
-    fr: "Ukraine"
-    de: "Ukraine"
-    en: "Ukraine"
-    es: "Ucrania"
-    pl: Ukraina
-"XA-GB":
-  label:
-    it: "Regno Unito"
-    fr: "United Kingdom"
-    de: "United Kingdom"
-    en: "United Kingdom"
-    es: "Reino Unido"
-    pl: Zjednoczone Królestwo
-"XD-US":
-  label:
-    it: "Stati Uniti d'America"
-    fr: "United States of America"
-    de: "United States of America"
-    en: "United States of America"
-    es: "Estados Unidos de América"
-    pl: Stany Zjednoczone AP
-"XD-UY":
-  label:
-    it: "Uruguay"
-    fr: "Uruguay"
-    de: "Uruguay"
-    en: "Uruguay"
-    es: "Uruguay"
-    pl: Urugwaj
-"XD-VE":
-  label:
-    it: "Venezuela, Repubblica Bolivariana del"
-    fr: "Venezuela, Bolivarian Republic of"
-    de: "Venezuela, Bolivarian Republic of"
-    en: "Venezuela, Bolivarian Republic of"
-    es: "Venezuela, República Bolivariana de"
-    pl: Wenezuela, Republika Boliwariańska
-# Relationships
-brother of:
-  label:
-    it: Fratello di
-    fr: "frère de"
-    de: Bruder von
-    en: brother of
-    es: hermano de
-    pl: Brat …
-child of:
-  label:
-    it: Figlio/figlia di
-    fr: Enfant de
-    de: Kind von
-    en: child of
-    es: "hijo/a de"
-    pl: Potomek …
-mother of:
-  label:
-    it: Madre di
-    fr: "Mère de"
-    de: Mutter von
-    en: mother of
-    es: madre de
-    pl: Matka …
-confused with:
-  label:
-    it: Confuso/confusa con
-    fr: "Confondu avec"
-    de: Verwechselt mit
-    en: confused with
-    es: "Confundido/a con"
-    pl: Mylon(y/a) z …
-sister of:
-  label:
-    it: Sorella di
-    fr: Soeur de
-    de: Schwester von
-    en: sister of
-    es: hermana de
-    pl: Siostra …
-married with:
-  label:
-    it: Sposato/sposata con
-    fr: "Marié avec"
-    de: Verheiratet mit
-    en: married with
-    es: "casado/a con"
-    pl: W małżeństwie z …
-father of:
-  label:
-    it: Padre di
-    fr: "Père de"
-    de: Vater von
-    en: father of
-    es: padre de
-    pl: Ojciec …
-related to:
-  label:
-    it: Parente di
-    fr: "Relatif à"
-    de: Verwandt mit
-    en: related to
-    es: relacionado/a con
-    pl: W pokrewieństwie z …
-other:
-  label:
-    it: Altro
-    fr: Autres
-    de: Weiteres
-    en: other
-    es: otro
-    pl: Pozostałe
-
-# Name variant codes
-bn:
-  label:
-    it: Soprannome
-    fr: Surnom
-    de: Beiname
-    en: Byname
-    es: Apodo
-    pl: Przydomek
-da:
-  label:
-    it: Pseudonimo
-    fr: Pseudonym
-    de: Pseudonym
-    en: Pseudonym
-    es: Seudónimo
-    pl: Pseudonim
-do:
-  label:
-    it: Nome di religione
-    fr: "Nom d'ordre"
-    de: Ordensname
-    en: Order Name
-    es: Nombre religioso
-    pl: Imię zakonne
-dv:
-  label:
-    it: Altra forma di ricerca
-    fr: Autre forme de recherche
-    de: andere Suchform
-    en: Other Searchform
-    es: Otra variante
-    pl: Inna forma wyszukiwania
-ee:
-  label:
-    it: Nome da sposato
-    fr: Nom de mariage
-    de: Ehename
-    en: Marriage Name
-    es: Apellido de casado/a
-    pl: Nazwisko po mężu
-ef:
-  label:
-    it: Nome di famiglia
-    fr: Nom de famillie
-    de: Familienname
-    en: Family Name
-    es: Apellido
-    pl: Nazwisko rodowe
-ff:
-  label:
-    it: Nome di persona
-    fr: Nom de la personne
-    de: Personenname
-    en: Person Name
-    es: Nombre personal
-    pl: Imię i nazwisko
-gg:
-  label:
-    it: Nome da nubile/celibe
-    fr: Nom de naissance
-    de: Geburtsname
-    en: Birthname
-    es: Nombre de nacimiento
-    pl: Nazwisko rodowe
-in:
-  label:
-    it: Iniziali
-    fr: Initiale
-    de: Initiale
-    en: Initial
-    es: Iniciales
-    pl: Inicjały
-mo:
-  label:
-    it: Monogramma
-    fr: Monogramme
-    de: Monogramm
-    en: Monogram
-    es: Monograma
-    pl: Monogram
-tn:
-  label:
-    it: Nome di battesimo
-    fr: Nom baptismale
-    de: Taufname
-    en: Baptsimal Name
-    es: Nombre bautismal
-    pl: Imię z chrztu
-ub:
-  label:
-    it: Traduzione
-    fr: Traduction
-    de: Übersetzung
-    en: Translation
-    es: "Traducción"
-    pl: Tłumaczenie
-z:
-  label:
-    it: Ortografia alternativa
-    fr: Autres formes
-    de: Andere Schreibweise
-    en: Other form
-    es: "Ortografía alternativa"
-    pl: Inna forma
-xx:
-  label:
-    it: Sconosciuto
-    fr: Inconnu
-    de: Unbekannt
-    en: Unknown
-    es: Desconocido
-    pl: Nieznane
-cmp: 
-  label: 
-    it: Rimando ad altro compositore
-    fr: Compositeur / Co-compositeur
-    de: Komponistenquerverweis
-    en: Composer cross-reference
-    es: Referencia cruzada de compositor
-    pl: Odniesienie do innego kompozytora
-dte: 
-  label: 
-    it: Dedicatario
-    fr: "Dédicataire"
-    de: "Widmungsträger"
-    en: Dedicatee
-    es: Dedicatario
-    pl: Adresat dedykacji
-asn: 
-  label: 
-    it: Nome associato
-    fr: Nom associé
-    de: Zugehöriger Name
-    en: Associated name
-    es: Nombre asociado
-    pt: Nome associado
-    pl: Powiązana nazwa
-lbt: 
-  label: 
-    it: Librettista
-    fr: Librettiste
-    de: Librettist
-    en: Librettist
-    es: Libretista
-    pl: Autor libretta
-lyr: 
-  label: 
-    it: Poeta
-    fr: Parolier
-    de: Textdichter
-    en: Text author
-    es: Autor(a) del texto
-    pl: Autor tekstu
-oth: 
-  label: 
-    it: Altra funzione
-    fr: Autre function
-    de: Sonstige Funktion
-    en: Other function
-    es: Otra función
-    pl: Inna funkcja
-#Keys
-#Keys
-A:
-  label:
-    it: "La maggiore"
-    fr: "La majeur"
-    de: "A-Dur"
-    en: "A major"
-    pt: "Lá  maior"
-    es: "La Mayor"
-    pl: A-dur
-a:
-  label:
-    it: "La minore"
-    fr: "La mineur"
-    de: "a-Moll"
-    en: "A minor"
-    pt: "Lá menor"
-    es: "La menor"
-    pl: a-moll
-A|x: 
-  label:
-    it: "La♯ maggiore"
-    fr: "La♯ majeur"
-    de: "Ais-Dur"
-    en: "A♯ major"
-    pt: "Lá sustenido maior"
-    es: "La sostenido Mayor"
-    pl: Ais-dur
-a|x: 
-  label:
-    it: "La♯ minore"
-    fr: "La♯ mineur"
-    de: "ais-Moll"
-    en: "A♯ minor"
-    pt: "Lá sustenido menor"
-    es: "La sostenido menor"
-    pl: ais-moll
-A|b: 
-  label:
-    it: "La♭ maggiore"
-    fr: "La♭ majeur"
-    de: "As-Dur"
-    en: "A♭ major"
-    pt: "Lá bemol maior"
-    es: "La bemol Mayor"
-    pl: As-dur
-a|b: 
-  label:
-    it: "La♭ minore"
-    fr: "La♭ mineur"
-    de: "as-Moll"
-    en: "A♭ minor"
-    pt: "Lá bemol menor"
-    es: "La bemol menor"
-    pl: as-moll
-B:
-  label:
-    it: "Si maggiore"
-    fr: "Si majeur"
-    de: "H-Dur"
-    en: "B major"
-    pt: Si maior
-    es: "Si Mayor"
-    pl: H-dur
-b:
-  label:
-    it: "Si minore"
-    fr: "Si mineur"
-    de: "h-Moll"
-    en: "B minor"
-    pt: Si menor
-    es: "Si menor"
-    pl: h-moll
-B|b: 
-  label:
-    it: "Si♭ maggiore"
-    fr: "Si♭ majeur"
-    de: "B-Dur"
-    en: "B♭ major"
-    pt: Si bemol maior
-    es: "Si bemol Mayor"
-    pl: B-dur
-b|b: 
-  label:
-    it: "Si♭ minore"
-    fr: "Si♭ mineur"
-    de: "b-Moll"
-    en: "B♭ minor"
-    pt: Si bemol menor
-    es: "Si bemol menor"
-    pl: b-moll
-C:
-  label:
-    it: "Do maggiore"
-    fr: "Do majeur"
-    de: "C-Dur"
-    en: "C major"
-    pt: "Dó maior"
-    es: "Do Mayor"
-    pl: C-dur
-c:
-  label:
-    it: "Do minore"
-    fr: "Do mineur"
-    de: "c-Moll"
-    en: "C minor"
-    pt: "Dó menor"
-    es: "Do menor"
-    pl: c-moll
-C|x: 
-  label:
-    it: "Do♯ maggiore"
-    fr: "Do♯ majeur"
-    de: "Cis-Dur"
-    en: "C♯ major"
-    pt: "Dó sustenido maior"
-    es: "Do sostenido Mayor"
-    pl: Cis-dur
-c|x: 
-  label:
-    it: "Do♯ minore"
-    fr: "Do♯ mineur"
-    de: "cis-Moll"
-    en: "C♯ minor"
-    pt: "Dó sustenido menor"
-    es: "Do sostenido menor"
-    pl: cis-moll
-C|b: 
-  label:
-    it: "Do♭ maggiore"
-    fr: "Do♭ majeur"
-    de: "Ces-Dur"
-    en: "C♭ major"
-    pt: "Dó bemol maior"
-    es: "Do bemol Mayor"
-    pl: Ces-dur
-c|b: 
-  label:
-    it: "Do♭ minore"
-    fr: "Do♭ mineur"
-    de: "ces-Moll"
-    en: "C♭ minor"
-    pt: "Dó bemol menor"
-    es: "Do bemol menor"
-    pl: ces-moll
-D:
-  label:
-    it: "Re maggiore"
-    fr: "Ré majeur"
-    de: "D-Dur"
-    en: "D major"
-    pt: "Ré maior"
-    es: "Re Mayor"
-    pl: D-dur
-d:
-  label:
-    it: "Re minore"
-    fr: "Ré minor"
-    de: "d-Moll"
-    en: "D minor"
-    pt: "Ré menor"
-    es: "Re menor"
-    pl: d-moll
-D|x: 
-  label:
-    it: "Re♯ maggiore"
-    fr: "Ré♯ majeur"
-    de: "Dis-Dur"
-    en: "D♯ major"
-    pt: "Ré sustenido maior"
-    es: "Re sostenido Mayor"
-    pl: Dis-dur
-d|x: 
-  label:
-    it: "Re♯ minore"
-    fr: "Ré♯ mineur"
-    de: "dis-Moll"
-    en: "D♯ minor"
-    pt: "Ré sustenido menor"
-    es: "Re sostenido menor"
-    pl: dis-moll
-D|b: 
-  label:
-    it: "Re♭ maggiore"
-    fr: "Ré♭ majeur"
-    de: "Des-Dur"
-    en: "D♭ major"
-    pt: "Ré bemol maior"
-    es: "Re bemol Mayor"
-    pl: Des-dur
-d|b: 
-  label:
-    it: "Re♭ minore"
-    fr: "Ré♭ mineur"
-    de: "des-Moll"
-    en: "D♭ minor"
-    pt: "Ré bemol menor"
-    es: "Re bemol menor"
-    pl: des-moll
-E:
-  label:
-    it: "Mi maggiore"
-    fr: "Mi majeur"
-    de: "E-Dur"
-    en: "E major"
-    pt: "Mi maior"
-    es: "Mi Mayor"
-    pl: E-dur
-e:
-  label:
-    it: "Mi minore"
-    fr: "Mi mineur"
-    de: "e-Moll"
-    en: "E minor"
-    pt: "Mi menor"
-    es: "Mi menor"
-    pl: e-moll
-E|b: 
-  label:
-    it: "Mi♭ maggiore"
-    fr: "Mi♭ majeur"
-    de: "Es-Dur"
-    en: "E♭ major"
-    pt: "Mi bemol maior"
-    es: "Mi bemol Mayor"
-    pl: Es-dur
-e|b: 
-  label:
-    it: "Mi♭ minore"
-    fr: "Mi♭ mineur"
-    de: "es-Moll"
-    en: "E♭ minor"
-    pt: "Mi bemol menor"
-    es: "Mi bemol menor"
-    pl: es-moll
-F:
-  label:
-    it: "Fa maggiore"
-    fr: "Fa majeur"
-    de: "F-Dur"
-    en: "F major"
-    pt: "Fá maior"
-    es: "Fa Mayor"
-    pl: F-dur
-f:
-  label:
-    it: "Fa minore"
-    fr: "Fa mineur"
-    de: "f-Moll"
-    en: "F minor"
-    pt: "Fá menor"
-    es: "Fa menor"
-    pl: f-moll
-F|x: 
-  label:
-    it: "Fa♯ maggiore"
-    fr: "Fa♯ majeur"
-    de: "Fis-Dur"
-    en: "F♯ major"
-    pt: "Fá sustenido maior"
-    es: "Fa sostenido menor"
-    pl: Fis-dur
-f|x: 
-  label:
-    it: "Fa♯ minore"
-    fr: "Fa♯ mineur"
-    de: "fis-Moll"
-    en: "F♯ minor"
-    pt: "Fá sustenido menor"
-    es: "Fa sostenido Mayor"
-    pl: fis-moll
-G:
-  label:
-    it: "Sol maggiore"
-    fr: "Sol majeur"
-    de: "G-Dur"
-    en: "G major"
-    pt: "Sol maior"
-    es: "Sol Mayor"
-    pl: G-dur
-g:
-  label:
-    it: "Sol minore"
-    fr: "Sol mineur"
-    de: "g-Moll"
-    en: "G minor"
-    pt: "Sol menor"
-    es: "Sol menor"
-    pl: g-moll
-G|x: 
-  label:
-    it: "Sol♯ maggiore"
-    fr: "Sol♯ majeur"
-    de: "Gis-Dur"
-    en: "G♯ major"
-    pt: "Sol sustenido maior"
-    es: "Sol sostenido menor"
-    pl: Gis-dur
-g|x: 
-  label:
-    it: "Sol♯ minore"
-    fr: "Sol♯ mineur"
-    de: "gis-Moll"
-    en: "G♯ minor"
-    pt: "Sol sustenido menor"
-    es: "Sol sostenido menor"
-    pl: gis-moll
-G|b: 
-  label:
-    it: "Sol♭ maggiore"
-    fr: "Sol♭ majeur"
-    de: "Ges-Dur"
-    en: "G♭ major"
-    pt: "Sol bemol maior"
-    es: "Sol bemol Mayor"
-    pl: Ges-dur
-g|b: 
-  label:
-    it: "Sol♭ minore"
-    fr: "Sol♭ mineur"
-    de: "ges-Moll"
-    en: "G♭ minor"
-    pt: "Sol bemol menor"
-    es: "Sol bemol menor"
-    pl: ges-moll
-# modes
-# modes
-1t:
-  label:
-    it: "Mode:  1t – Dorian"
-    fr: "Mode:  1t – Dorian"
-    de: "Mode:  1t – Dorian"
-    en: "Mode:  1t – Dorian"
-    pt: "Modo:  1º tom (Dórico)"
-    es: "Modo: 1º tono (Dórico)"
-    pl: "Skala: 1t – dorycka"
-2t:
-  label:
-    it: "Mode:  2t – Hypodorian"
-    fr: "Mode:  2t – Hypodorian"
-    de: "Mode:  2t – Hypodorian"
-    en: "Mode:  2t – Hypodorian"
-    pt: "Modo:  2º tom (Hipodórico)"
-    es: "Modo:  2º tono (Hipodórico)"
-    pl: "Skala: 2t – hypodorycka"
-3t:
-  label:
-    it: "Mode:  3t – Phrygian"
-    fr: "Mode:  3t – Phrygian"
-    de: "Mode:  3t – Phrygian"
-    en: "Mode:  3t – Phrygian"
-    pt: "Modo:  3º tom (Frígio)"
-    es: "Modo:  3º tono (Frigio)"
-    pl: "Skala: 3t – frygijska"
-4t:
-  label:
-    it: "Mode:  4t – Hypophrygian"
-    fr: "Mode:  4t – Hypophrygian"
-    de: "Mode:  4t – Hypophrygian"
-    en: "Mode:  4t – Hypophrygian"
-    pt: "Modo:  4º tom (Hipofrígio)"
-    es: "Modo:  4º tono (Hipofrigio)"
-    pl: "Skala: 4t – hypofrygijska"
-5t:
-  label:
-    it: "Mode:  5t – Lydian"
-    fr: "Mode:  5t – Lydian"
-    de: "Mode:  5t – Lydian"
-    en: "Mode:  5t – Lydian"
-    pt: "Modo:  5º tom (Lídio)"
-    es: "Modo:  5º tono (Lidio)"
-    pl: "Skala: 5t – lidyjska"
-6t:
-  label:
-    it: "Mode:  6t – Hypolydian"
-    fr: "Mode:  6t – Hypolydian"
-    de: "Mode:  6t – Hypolydian"
-    en: "Mode:  6t – Hypolydian"
-    pt: "Modo:  6º tom (Hipolídio)"
-    es: "Modo:  6º tono (Hipolidio)"
-    pl: "Skala: 6t – hypolidyjska"
-7t:
-  label:
-    it: "Mode:  7t – Mixolydian"
-    fr: "Mode:  7t – Mixolydian"
-    de: "Mode:  7t – Mixolydian"
-    en: "Mode:  7t – Mixolydian"
-    pt: "Modo:  7º tom (Mixolídio)"
-    es: "Modo:  7º tono (Mixolidio)"
-    pl: "Skala: 7t – miksolidyjska"
-8t:
-  label:
-    it: "Mode:  8t – Hypomixolydian"
-    fr: "Mode:  8t – Hypomixolydian"
-    de: "Mode:  8t – Hypomixolydian"
-    en: "Mode:  8t – Hypomixolydian"
-    pt: "Modo:  8º tom (Hipomixolídio)"
-    es: "Modo:  8º tono (Hipomixolidio)"
-    pl: "Skala: 8t – hypomiksolidyjska"
-9t:
-  label:
-    it: "Mode:  9t – Aeolian"
-    fr: "Mode:  9t – Aeolian"
-    de: "Mode:  9t – Aeolian"
-    en: "Mode:  9t – Aeolian"
-    pt: "Modo:  9º tom (Eólio)"
-    es: "Modo:  9º tono (Eólico)"
-    pl: "Skala: 9t – eolska"
-10t:
-  label:
-    it: "Mode: 10t – Hypoaeolian"
-    fr: "Mode: 10t – Hypoaeolian"
-    de: "Mode: 10t – Hypoaeolian"
-    en: "Mode: 10t – Hypoaeolian"
-    pt: "Modo: 10º tom (Hipoeólio)"
-    es: "Modo: 10º tono (Hipoeólico)"
-    pl: "Skala: 10t – hypoeolska"
-11t:
-  label:
-    it: "Mode: 11t – Ionian"
-    fr: "Mode: 11t – Ionian"
-    de: "Mode: 11t – Ionian"
-    en: "Mode: 11t – Ionian"
-    pt: "Modo:  11º tom (Jônio)"
-    es: "Modo:  11º tono (Jónico)"
-    pl: "Skala: 11t – jońska"
-12t:
-  label:
-    it: "Mode: 12t – Hypoionian"
-    fr: "Mode: 12t – Hypoionian"
-    de: "Mode: 12t – Hypoionian"
-    en: "Mode: 12t – Hypoionian"
-    pt: "Modo:  12º modo (Hipojônio)"
-    es: "Modo:  12º tono (Hipojónico)"
-    pl: "Skala: 12t – hypojońska"
-1tt:
-  label:
-    it: "Mode:  1tt – Dorian, transposed"
-    fr: "Mode:  1tt – Dorian, transposed"
-    de: "Mode:  1tt – Dorian, transposed"
-    en: "Mode:  1tt – Dorian, transposed"
-    pt: "Modo:  1º tom (Dórico), transposta"
-    es: "Modo: 1º tono (Dórico), transpuesto"
-    pl: "Skala: 1tt – dorycka, transponowana"
-2tt:
-  label:
-    it: "Mode:  2tt – Hypodorian, transposed"
-    fr: "Mode:  2tt – Hypodorian, transposed"
-    de: "Mode:  2tt – Hypodorian, transposed"
-    en: "Mode:  2tt – Hypodorian, transposed"
-    pt: "Modo:  2º tom (Hipodórico), transposta"
-    es: "Modo:  2º tono (Hipodórico), transpuesto"
-    pl: "Skala: 2tt – hypodorycka, transponowana"
-3tt:
-  label:
-    it: "Mode:  3tt – Phrygian, transposed"
-    fr: "Mode:  3tt – Phrygian, transposed"
-    de: "Mode:  3tt – Phrygian, transposed"
-    en: "Mode:  3tt – Phrygian, transposed"
-    pt: "Modo:  3º tom (Frígio), transposta"
-    es: "Modo:  3º tono (Frigio), transpuesto"
-    pl: "Skala: 3tt – frygijska, transponowana"
-4tt:
-  label:
-    it: "Mode:  4tt – Hypophrygian, transposed"
-    fr: "Mode:  4tt – Hypophrygian, transposed"
-    de: "Mode:  4tt – Hypophrygian, transposed"
-    en: "Mode:  4tt – Hypophrygian, transposed"
-    pt: "Modo:  4º tom (Hipofrígio), transposta"
-    es: "Modo:  4º tono (Hipofrigio), transpuesto"
-    pl: "Skala: 4tt – hypofrygijska, transponowana"
-5tt:
-  label:
-    it: "Mode:  5tt – Lydian, transposed"
-    fr: "Mode:  5tt – Lydian, transposed"
-    de: "Mode:  5tt – Lydian, transposed"
-    en: "Mode:  5tt – Lydian, transposed"
-    pt: "Modo:  5º tom (Lídio), transposta"
-    es: "Modo:  5º tono (Lidio), transpuesto"
-    pl: "Skala: 5tt – lidyjska, transponowana"
-6tt:
-  label:
-    it: "Mode:  6tt – Hypolydian, transposed"
-    fr: "Mode:  6tt – Hypolydian, transposed"
-    de: "Mode:  6tt – Hypolydian, transposed"
-    en: "Mode:  6tt – Hypolydian, transposed"
-    pt: "Modo:  6º tom (Hipolídio), transposta"
-    es: "Modo:  6º tono (Hipolidio), transpuesto"
-    pl: "Skala: 6tt – hypolidyjska, transponowana"
-7tt:
-  label:
-    it: "Mode:  7tt – Mixolydian, transposed"
-    fr: "Mode:  7tt – Mixolydian, transposed"
-    de: "Mode:  7tt – Mixolydian, transposed"
-    en: "Mode:  7tt – Mixolydian, transposed"
-    pt: "Modo:  7º tom (Mixolídio), transposta"
-    es: "Modo:  7º tono (Mixolidio), transpuesto"
-    pl: "Skala: 7tt – miksolidyjska, transponowana"
-8tt:
-  label:
-    it: "Mode:  8tt – Hypomixolydian, transposed"
-    fr: "Mode:  8tt – Hypomixolydian, transposed"
-    de: "Mode:  8tt – Hypomixolydian, transposed"
-    en: "Mode:  8tt – Hypomixolydian, transposed"
-    pt: "Modo:  8º tom (Hipomixolídio), transposta"
-    es: "Modo:  8º tono (Hipomixolidio), transpuesto"
-    pl: "Skala: 8tt – hypomiksolidyjska, transponowana"
-9tt:
-  label:
-    it: "Mode:  9tt – Aeolian, transposed"
-    fr: "Mode:  9tt – Aeolian, transposed"
-    de: "Mode:  9tt – Aeolian, transposed"
-    en: "Mode:  9tt – Aeolian, transposed"
-    pt: "Modo:  9º tom (Eólio), transposta"
-    es: "Modo:  9º tono (Eólico), transpuesto"
-    pl: "Skala: 9tt – eolska, transponowana"
-10tt:
-  label:
-    it: "Mode: 10tt – Hypoaeolian, transposed"
-    fr: "Mode: 10tt – Hypoaeolian, transposed"
-    de: "Mode: 10tt – Hypoaeolian, transposed"
-    en: "Mode: 10tt – Hypoaeolian, transposed"
-    pt: "Modo: 10º tom (Hipoeólio), transposta"
-    es: "Modo: 10º tono (Hipoeólico), transpuesto"
-    pl: "Skala: 10tt – hypoeolska, transponowana"
-11tt:
-  label:
-    it: "Mode: 11tt – Ionian, transposed"
-    fr: "Mode: 11tt – Ionian, transposed"
-    de: "Mode: 11tt – Ionian, transposed"
-    en: "Mode: 11tt – Ionian, transposed"
-    pt: "Modo:  11º tom (Jônio), transposta"
-    es: "Modo:  11º tono (Jónico), transpuesto"
-    pl: "Skala: 11tt – jońska, transponowana"
-12tt:
-  label:
-    it: "Mode: 12tt – Hypoionian, transposed"
-    fr: "Mode: 12tt – Hypoionian, transposed"
-    de: "Mode: 12tt – Hypoionian, transposed"
-    en: "Mode: 12tt – Hypoionian, transposed"
-    pt: "Modo:  12º modo (Hipojônio), transposta"
-    es: "Modo:  12º tono (Hipojónico), transpuesto"
-    pl: "Skala: 12tt – hypojońska, transponowana"
-1byz:
-  label:
-    it: "Octoechos 1: Ēchos prōtos (First mode of Byzantine music)"
-    fr: "Octoechos 1: Ēchos prōtos (First mode of Byzantine music)"
-    de: "Octoechos 1: Ēchos prōtos (First mode of Byzantine music)"
-    en: "Octoechos 1: Ēchos prōtos (First mode of Byzantine music)"
-    pt: "Octoechos 1: Ēchos prōtos (Primeiro modo bizantino)"
-    es: "Octoechos 1: Ēchos prōtos (Primer modo bizantino)"
-    pl: "Octoechos 1: Ēchos prōtos (pierwsza skala muzyki bizantyjskiej)"
-2byz:
-  label:
-    it: "Octoechos 2: Ēchos deuteros (Second mode of Byzantine music)"
-    fr: "Octoechos 2: Ēchos deuteros (Second mode of Byzantine music)"
-    de: "Octoechos 2: Ēchos deuteros (Second mode of Byzantine music)"
-    en: "Octoechos 2: Ēchos deuteros (Second mode of Byzantine music)"
-    pt: "Octoechos 2: Ēchos deuteros (Segundo modo bizantino)"
-    es: "Octoechos 2: Ēchos deuteros (Segundo modo bizantino)"
-    pl: "Octoechos 2: Ēchos deuteros (druga skala muzyki bizantyjskiej)"
-3byz:
-  label:
-    it: "Octoechos 3: Ēchos tritos (Third mode of Byzantine music)"
-    fr: "Octoechos 3: Ēchos tritos (Third mode of Byzantine music)"
-    de: "Octoechos 3: Ēchos tritos (Third mode of Byzantine music)"
-    en: "Octoechos 3: Ēchos tritos (Third mode of Byzantine music)"
-    pt: "Octoechos 3: Ēchos tritos (Terceiro modo bizantino)"
-    es: "Octoechos 3: Ēchos tritos (Tercer modo bizantino)"
-    pl: "Octoechos 3: Ēchos tritos (trzecia skala muzyki bizantyjskiej)"
-4byz:
-  label: 
-    it: "Octoechos 4: Ēchos tetartos (Fourth mode of Byzantine music)"
-    fr: "Octoechos 4: Ēchos tetartos (Fourth mode of Byzantine music)"
-    de: "Octoechos 4: Ēchos tetartos (Fourth mode of Byzantine music)"
-    en: "Octoechos 4: Ēchos tetartos (Fourth mode of Byzantine music)"
-    pt: "Octoechos 4: Ēchos tetartos (Quarto modo bizantino)"
-    pt: "Octoechos 4: Ēchos tetartos (Cuarto modo bizantino)"
-    pl: "Octoechos 4: Ēchos tetartos (czwarta skala muzyki bizantyjskiej)"
-5byz:
-  label: 
-    it: "Octoechos 5: Ēchos plagios prōtos (First plagal mode of Byzantine music)"
-    fr: "Octoechos 5: Ēchos plagios prōtos (First plagal mode of Byzantine music)"
-    de: "Octoechos 5: Ēchos plagios prōtos (First plagal mode of Byzantine music)"
-    en: "Octoechos 5: Ēchos plagios prōtos (First plagal mode of Byzantine music)"
-    pt: "Octoechos 5: Ēchos plagios prōtos (Primeiro modo bizantino plagal)"
-    es: "Octoechos 5: Ēchos plagios prōtos (Primer modo bizantino plagal)"
-    pl: "Octoechos 5: Ēchos plagios prōtos (pierwsza skala plagalna muzyki bizantyjskiej)"
-6byz:
-  label: 
-    it: "Octoechos 6: Ēchos plagios deuteros (Second plagal mode of Byzantine music)"
-    fr: "Octoechos 6: Ēchos plagios deuteros (Second plagal mode of Byzantine music)"
-    de: "Octoechos 6: Ēchos plagios deuteros (Second plagal mode of Byzantine music)"
-    en: "Octoechos 6: Ēchos plagios deuteros (Second plagal mode of Byzantine music)"
-    pt: "Octoechos 6: Ēchos plagios deuteros (Segundo modo bizantino plagal)"
-    es: "Octoechos 6: Ēchos plagios deuteros (Segundo modo bizantino plagal)"
-    pl: "Octoechos 6: Ēchos plagios deuteros (druga skala plagalna muzyki bizantyjskiej)"
-7byz:
-  label: 
-    it: "Octoechos 7: Ēchos barys (Third plagal mode of Byzantine music)"
-    fr: "Octoechos 7: Ēchos barys (Third plagal mode of Byzantine music)"
-    de: "Octoechos 7: Ēchos barys (Third plagal mode of Byzantine music)"
-    en: "Octoechos 7: Ēchos barys (Third plagal mode of Byzantine music)"
-    pt: "Octoechos 7: Ēchos barys (Terceiro modo bizantino plagal)"
-    es: "Octoechos 7: Ēchos barys (Tercer modo bizantino plagal)"
-    pl: "Octoechos 7: Ēchos barys (trzecia skala plagalna muzyki bizantyjskiej)"
-8byz:
-  label: 
-    it: "Octoechos 8: Ēchos plagios tetartos (Fourth plagal mode of Byzantine music)"
-    fr: "Octoechos 8: Ēchos plagios tetartos (Fourth plagal mode of Byzantine music)"
-    de: "Octoechos 8: Ēchos plagios tetartos (Fourth plagal mode of Byzantine music)"
-    en: "Octoechos 8: Ēchos plagios tetartos (Fourth plagal mode of Byzantine music)"
-    pt: "Octoechos 8: Ēchos plagios tetartos (Quarto modo bizantino plagal)"
-    es: "Octoechos 8: Ēchos plagios tetartos (Cuarto modo bizantino plagal)"
-    pl: "Octoechos 8: Ēchos plagios tetartos (czwarta skala plagalna muzyki bizantyjskiej)"
-#Clefs (031)
+'000':
+  label: records.leader
+'001':
+  label: records.rism_id_number
+'003':
+  label: records.control_number_identifier
+'005':
+  label: records.date_time_last_transaction
 01_modern_clefs:
-  label:
-    it: "Chiavi comuni"
-    fr: "Clés communes"
-    de: "Common clefs"
-    en: "Common clefs"
-    es: Claves comunes
-    pl: Klucze współczesne
-C-1:
-  label:
-    it: "C-1"
-    fr: "C-1"
-    de: "C-1"
-    en: "C-1"
-    es: "C-1"
-    pl: C-1
-C-2:
-  label:
-    it: "C-2"
-    fr: "C-2"
-    de: "C-2"
-    en: "C-2"
-    es: "C-2"
-    pl: C-2
-C-3:
-  label:
-    it: "C-3"
-    fr: "C-3"
-    de: "C-3"
-    en: "C-3"
-    es: "C-3"
-    pl: C-3
-C-4:
-  label:
-    it: "C-4"
-    fr: "C-4"
-    de: "C-4"
-    en: "C-4"
-    es: "C-4"
-    pl: C-4
-C-5:
-  label:
-    it: "C-5"
-    fr: "C-5"
-    de: "C-5"
-    en: "C-5"
-    es: "C-5"
-    pl: C-5
-F-1:
-  label:
-    it: "F-1"
-    fr: "F-1"
-    de: "F-1"
-    en: "F-1"
-    es: "F-1"
-    pl: F-1
-F-2:
-  label:
-    it: "F-2"
-    fr: "F-2"
-    de: "F-2"
-    en: "F-2"
-    es: "F-2"
-    pl: F-2
-F-3:
-  label:
-    it: "F-3"
-    fr: "F-3"
-    de: "F-3"
-    en: "F-3"
-    es: "F-3"
-    pl: F-3
-F-4:
-  label:
-    it: "F-4 (chiave di basso)"
-    fr: "F-4 (clé fa)"
-    de: "F-4 (Baß-Schlüssel)"
-    en: "F-4 (bass clef)"
-    es: "F-4 (clave de bajo)"
-    pl: F-4 (klucz basowy)
-F-5:
-  label:
-    it: "F-5"
-    fr: "F-5"
-    de: "F-5"
-    en: "F-5"
-    es: "F-5"
-    pl: F-5
-G-1:
-  label:
-    it: "G-1"
-    fr: "G-1"
-    de: "G-1"
-    en: "G-1"
-    es: "G-1"
-    pl: G-1
-G-2:
-  label:
-    it: "G-2 (chiave di violino)"
-    fr: "G-2 (clé de sol)"
-    de: "G-2 (Violin-Schlüssel)"
-    en: "G-2 (treble clef)"
-    es: "G-2(clave aguda estándar)"
-    pl: G-2 (klucz wiolinowy)
-G-3:
-  label:
-    it: "G-3"
-    fr: "G-3"
-    de: "G-3"
-    en: "G-3"
-    es: "G-3"
-    pl: G-3
-G-4:
-  label:
-    it: "G-4"
-    fr: "G-4"
-    de: "G-4"
-    en: "G-4"
-    es: "G-4"
-    pl: G-4
-G-5:
-  label:
-    it: "G-5"
-    fr: "G-5"
-    de: "G-5"
-    en: "G-5"
-    es: "G-5"
-    pl: G-5
-g-2:
-  label:
-    it: "g-2 (Chiave di violino ottavizzata)"
-    fr: "g-2 (octava bassa)"
-    de: "g-2 (oktavierenden Violinschlüssels)"
-    en: "g-2 (octave treble clef)"
-    es: "g-2 (clave de sol octava baja)"
-    pl: g-2 (oktawowy klucz wiolinowy) 
+  label: records.common_clefs
+'024':
+  fields:
+    '2':
+      label: records.source_number_code
+    a:
+      label: records.standard_number_code
+  label: records.other_standard_identifier
 02_mensural_clefs:
-  label:
-    it: "Chiavi mensurali"
-    fr: "Clés anciennes"
-    de: "Mensural clefs"
-    en: "Mensural clefs"
-    es: "Claves mensurales"
-    pl: Klucze menzuralne
+  label: records.mensural_clefs
+'031':
+  fields:
+    a:
+      label: records.work_number
+    b:
+      label: records.movement_number
+    c:
+      label: records.incipit_number
+    d:
+      label: records.title_movement_tempo
+    e:
+      label: records.role
+    g:
+      label: records.clef
+    m:
+      label: records.voice_instrument
+    n:
+      label: records.key_signature
+    o:
+      label: records.time_signature
+    p:
+      label: records.music_incipit
+    q:
+      label: records.general_note
+    r:
+      label: records.key_or_mode
+    s:
+      label: general.validity
+    t:
+      label: records.text_incipit
+    z:
+      label: records.scoring_in_movement
+  label: records.incipit
+'040':
+  fields:
+    a:
+      label: records.original_cataloging_agency
+    b:
+      label: records.language_of_cataloging
+    c:
+      label: records.transcribing_agency
+    d:
+      label: records.modifying_agency
+  label: records.cataloging_source
+'042':
+  fields:
+    a:
+      label: records.authentication_code
+  label: records.authentication_code
+'043':
+  fields:
+    c:
+      label: records.nationality
+  label: records.nationality
+'100':
+  fields:
+    a:
+      label: records.composer
+    d:
+      label: records.years_birth_death
+    m:
+      label: records.scoring_summary
+    n:
+      label: records.opus_thematic_index_number
+    r:
+      label: records.key_or_mode
+    t:
+      label: records.title_of_work
+  label: records.heading
+10t:
+  label: records.mode_10t
+10tt:
+  label: records.mode_10tt
+11t:
+  label: records.mode_11t
+11tt:
+  label: records.mode_11tt
+12t:
+  label: records.mode_12t
+12tt:
+  label: records.mode_12tt
+1byz:
+  label: records.octoechos1
+1t:
+  label: records.mode_1t
+1tt:
+  label: records.mode_1tt
+2byz:
+  label: records.octoechos2
+2t:
+  label: records.mode_2t
+2tt:
+  label: records.mode_2tt
+'370':
+  fields:
+    a:
+      label: records.place_birth
+  label: records.associated_place
+'380':
+  fields:
+    a:
+      label: records.subject_heading
+  label: records.subject_heading
+3byz:
+  label: records.octoechos3
+3t:
+  label: records.mode_3t
+3tt:
+  label: records.mode_3tt
+'400':
+  fields:
+    a:
+      label: records.heading_composer_name
+    d:
+      label: records.years_birth_death
+    m:
+      label: records.scoring_summary
+    n:
+      label: records.number_part_section
+    r:
+      label: records.key_or_mode
+    t:
+      label: records.title_of_work
+  label: records.heading
+4byz:
+  label: records.octoechos4
+4t:
+  label: records.mode_4t
+4tt:
+  label: records.mode_4tt
+'500':
+  fields:
+    a:
+      label: records.related_personal_name
+    y:
+      label: records.type_relationship
+  label: records.related_personal_name
+'510':
+  fields:
+    a:
+      label: records.associated_institution
+  label: records.associated_institution
+'548':
+  fields:
+    a:
+      label: records.date
+    i:
+      label: records.type_relationship
+  label: records.chronological_term
+'550':
+  fields:
+    a:
+      label: records.topical_term
+    i:
+      label: records.relation
+  label: records.topical_term
+'551':
+  fields:
+    a:
+      label: records.geographic_name
+    i:
+      label: records.type
+  label: records.geographic_name
+5byz:
+  label: records.octoechos5
+5t:
+  label: records.mode_5t
+5tt:
+  label: records.mode_5tt
+'667':
+  fields:
+    a:
+      label: records.internal_note
+  label: records.internal_note
+'670':
+  fields:
+    a:
+      label: records.source_data_found
+    b:
+      label: records.information_found
+  label: records.source_data_found
+'675':
+  fields:
+    a:
+      label: records.source_data_not_found
+  label: records.source_data_not_found
+'678':
+  fields:
+    a:
+      label: records.additional_bibliographic_information
+  label: records.additional_bibliographic_information
+'680':
+  fields:
+    a:
+      label: records.general_note
+  label: records.general_note
+6byz:
+  label: records.octoechos6
+6t:
+  label: records.mode_6t
+6tt:
+  label: records.mode_6tt
+'700':
+  fields:
+    '4':
+      label: records.function
+    a:
+      label: records.name
+    d:
+      label: records.life_dates
+    j:
+      label: records.attribution_qualifier
+  label: records.additional_personal_name
+'710':
+  fields:
+    '4':
+      label: records.function
+    '8':
+      label: records.set
+    a:
+      label: records.institution
+    b:
+      label: records.department
+    g:
+      label: records.attribution_qualifier
+  label: records.additional_institution
+'747':
+  fields:
+    a:
+      label: records.liturgical_festival
+  label: records.liturgical_festival
+7byz:
+  label: records.octoechos7
+7t:
+  label: records.mode_7t
+7tt:
+  label: records.mode_7tt
+'856':
+  fields:
+    u:
+      label: records.external_resource
+    y:
+      label: records.note_external_resource
+  label: records.external_resource_uri
+8byz:
+  label: records.octoechos8
+8t:
+  label: records.mode_8t
+8tt:
+  label: records.mode_8tt
+'930':
+  fields:
+    a:
+      label: records.work
+    i:
+      label: records.type_relationship
+  label: records.related_work
+9t:
+  label: records.mode_9t
+9tt:
+  label: records.mode_9tt
+A:
+  label: records.a_major
+Alleged:
+  label: records.alleged
+Ascertained:
+  label: records.ascertained
+A|b:
+  label: records.af_major
+A|x:
+  label: records.as_major
+B:
+  label: records.b_major
+B|b:
+  label: records.bf_major
+C:
+  label: records.c_major
 C+1:
-  label:
-    it: "C+1"
-    fr: "C+1"
-    de: "C+1"
-    en: "C+1"
-    es: "C+1"
-    pl: C+1
+  label: records.c_plus_1
 C+2:
-  label:
-    it: "C+2"
-    fr: "C+2"
-    de: "C+2"
-    en: "C+2"
-    es: "C+2"
-    pl: C+2
+  label: records.c_plus_2
 C+3:
-  label:
-    it: "C+3"
-    fr: "C+3"
-    de: "C+3"
-    en: "C+3"
-    es: "C+3"
-    pl: C+3
+  label: records.c_plus_3
 C+4:
-  label:
-    it: "C+4"
-    fr: "C+4"
-    de: "C+4"
-    en: "C+4"
-    es: "C+4"
-    pl: C+4
+  label: records.c_plus_4
 C+5:
-  label:
-    it: "C+5"
-    fr: "C+5"
-    de: "C+5"
-    en: "C+5"
-    es: "C+5"
-    pl: C+5
+  label: records.c_plus_5
+C-1:
+  label: records.c_minus_1
+C-2:
+  label: records.c_minus_2
+C-3:
+  label: records.c_minus_3
+C-4:
+  label: records.c_minus_4
+C-5:
+  label: records.c_minus_5
+Conjectural:
+  label: records.conjectural
+C|b:
+  label: records.cf_major
+C|x:
+  label: records.cs_major
+D:
+  label: records.d_major
+Doubtful:
+  label: records.doubtful
+D|b:
+  label: records.df_major
+D|x:
+  label: records.ds_major
+E:
+  label: records.e_major
+E|b:
+  label: records.ef_major
+F:
+  label: records.f_major
 F+1:
-  label:
-    it: "F+1"
-    fr: "F+1"
-    de: "F+1"
-    en: "F+1"
-    es: "F+1"
-    pl: F+1
+  label: records.f_plus_1
 F+2:
-  label:
-    it: "F+2"
-    fr: "F+2"
-    de: "F+2"
-    en: "F+2"
-    es: "F+2"
-    pl: F+2
+  label: records.f_plus_2
 F+3:
-  label:
-    it: "F+3"
-    fr: "F+3"
-    de: "F+3"
-    en: "F+3"
-    es: "F+3"
-    pl: F+3
+  label: records.f_plus_3
 F+4:
-  label:
-    it: "F+4"
-    fr: "F+4"
-    de: "F+4"
-    en: "F+4"
-    es: "F+4"
-    pl: F+4
+  label: records.f_plus_4
 F+5:
-  label:
-    it: "F+5"
-    fr: "F+5"
-    de: "F+5"
-    en: "F+5"
-    es: "F+5"
-    pl: F+5
+  label: records.f_plus_5
+F-1:
+  label: records.f_minus_1
+F-2:
+  label: records.f_minus_2
+F-3:
+  label: records.f_minus_3
+F-4:
+  label: records.f_minus_4_bass
+F-5:
+  label: records.f_minus_5
+F|x:
+  label: records.fs_major
+G:
+  label: records.g_major
 G+1:
-  label:
-    it: "G+1"
-    fr: "G+1"
-    de: "G+1"
-    en: "G+1"
-    es: "G+1"
-    pl: G+1
+  label: records.g_plus_1
 G+2:
-  label:
-    it: "G+2"
-    fr: "G+2"
-    de: "G+2"
-    en: "G+2"
-    es: "G+2"
-    pl: G+2
+  label: records.g_plus_2
 G+3:
-  label:
-    it: "G+3"
-    fr: "G+3"
-    de: "G+3"
-    en: "G+3"
-    es: "G+3"
-    pl: G+3
+  label: records.g_plus_3
 G+4:
-  label:
-    it: "G+4"
-    fr: "G+4"
-    de: "G+4"
-    en: "G+4"
-    es: "G+4"
-    pl: G+4
+  label: records.g_plus_4
 G+5:
-  label:
-    it: "G+5"
-    fr: "G+5"
-    de: "G+5"
-    en: "G+5"
-    es: "G+5"
-    pl: G+5
-#Attribution qualifier for 710$j
-"Verified":
-  label:
-    it: Verificato
-    fr: "Vérifié"
-    de: Gesichert
-    en: Verified
-    es: Verificada
-    pl: Zweryfikowane
-"Ascertained":
-  label:
-    it: Accertato
-    fr: "Authentifié"
-    de: Ermittelt
-    en: Ascertained
-    es: Certificada
-    pl: Stwierdzone
-"Alleged":
-  label:
-    it: Presunto
-    fr: "Présumé"
-    de: Angeblich
-    en: Alleged
-    es: Supuesta
-    pl: Domniemane
-"Doubtful":   
-  label:
-    it: Dubbio
-    fr: "Douteux"
-    de: Zweifelhaft
-    en: Doubtful
-    es: Dudosa
-    pl: Wątpliwe
-"Misattributed":   
-  label:
-    it: Attribuito erroneamente
-    fr: "Erroné"
-    de: Fälschlich
-    en: Misattributed
-    es: Mal atribuida
-    pl: Błędnie przypisane
-"Conjectural":   
-  label:
-    it: Congetturale
-    fr: Conjectural
-    de: Mutmaßlich
-    en: Conjectural
-    es: Conjetural
-    pl: Spekulatywne
-
+  label: records.g_plus_5
+G-1:
+  label: records.g_minus_1
+G-2:
+  label: records.g_minus_2_treble
+G-3:
+  label: records.g_minus_3
+G-4:
+  label: records.g_minus_4
+G-5:
+  label: records.g_minus_5
+G|b:
+  label: records.gf_major
+G|x:
+  label: records.gs_major
+Misattributed:
+  label: records.misattributed
+Verified:
+  label: general.verified
+XA-AT:
+  label: places.austria
+XA-AT-2:
+  label: places.austria_carinthia
+XA-AT-3:
+  label: places.austria_lower_austria
+XA-AT-4:
+  label: places.austria_upper_austria
+XA-AT-5:
+  label: places.austria_salzburg
+XA-AT-6:
+  label: places.austria_styria
+XA-AT-7:
+  label: places.austria_tyrol
+XA-AT-9:
+  label: places.austria_vienna
+XA-BE:
+  label: places.belgium
+XA-BG:
+  label: places.bulgaria
+XA-CH:
+  label: places.switzerland
+XA-CH-VD:
+  label: places.switzerland_vaud
+XA-CZ:
+  label: places.czech_republic
+XA-DE:
+  label: places.germany
+XA-DE-BY:
+  label: places.germany_bavaria
+XA-DE-SN:
+  label: places.germany_saxony
+XA-DK:
+  label: places.denmark
+XA-EE:
+  label: places.estonia
+XA-ES:
+  label: places.spain
+XA-FI:
+  label: places.finland
+XA-FR:
+  label: places.france
+XA-GB:
+  label: places.uk
+XA-GR:
+  label: places.greece
+XA-HR:
+  label: places.croatia
+XA-HU:
+  label: places.hungary
+XA-IE:
+  label: places.ireland
+XA-IS:
+  label: places.iceland
+XA-IT:
+  label: places.italy
+XA-IT-32:
+  label: places.italy_trentino_alto_adige
+XA-LT:
+  label: places.lithuania
+XA-LU:
+  label: places.luxembourg
+XA-LV:
+  label: places.latvia
+XA-ME:
+  label: places.montenegro
+XA-MT:
+  label: places.malta
+XA-NL:
+  label: places.netherlands
+XA-NO:
+  label: places.norway
+XA-PL:
+  label: places.poland
+XA-PT:
+  label: places.portugal
+XA-RO:
+  label: places.romania
+XA-RS:
+  label: places.serbia
+XA-RU:
+  label: places.russian_federation
+XA-SE:
+  label: places.sweden
+XA-SI:
+  label: places.slovenia
+XA-SK:
+  label: places.slovakia
+XA-UA:
+  label: places.ukraine
+XA-VA:
+  label: places.holy_see
+XB-AM:
+  label: places.armenia
+XB-CN:
+  label: places.china
+XB-IL:
+  label: places.israel
+XB-IN:
+  label: places.india
+XB-IR:
+  label: places.iran
+XB-JP:
+  label: places.japan
+XB-KH:
+  label: places.cambodia
+XB-KR:
+  label: places.korea
+XB-SY:
+  label: places.syrian_arab_republic
+XB-TR:
+  label: places.turkey
+XC-BJ:
+  label: languages.benin
+XC-DZ:
+  label: places.algeria
+XC-EG:
+  label: places.egypt
+XC-ZA:
+  label: places.south_africa
+XD-AR:
+  label: places.argentina
+XD-BR:
+  label: places.brazil
+XD-CA:
+  label: places.canada
+XD-CL:
+  label: places.chile
+XD-CO:
+  label: places.colombia
+XD-CU:
+  label: places.cuba
+XD-HN:
+  label: places.honduras
+XD-MX:
+  label: places.mexico
+XD-PR:
+  label: places.puerto_rico
+XD-PY:
+  label: places.paraguay
+XD-TT:
+  label: places.trinidad_tobego
+XD-US:
+  label: places.usa
+XD-UY:
+  label: places.uruguay
+XD-VE:
+  label: places.venezuela
+XE-AU:
+  label: places.australia
+XE-NZ:
+  label: places.new_zealand
+a:
+  label: records.a_minor
+administration:
+  label: records.administration
+asn:
+  label: records.associated_name
+a|b:
+  label: records.af_minor
+a|x:
+  label: records.as_minor
+b:
+  label: records.b_minor
+bn:
+  label: records.byname
+brother of:
+  label: records.brother_of
+b|b:
+  label: records.bf_minor
+c:
+  label: records.c_minor
+child of:
+  label: records.child_of
+cmp:
+  label: records.composer_cross_reference
+codes:
+  label: records.numbers_code_fields
+confused with:
+  label: records.confused_with
+control:
+  label: records.control_fields
+c|b:
+  label: records.cf_minor
+c|x:
+  label: records.cs_minor
+d:
+  label: records.d_minor
+da:
+  label: records.pseudonym
+do:
+  label: records.order_name
+doc_abbreviations:
+  label: records.abbreviations
+doc_aid:
+  label: records.aids
+doc_cataloguing_collections:
+  label: records.cataloging_collection_convoluta
+doc_edit_functions:
+  label: records.basic_functions
+doc_edit_workflow:
+  label: general.workflow
+doc_editor:
+  label: general.editor_help
+doc_introduction:
+  label: records.introduction
+doc_masks:
+  label: records.cataloging_forms
+doc_tag_index:
+  label: general.marc_tag_index
+doc_templates:
+  label: records.templates
+dte:
+  label: records.dedicatee
+dv:
+  label: records.other_searchform
+d|b:
+  label: records.df_minor
+d|x:
+  label: records.ds_minor
+e:
+  label: records.e_minor
+ee:
+  label: records.married_name
+ef:
+  label: records.family_name
+e|b:
+  label: records.ef_minor
+f:
+  label: records.f_minor
+father of:
+  label: records.father_of
+female:
+  label: general.female
+ff:
+  label: records.person_name
+f|x:
+  label: records.fs_minor
+g:
+  label: records.g_minor
+g-2:
+  label: records.g_minus_2_octave
+gg:
+  label: records.birth_name
+go:
+  label: records.place_birth
+g|b:
+  label: records.gf_minor
+g|x:
+  label: records.gs_minor
+ha:
+  label: records.place_origin
+in:
+  label: records.initial
+incipits:
+  label: records.incipits
+lbt:
+  label: records.librettist
+lyr:
+  label: records.text_author
+main_work:
+  label: records.main_entry_fields
+male:
+  label: general.male
+married with:
+  label: records.married_with
+mo:
+  label: records.monogram
+mother of:
+  label: records.mother_of
+notes:
+  label: records.note_fields
+oth:
+  label: records.other_function
+other:
+  label: records.other
+places:
+  label: records.countries_places
+po:
+  label: records.postal_place
+references:
+  label: records.references_and_notes
+related to:
+  label: records.related_to
+relations:
+  label: records.relations
+sister of:
+  label: records.sister_of
+so:
+  label: records.place_death
+subject:
+  label: records.subject_access_fields
+tn:
+  label: records.baptismal_name
+ub:
+  label: records.translation
+unknown:
+  label: records.unknown
+variants:
+  label: records.title_variants
+wl:
+  label: records.country_activity
+wo:
+  label: records.place_activity
+wr:
+  label: records.region_of_activity
+xx:
+  label: records.unknown
+z:
+  label: records.other_form

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -253,6 +253,7 @@ ActiveAdmin.setup do |config|
         lang.add :label => "IT", :url => proc { url_for(:locale => 'it') }, id: 'i18n-it', :priority => 4, :html_options   => {:style => 'float:left;'}
         lang.add :label => "PT", :url => proc { url_for(:locale => 'pt') }, id: 'i18n-pt', :priority => 5, :html_options   => {:style => 'float:left;'}
         lang.add :label => "ES", :url => proc { url_for(:locale => 'es') }, id: 'i18n-es', :priority => 6, :html_options   => {:style => 'float:left;'}
+        lang.add :label => "PL", :url => proc { url_for(:locale => 'pl') }, id: 'i18n-pl', :priority => 7, :html_options   => {:style => 'float:left;'}
       end
       # Add the menu by hand because otherwise it is not getting translated
       menu.add :label => proc {I18n.t(:menu_comments)}, id: 'comments_menu', :priority => 4, :url => "/admin/comments"

--- a/config/locales/marc_records/de.yml
+++ b/config/locales/marc_records/de.yml
@@ -1,0 +1,789 @@
+de:
+  general:
+    e_mail: E-Mail
+    editor_help: Editor Hilfe
+    faq: FAQ
+    female: weiblich
+    how_do_i: Wie kann ich ... Tipps & Tricks
+    index_marc_fields: MARC Tag Index
+    male: männlich
+    marc_tag_index: MARC Tag Index
+    'no': Nein
+    rism: RISM
+    rism_best_practices: RISM BEST PRACTISES
+    rism_instrument_abbreviations: Stimmen- und Instrumentenbezeichnungen tabellarisch
+    rism_series: RISM Series
+    rism_series_a_b_references: Querverweise zu RISM A/I und RISM B
+    rism_series_number: RISM-Nummer
+    rule_type: Regelwerk
+    scope_printed_music_rism: Umfang der Dokumentation von Musikdrucke in RISM
+    searching: Suche
+    status: Status
+    undetermined: Unbestimmt
+    ungrouped_fields: Nicht zugeteilte Felder
+    unknown_fields: Unbekannte Felder
+    unused: UNUSED - WILL BE REMOVED
+    uri: URI
+    url: URL
+    using_muscat: Editor Hilfe
+    validity: Gültigkeit
+    verified: Gesichert
+    when_to_input_new_record: Wann soll einen neuen Eintrag erstellt werden (Musikdrucke)
+    workflow: Workflow
+    'yes': Ja
+  languages:
+    afrikaans: Afrikaans
+    arabic: Arabisch
+    aragonese: Aragonesisch
+    armenian: Armenische
+    basque: Baskisch
+    bosnian: Bosnisch
+    bulgarian: Bulgarisch
+    catalan: Katalanisch
+    celtic_other: Celtic (Other)
+    chinese: Chinesisch
+    creoles_pidgins_other: Creoles and Pidgins (Other)
+    croatian: Kroatisch
+    czech: Tschechisch
+    danish: Dänisch
+    dutch: Niederländisch
+    english: Englisch
+    estonian: Estnisch
+    ethiopic: Äthiopisch
+    finnish: Finnisch
+    french: Französisch
+    french_middle: Französisch, Mitte (ca. 1300-1600)
+    french_old: Französisch, alt (ca. 842-1300)
+    gallician: Galizisch
+    german: Deutsch
+    german_old_high: German, Old High (ca. 750-1050)
+    germanic: Germanisch
+    greek_ancient: Altgriechisch (bis 1453)
+    greek_modern: Neugriechisch (1453-)
+    hebrew: Hebräisch
+    hungarian: Ungarisch
+    icelandic: Isländisch
+    insari_sami: Inari Sami
+    irish: Irisch
+    italian: Italienisch
+    korean: Koreanisch
+    latin: Lateinisch
+    latvian: Lettisch
+    lithuanian: Litauisch
+    low_german: Niederdeutsch
+    lower_sorbian: Sorbisch, Niedersorbisch
+    luxembourgish: Luxemburgisch
+    macedonian: Mazedonisch
+    maori: Māori
+    middle_english: Mittelenglisch
+    middle_high_german: Mittelhochdeutsch
+    mongolian: Mongolisch
+    neapolitan: Neapolitanisch
+    north_frisian: Nordfriesisch
+    norwegian: Norwegisch
+    occitan: Okzitanisch
+    oirat: Oiratische
+    old_church_slavonic: Altkirchenslawisch
+    persian: Persisch
+    polish: Polnisch
+    portugese: Portugiesisch
+    romani: Romani
+    romanian: Rumänisch
+    romansh: Bündnerromanisch (Rätoromanisch)
+    russian: Russisch
+    sanskrit: Sanskrit
+    scots: Schottisch
+    serbian: Serbisch
+    sichuan_yi: Sichuan Yi
+    sicilian: Sizilianisch
+    slavic: Slawisch
+    slovak: Slowakisch
+    slovenian: Slowenisch
+    sorbian: Sorbisch
+    spanish: Spanisch
+    swedish: Schwedisch
+    swiss_german: Schweizerdeutsch
+    tagalog: Tagalog
+    tartar: Tatarische
+    thai: Thailändisch
+    tibetan: Tibetanisch
+    tsimshian: Tsimshian
+    turkish: Türkisch
+    ukrainian: Ukrainisch
+    upper_sorbian: Sorbisch, Obersorbisch
+    vietnamese: Vietnamesisch
+    welsh: Walisisch
+    west_frisian: Westfriesisch
+    yiddish: Jiddisch
+  places:
+    algeria: Algerien
+    andorra: Andorra
+    argentina: Argentinien
+    armenia: Armenien
+    australia: Australien
+    austria: Österreich
+    austria_carinthia: 'Austria: Carinthia'
+    austria_lower_austria: 'Austria: Lower Austria'
+    austria_salzburg: 'Austria: Salzburg'
+    austria_styria: 'Austria: Styria'
+    austria_tyrol: 'Austria: Tyrol'
+    austria_upper_austria: 'Austria: Upper Austria'
+    austria_vienna: 'Austria: Vienna'
+    belgium: Belgien
+    benin: Benin
+    brazil: Brasilien
+    bulgaria: Bulgarien
+    cambodia: Cambodia
+    canada: Kanada
+    chile: Chile
+    china: China
+    colombia: Kolombien
+    croatia: Kroatien
+    cuba: Kuba
+    czech_republic: Czech Republic
+    denmark: Dänemark
+    ecuador: Ecuador
+    egypt: Ägypten
+    estonia: Estonia
+    finland: Finland
+    france: Frankreich
+    georgia: Georgia
+    germany: Deutschland
+    germany_bavaria: 'Germany: Bavaria'
+    germany_saxony: 'Germany: Saxony'
+    greece: Griechenland
+    guatemala: Guatemala
+    guinea: Guinea
+    holy_see: Holy See
+    honduras: Honduras
+    hong_kong: Hongkong
+    hungary: Ungarn
+    iceland: Island
+    india: Indien
+    indonesia: Indonesien
+    iran: Iran, Islamic Republic of
+    iraq: Irak
+    ireland: Irland
+    israel: Israel
+    italy: Italien
+    italy_trentino_alto_adige: 'Italy: Trentino-Alto Adige'
+    japan: Japan
+    korea: Korea, Republic of
+    latvia: Latvia
+    lithuania: Lithuania
+    luxembourg: Luxemburg
+    malta: Malta
+    mexico: Mexiko
+    moldavia: Moldawien
+    monaco: Monaco
+    montenegro: Montenegro
+    netherlands: Niederlande
+    new_zealand: New Zealand
+    northern_ireland: Nordirland
+    norway: Norwegen
+    papua_new_guinea: Papua Neu-Guinea
+    paraguay: Paraguay
+    peru: Peru
+    philippines: Philippinen
+    poland: Polen
+    portugal: Portugal
+    puerto_rico: Puerto Rico
+    romania: Rumänien
+    russian_federation: Russian Federation
+    saudi_arabia: Saudi-Arabien
+    serbia: Serbien
+    slovakia: Slovakia
+    slovenia: Slovenien
+    south_africa: South Africa
+    spain: Spanien
+    sweden: Schweden
+    switzerland: Schweiz
+    switzerland_vaud: 'Switzerland: Vaud'
+    syrian_arab_republic: Syrian Arab Republic
+    taiwan: Taiwan (Provinz von China)
+    trinidad_tobego: Trinidad and Tobago
+    turkey: Türkei
+    uk: United Kingdom
+    ukraine: Ukraine
+    uruguay: Uruguay
+    usa: Vereinigte Staaten von Amerika (USA)
+    venezuela: Venezuela, Bolivarian Republic of
+    vietnam: Vietnam
+  records:
+    a_major: A-Dur
+    a_minor: a-Moll
+    abbreviations: Abkürzungen
+    abbreviations_terminology: Abkürzungen und Bezeichnungen
+    access_restrictions: Zugangsbeschränkungen
+    accession_number: Akzessionsnumer
+    added_entry_name: Nebeneintragungen
+    additional_author: Zusätzlicher Autor
+    additional_bibliographic_information: Weitere bibliographische Angaben
+    additional_biographical_information: Weitere biographische Angaben
+    additional_choir_voice: Zusätzliche Chorstimmen
+    additional_institution: Nebeneintragung Körperschaften
+    additional_personal_name: Nebeneintragung Personen
+    additional_personal_name_lit: Sonstige Person
+    additional_solo_voice: Zusätzliche Solostimme
+    additional_title: Alternativer Titel
+    additional_title_lit: Zusätzlicher Titel
+    administration: Administration
+    af_major: As-Dur
+    af_minor: as-Moll
+    aide: Arbeitshilfen
+    aids: Arbeitshilfen
+    alleged: Angeblich
+    alternate_spelling: Andere Schreibweise
+    archive: Archiv
+    arrangement: Bearbeitung
+    arrangement_statement: Bearbeitung
+    arranger: Bearbeiter
+    artist: Bühnenbildner
+    artistic_production: Verfasser
+    as_major: Ais-Dur
+    as_minor: ais-Moll
+    ascertained: Ermittelt
+    assignee: Lizenznehmer
+    associated_institution: Beziehung Körperschaft
+    associated_name: Zugehöriger Name
+    associated_name_lit: Behandelte Person
+    associated_place: Associated Place
+    attribution_qualifier: Zuschreibungsvermerk
+    authentication_code: Individualsierung
+    author: Autor
+    author_editor: Autor / Herausgeber
+    authorities: Normdaten
+    authority_agency: Normdatenagentur
+    authority_reference: Normdatenverweise
+    autography: Autographie
+    b_major: H-Dur
+    b_minor: h-Moll
+    baptismal_name: Taufname
+    basic_functions: Grundsätzliche Funktionen
+    basso_continuo: Basso continuo
+    bf_major: B-Dur
+    bf_minor: b-Moll
+    bibliographic_reference: Literaturverweis
+    binder: Buchbinder
+    binding_note: Einband
+    birth_name: Geburtsname
+    book_format: Buchformat
+    bookseller: Musikalienhändler
+    bound_with: Zusammengebunden mit
+    brass_instruments: Blechblasinstrumente
+    brief: Kurzkatalogisat
+    brother_of: Bruder von
+    byname: Beiname
+    c_major: C-Dur
+    c_minor: c-Moll
+    c_minus_1: C-1
+    c_minus_2: C-2
+    c_minus_3: C-3
+    c_minus_4: C-4
+    c_minus_5: C-5
+    c_plus_1: C+1
+    c_plus_2: C+2
+    c_plus_3: C+3
+    c_plus_4: C+4
+    c_plus_5: C+5
+    catalog_opus_number: Werkverzeichnis/Opus
+    catalog_works: Werkverzeichnis
+    cataloging_agency: Katalogisierungsagentur
+    cataloging_collection_convoluta: Erfassung von Sammlungen
+    cataloging_collections: Erfassung von Sammlungen
+    cataloging_forms: Masken
+    cataloging_language: Katalogisierungsspache
+    cataloging_level: Erfassungstiefe
+    cataloging_musical_sources: Katalogisierung von Musikquellen
+    cataloging_source: Katalogisierungsquelle
+    category: Art/Inhalt
+    censor: Zensor
+    cf_major: Ces-Dur
+    cf_minor: ces-Moll
+    child_of: Kind von
+    choir_voice: Chorstimmen
+    choreographer: Choreograph
+    chronological_subdivision: Chronologische Unterteilung
+    chronological_term: Datierungen
+    city: Ort
+    clef: Schlüssel
+    co-composer: Mitkomponist
+    coded_date: Datum und Ort eines Ereignisses (codiert)
+    coded_instrumentation: Kodierte Besetzung
+    collaborator: Mitverfasser
+    colophon: Kolophon
+    common_clefs: Common clefs
+    compiler: Kompilator
+    composer: Komponist
+    composer_author: Komponist/Autor
+    composer_cross_reference: Komponistenquerverweis
+    computer_printout: Computerausdruck
+    conceptor: Autor der Textvorlage
+    conductor: Dirigent
+    confused_with: Verwechselt mit
+    conjectural: Mutmaßlich
+    contact: Kontakt
+    contact_area: Kontakt
+    content: Inhalt
+    content_description: Inhaltsangaben
+    contents_note: Bemerkungen zu Inhaltsangaben
+    contributor: Mitverfasser
+    control_fields: Kontrollfelder
+    control_number_identifier: Kontrollnummer-Bezeichnung
+    copy_examined: Vorlageexemplar
+    copyist: Schreiber
+    copyright_holder: Rechteinhaber
+    costume_designer: Kostümbildner
+    countries_places: Länder und Orte
+    country: Land
+    country_active: Wirkungsland
+    country_activity: Wirkungsland
+    country_code: Länder-Code
+    country_of_publication: Land
+    county_province: Bezirk oder Staat
+    creation_production_note: Bemerkung zur Person / Körperschaft
+    cs_major: Cis-Dur
+    cs_minor: cis-Moll
+    d_major: D-Dur
+    d_minor: d-Moll
+    dancer: Tänzer
+    date: Datum
+    date_of_acquisition: Beschaffungsdatum
+    date_of_creation: Datum der Erstellung
+    date_time_last_transaction: Datum und Zeit der letzten Transaktion
+    date_type: Datierungtypus
+    dates: Datierungen
+    dedicatee: Widmungsträger
+    department: Abteilung
+    depositor: Depositor
+    description: Beschreibung
+    description_area: Beschreibung
+    description_summary: Zusammenfassende Beschreibung
+    designer: Designer
+    df_major: Des-Dur
+    df_minor: des-Moll
+    digitized_music: Notendigitalisat
+    digitized_source: Quellendigitalisat
+    dimensions: Format
+    diplomatic_title: Diplomatischer Titel
+    dissertation_note: Hinweis zur Dissertation
+    distribution: Besetzung
+    distributor: Vertrieb
+    documentation_center: Dokumentationszentrum
+    donor: Donator
+    doubtful: Zweifelhaft
+    dramatic_roles_original: Originale Schreibweise
+    dramatic_roles_standardized: Rollennamen, standardisierte Schreibweise
+    ds_major: Dis-Dur
+    ds_minor: dis-Moll
+    dubious: Zweifelhaft
+    e_major: E-Dur
+    e_minor: e-Moll
+    ecclesiastical_modes: Kirchentonarten
+    edition: Edition
+    edition_imprint_fields: Ausgabe- und Impressumsfelder
+    edition_statement: Ausgabe
+    editor: Herausgeber
+    ef_major: Es-Dur
+    ef_minor: es-Moll
+    engraver: Stecher
+    engraving: Stich
+    event_organizer: Veranstalter
+    event_place: Veranstaltungsort
+    excerpts: Ausschnitte
+    extent: Umfang
+    extent_parts: Umfang Stimmenmaterial
+    external_resource: Elektronische Lokalisierung und Zugriff
+    external_resource_uri: Elektronische Lokalisierung und Zugriff
+    external_resource_url: Uniform Resource Identifier
+    f_major: F-Dur
+    f_minor: f-Moll
+    f_minus_1: F-1
+    f_minus_2: F-2
+    f_minus_3: F-3
+    f_minus_4_bass: F-4 (Baß-Schlüssel)
+    f_minus_5: F-5
+    f_plus_1: F+1
+    f_plus_2: F+2
+    f_plus_3: F+3
+    f_plus_4: F+4
+    f_plus_5: F+5
+    facsimile: Faksimile
+    family_name: Familienname
+    father_of: Vater von
+    figured_bass_scores: Generalbass
+    fijian: Fidschianisch
+    fingerprint_identifier: Fingerprint-Erkennung
+    first_second_group: Erste und zweite Zeichengruppe
+    form_subdivision: Unterteilung nach der Form
+    format_extent: Quellenart, Umfang
+    former_owner: Vorbesitzer
+    fragments: Fragmente
+    friulano: Friulano
+    fs_major: Fis-Dur
+    fs_minor: fis-Moll
+    full: Vollkatalogisat
+    function: Funktionsbezeichnung
+    further_information: Anmerkungen
+    g_major: G-Dur
+    g_minor: g-Moll
+    g_minus_1: G-1
+    g_minus_2_octave: g-2 (oktavierenden Violinschlüssels)
+    g_minus_2_treble: G-2 (Violin-Schlüssel)
+    g_minus_3: G-3
+    g_minus_4: G-4
+    g_minus_5: G-5
+    g_plus_1: G+1
+    g_plus_2: G+2
+    g_plus_3: G+3
+    g_plus_4: G+4
+    g_plus_5: G+5
+    gender: Geschlecht
+    general_abbreviations: Allgemeine Abkürzungen und Begriffe
+    general_cataloguing_guidelines: Allgemeine Erfassung Hilfe
+    general_note: Bemerkungen
+    general_note_incipits: Kommentar zum Musikincipit
+    general_note_institution: Allgemeine Fußnote
+    general_note_personal: Externe Bemerkungen
+    geographic_name: Geographischer Name
+    geographic_subdivision: Geographische Unterteilung
+    gf_major: Ges-Dur
+    gf_minor: ges-Moll
+    gs_major: Gis-Dur
+    gs_minor: gis-Moll
+    heading: Ansetzungsform
+    heading_composer_name: Komponist
+    heading_personal_name: Ansetzungsform
+    heading_personal_name1: Personenname
+    help_transposing_instruments: Hilfe zu transponierenden Instrumenten
+    history_institution: Geschichte der Körperschaft
+    holdings_location: Bestandsdaten
+    identity: Identifizierung
+    identity_area: IDENTITY AREA
+    iiif_manifest: IIIF manifest
+    illustrator: Illustrator
+    images: Bilder
+    import: Fremddateneinspielung
+    imprint: Imprint
+    incipit: Musikincipit
+    incipit_number: Incipitnummer
+    incipits: Incipits
+    index_terms: Deskriptoren
+    information_found: Ansetzung laut Literaturnachweis
+    initial: Initiale
+    initial_entry: Ersteintrag
+    initials: Initiale
+    insertions: Einlagen
+    inserts: Einlagen
+    institution: Körperschaft
+    institutions: Körperschaften
+    instrumentalist: Instrumentalist
+    internal_note: Interne Bemerkungen
+    introduction: Einleitung
+    isbn: ISBN
+    ismn: ISMN
+    issn: ISSN
+    item_in_collection: Untergeordneter Eintrag
+    item_part_of: In
+    items_in_source: Untergeordnete Einträge
+    japanese: Japanisch
+    key: Tonart
+    key_or_mode: Tonart, Modus
+    key_signature: Akzidentien
+    keyboards: Tasteninstrumente
+    keys: Tonarten
+    language_code: Sprachcode
+    language_codes: Sprachcodes
+    language_libretto: Sprachcode von Libretti
+    language_note: Sprachenvermerk
+    language_of_cataloging: Katalogisierungssprache
+    language_original_text: Sprachcode des Originaltextes
+    language_text: Sprachcode
+    latitude: Breitengrad
+    leader: Leader
+    library: Bibliothek
+    library_information: Besitzerangaben
+    library_information_relations: Besitzerangaben und Verlinkung
+    library_siglum: Bibliothekssigel
+    librettist: Librettist
+    licensee: Lizenzinhaber
+    life_dates: Geburts- und Todesdaten
+    link_type: Linktyp
+    linkage: Verlinkung
+    linking_entry_fields: Verknüpfungseintragungen
+    literature: Literatur
+    lithograph: Lithograph
+    lithographer: Lithograph
+    lithography: Lithographie
+    liturgical_festival: Liturgische Feste
+    liturgical_festivals: Liturgische Feste
+    local_id_number: Lokale Nummer
+    local_note_field: Lokale Bemerkungen
+    local_notes_field: Interne Fussnoten
+    local_number: Lokale Nummer
+    location: Ort
+    location_and_address: Adresse
+    location_insertion: Stelle der Einlage im Hauptwerk
+    location_on_source: Fundorte auf Quellen
+    location_performance: Aufführungsort
+    location_printer: Druckort
+    longitude: Längengrad
+    lyricist: Textdichter
+    main_entry_fields: Haupteintragungen
+    married_name: Ehename
+    married_to: Verheiratet mit
+    married_with: Verheiratet mit
+    material_description: Materialbeschreibung
+    material_examined: Autopsie
+    material_held: Erhaltenes Material
+    material_not_examined: Keine Autopsie
+    media_type: Physisches Medium
+    mensural_clefs: Mensural clefs
+    method_of_acquisition: Beschaffungsart
+    misattributed: Fälschlich
+    miscellaneous: Verschiedenes
+    mode_10t: 'Mode: 10t – Hypoaeolian'
+    mode_10tt: 'Mode: 10tt – Hypoaeolian, transposed'
+    mode_11t: 'Mode: 11t – Ionian'
+    mode_11tt: 'Mode: 11tt – Ionian, transposed'
+    mode_12t: 'Mode: 12t – Hypoionian'
+    mode_12tt: 'Mode: 12tt – Hypoionian, transposed'
+    mode_1t: 'Mode:  1t – Dorian'
+    mode_1tt: 'Mode:  1tt – Dorian, transposed'
+    mode_2t: 'Mode:  2t – Hypodorian'
+    mode_2tt: 'Mode:  2tt – Hypodorian, transposed'
+    mode_3t: 'Mode:  3t – Phrygian'
+    mode_3tt: 'Mode:  3tt – Phrygian, transposed'
+    mode_4t: 'Mode:  4t – Hypophrygian'
+    mode_4tt: 'Mode:  4tt – Hypophrygian, transposed'
+    mode_5t: 'Mode:  5t – Lydian'
+    mode_5tt: 'Mode:  5tt – Lydian, transposed'
+    mode_6t: 'Mode:  6t – Hypolydian'
+    mode_6tt: 'Mode:  6tt – Hypolydian, transposed'
+    mode_7t: 'Mode:  7t – Mixolydian'
+    mode_7tt: 'Mode:  7tt – Mixolydian, transposed'
+    mode_8t: 'Mode:  8t – Hypomixolydian'
+    mode_8tt: 'Mode:  8tt – Hypomixolydian, transposed'
+    mode_9t: 'Mode:  9t – Aeolian'
+    mode_9tt: 'Mode:  9tt – Aeolian, transposed'
+    modifying_agency: Modifizierende Katalogisierungsstelle
+    monogram: Monogramm
+    mother_of: Mutter von
+    movement_number: Satznummer
+    multiple: Mehrere
+    multiple_copies: Mehrere Exemplare
+    multiple_single_dates: Mehrere Einzeldaten
+    museum: Museum
+    music_incipit: Musikincipit
+    name: Personenname
+    name_family: Familienname
+    name_printer: Drucker, Druckerei
+    name_variant: Namensvarianten
+    name_variants: Namensvarianten
+    named_dramatic_roles: 'Rollennamen: Schreibweise'
+    nationality: Länder-Code
+    nickname: Beiname
+    no_linguistic_content: ohne Sprache
+    non_migrated_bound: Non-migrated bound with value from 563
+    note_external_resource: Für das Publikum bestimmte Fussnote
+    note_fields: Bemerkungen
+    note_on_performance: Bemerkungen zu den Aufführungen
+    now_in: Heute in
+    number: Anzahl
+    number_page: Nummer/Seitenzahl
+    number_part_section: Anzahl Teile oder Abschnitte eines Werks
+    number_volume_part: Nummer des Bandes oder Teils
+    numbers_code_fields: Nummern und Codes
+    octoechos1: 'Octoechos 1: Ēchos prōtos (First mode of Byzantine music)'
+    octoechos2: 'Octoechos 2: Ēchos deuteros (Second mode of Byzantine music)'
+    octoechos3: 'Octoechos 3: Ēchos tritos (Third mode of Byzantine music)'
+    octoechos4: 'Octoechos 4: Ēchos tetartos (Fourth mode of Byzantine music)'
+    octoechos5: 'Octoechos 5: Ēchos plagios prōtos (First plagal mode of Byzantine
+      music)'
+    octoechos6: 'Octoechos 6: Ēchos plagios deuteros (Second plagal mode of Byzantine
+      music)'
+    octoechos7: 'Octoechos 7: Ēchos barys (Third plagal mode of Byzantine music)'
+    octoechos8: 'Octoechos 8: Ēchos plagios tetartos (Fourth plagal mode of Byzantine
+      music)'
+    online_finding_aids: Archivführer und andere Publikationen
+    opera_houses_concert_halls: Opernhäuser und Konzerthallen
+    opus_number: Opus
+    opus_thematic_index_number: Opus / WV-Nummer
+    order_name: Ordensname
+    origin: Herkunft
+    original_cataloging_agency: Original-Katalogisierungsstelle
+    other: Sonstige Funktion
+    other_form: Andere Schreibweise
+    other_form_of_name: Andere Namensformen
+    other_function: Sonstige Funktion
+    other_help: Weitere Hilfen
+    other_instruments: Weitere Instrumente
+    other_life_dates: Andere Lebensdaten
+    other_physical_details: Zusätzliche Materialbeschreibung
+    other_searchform: andere Suchform
+    other_shelfmark: Weitere Signatur
+    other_standard_identifier: Normdatenverweise
+    other_variant: andere Suchform
+    paper_maker: Papierhersteller
+    papermaker: Papierhersteller
+    parallel_form: Parallele Namensformen
+    parent_record: Übergeordneter Eintrag
+    parts_held: Vorhandene Stimmen
+    parts_held_extent: Stimmenmaterial
+    patron: Mäzen/Auftraggeber
+    people_institutions: Personen und Körperschaften
+    percussion: Schlaginstrumente
+    performance: Mitwirkende
+    performances: Aufführungen
+    performer: Interpret
+    performer_note: Bemerkungen zu den Aufführungen
+    person: Person
+    person_name: Personenname
+    personal_name: Personenname
+    personal_names: Personen
+    photoreproductive_process: Blaupause
+    physical_description: Material
+    physical_description_fields: Felder für die physische Beschreibung
+    place: Ort
+    place_active: Wirkungsort
+    place_activity: Wirkungsort
+    place_birth: Geburtsort
+    place_death: Sterbeort
+    place_origin: Herkunftsangabe
+    place_publication: Verlagsort
+    places: Orte
+    plate_number: Plattennummer
+    plucked_instruments: Zupfinstrumente
+    postal_code: Postleitzahl
+    postal_place: postalischer Ort
+    preceding_entry: Früherer Eintrag
+    printer: Drucker
+    printing_technique: Drucktechnik
+    production: Verlauf
+    production_personnel: Produktionspersonal
+    profession_or_function: Beruf oder Funktion
+    provenance: Bestandsname
+    provenance_notes: Provenienzvermerke
+    pseudonym: Pseudonym
+    public_note: Bemerkungen
+    publisher: Verleger
+    publisher_copyist: Schreiber, Verleger, Verlag
+    publishing_printing_production: Abschrift oder Impressum
+    range_dates: Datierungsbereich
+    record_actions: Titel veröffentlichen
+    record_audit: RECORD AUDIT
+    record_origin: Herkunft
+    record_status: RECORD STATUS
+    reference_record_id: REFERENCE RECORD ID
+    references: Literatur
+    references_and_notes: Literatur und Bemerkungen
+    region_active: Wirkungsregion
+    region_of_activity: Wirkungsregion
+    related_institution: In Beziehung stehende Körperschaft
+    related_personal_name: Zugehörige Personen
+    related_place: Ort
+    related_resources: Links
+    related_titles: Verlinkungen
+    related_to: Verwandt mit
+    related_work: zugehörige Werke
+    relation: Bedeutung
+    relations: Beziehungen
+    religious_name: Ordensname
+    religious_order: Orden/Titel
+    reproduction: Reproduktion
+    research_institute: Forschungsinstitut
+    retrospective_conversion: Retroeinspielung
+    rism_id_number: RISM Dokumentnummer
+    role: Rolle
+    scoring_in_movement: Besetzung Satz
+    scoring_summary: Besetzungshinweis
+    scribe: Schreiber
+    secondary_literature: Sekundärliteratur
+    series: Series
+    series_added_entry: Nebeneintragungen Gesamttitel
+    series_statement: Gesamttitelangaben
+    set: Set
+    shelfmark: Signatur
+    shelfmark_olim: Alte Signatur (olim)
+    short_title: Kurztitel
+    sigla: Sigel
+    siglum: Sigel
+    single_date: Einzeldatum
+    sister_of: Schwester von
+    sketches: Skizzen
+    solo_voice: Solostimme
+    soloist_instrument: Solistisches Instrument
+    source_data_found: Literaturnachweis
+    source_data_not_found: Quelle ohne Ergebnis konsultiert
+    source_description: Vorlageexemplar
+    source_details: Physische Beschreibung
+    source_number_code: Normdatenagentur
+    source_of_acquisition_note: Beschaffungsquelle
+    source_type: Quellentyp
+    special_production_technique: Spezielle Fertigungstechnik
+    standard: Standard
+    standard_musical_terms: STANDARD MUSIC TERMS
+    standard_number_code: Normdatenverweise
+    standard_texts_sacred_works: Liturgische Texte
+    standard_watermarks: Wasserzeichen
+    standardized_title: Einordnungstitel
+    standardized_titles_printed_music: Einordnungstitel für Musikdrucke
+    standardized_titles_subject_headings: Einordnungstitel - Schlagworte
+    street_address: Strasse
+    strings: Streichinstrumente
+    subheading: Unterteilung nach der Form
+    subheading_general: Allgemeine Unterteilung
+    subject_access_fields: Schlagworteintragungen
+    subject_heading: Schlagworteintragung
+    subject_headings: Schlagworte
+    subordinate_unit: Untergeordnete Körperschaft
+    succeeding_entry: Folgeeintrag
+    summary: Zusammenfassung
+    supplementary_material: Beigelegtes Material, Addenda
+    technical_errors: Technische Fehler
+    technical_production: Hersteller
+    temp_val: Temp val
+    templates: Templates
+    terms_voices_instruments: Stimmen- und Instrumentenbezeichnungen
+    text_author: Textdichter
+    text_incipit: Textincipit
+    third_fourth_group: Dritte und vierte Zeichengruppe
+    time_signature: Metrum
+    title: Titel
+    title_content_description: Titel und Inhaltsangaben
+    title_item: Titel
+    title_movement_tempo: Satztitel, Tempo
+    title_of_work: Werktitel
+    title_on_source: Diplomatischer Titel
+    title_periodical_book_series: 'In:'
+    title_related_fields: Titel- und damit verbundene Felder
+    title_section_part: ''
+    title_variants: Namensvarianten
+    titles_text_incipits: Titel und  Texte
+    topical_term: Sachbegriff
+    total_scoring: Besetzung
+    transcribing_agency: Übertragende Katalogisierungsstelle
+    translation: Übersetzung
+    translator: Übersetzer
+    transparency: Transparentfolie
+    type: Typ
+    type_institution: Typ der Körperschaft
+    type_name_variant: Art der Namensvariante
+    type_publication: Ausgabeform
+    type_relationship: Beziehung
+    typescript: Typescript
+    typography: Typendruck
+    unknown: Unbekannt
+    unparsed_fingerprint: Zusammenhängender Fingerprint
+    variant_ms_title: Weiterer diplomatischer Titel
+    variant_source_title: Weiterer diplomatischer Titel
+    variations: Variationen
+    vocalist: Sänger
+    voice_instrument: Besetzung
+    volume_year_page: Jahrgang, Seite
+    watermark_description: Wasserzeichen
+    woodwinds: Holzblasinstrumente
+    work: Werktitel
+    work_number: Incipitnummer
+    year: Jahr
+    years_birth_death: Geburts- und Todesdaten

--- a/config/locales/marc_records/en.yml
+++ b/config/locales/marc_records/en.yml
@@ -1,0 +1,789 @@
+en:
+  general:
+    e_mail: E-mail
+    editor_help: Editor help
+    faq: Frequently asked questions
+    female: Female
+    how_do_i: How do I ... Tips & Tricks
+    index_marc_fields: Index of MARC fields
+    male: Male
+    marc_tag_index: MARC tag index
+    'no': 'No'
+    rism: RISM
+    rism_best_practices: RISM best practices
+    rism_instrument_abbreviations: RISM instrument abbreviations (continued)
+    rism_series: RISM Series
+    rism_series_a_b_references: RISM Series A/I and B reference
+    rism_series_number: RISM series number
+    rule_type: Rule type
+    scope_printed_music_rism: Scope of printed music in RISM
+    searching: Searching
+    status: Status
+    undetermined: Undetermined
+    ungrouped_fields: Ungrouped fields
+    unknown_fields: Unknown fields
+    unused: UNUSED - WILL BE REMOVED
+    uri: URI
+    url: URL
+    using_muscat: Using Muscat
+    validity: Validity
+    verified: Verified
+    when_to_input_new_record: When to input a new record (printed music)
+    workflow: Workflow
+    'yes': 'Yes'
+  languages:
+    afrikaans: Afrikaans
+    arabic: Arabic
+    aragonese: Aragonese
+    armenian: Armenian
+    basque: Basque
+    bosnian: Bosnian
+    bulgarian: Bulgarian
+    catalan: Catalan
+    celtic_other: Celtic (Other)
+    chinese: Chinese
+    creoles_pidgins_other: Creoles and Pidgins (Other)
+    croatian: Croatian
+    czech: Czech
+    danish: Danish
+    dutch: Dutch
+    english: English
+    estonian: Estonian
+    ethiopic: Ethiopic
+    finnish: Finnish
+    french: French
+    french_middle: French, Middle (ca. 1300-1600)
+    french_old: French, Old (ca. 842-1300)
+    gallician: Galician
+    german: German
+    german_old_high: German, Old High (ca. 750-1050)
+    germanic: Germanic
+    greek_ancient: Greek, Ancient (to 1453)
+    greek_modern: Greek, Modern (1453-)
+    hebrew: Hebrew
+    hungarian: Hungarian
+    icelandic: Icelandic
+    insari_sami: Inari Sami
+    irish: Irish
+    italian: Italian
+    korean: Korean
+    latin: Latin
+    latvian: Latvian
+    lithuanian: Lithuanian
+    low_german: Low German
+    lower_sorbian: Sorbian, Lower Sorbian
+    luxembourgish: Luxembourgish
+    macedonian: Macedonian
+    maori: Maori
+    middle_english: Middle English
+    middle_high_german: Middle High German
+    mongolian: Mongolian
+    neapolitan: Neapolitan
+    north_frisian: North Frisian
+    norwegian: Norwegian
+    occitan: Occitan
+    oirat: Oirat
+    old_church_slavonic: Old Church Slavonic
+    persian: Persian
+    polish: Polish
+    portugese: Portuguese
+    romani: Romani
+    romanian: Romanian
+    romansh: Romansh
+    russian: Russian
+    sanskrit: Sanskrit
+    scots: Scots
+    serbian: Serbian
+    sichuan_yi: Sichuan Yi
+    sicilian: Sicilian
+    slavic: Slavic
+    slovak: Slovak
+    slovenian: Slovenian
+    sorbian: Sorbian
+    spanish: Spanish
+    swedish: Swedish
+    swiss_german: Swiss German
+    tagalog: Tagalog
+    tartar: Tatar
+    thai: Thai
+    tibetan: Tibetan
+    tsimshian: Tsimshian
+    turkish: Turkish
+    ukrainian: Ukrainian
+    upper_sorbian: Sorbian, Upper Sorbian
+    vietnamese: Vietnamese
+    welsh: Welsh
+    west_frisian: West Frisian
+    yiddish: Yiddish
+  places:
+    algeria: Algeria
+    andorra: Andorra
+    argentina: Argentina
+    armenia: Armenia
+    australia: Australia
+    austria: Austria
+    austria_carinthia: 'Austria: Carinthia'
+    austria_lower_austria: 'Austria: Lower Austria'
+    austria_salzburg: 'Austria: Salzburg'
+    austria_styria: 'Austria: Styria'
+    austria_tyrol: 'Austria: Tyrol'
+    austria_upper_austria: 'Austria: Upper Austria'
+    austria_vienna: 'Austria: Vienna'
+    belgium: Belgium
+    benin: Benin
+    brazil: Brazil
+    bulgaria: Bulgaria
+    cambodia: Cambodia
+    canada: Canada
+    chile: Chile
+    china: China
+    colombia: Colombia
+    croatia: Croatia
+    cuba: Cuba
+    czech_republic: Czech Republic
+    denmark: Denmark
+    ecuador: Ecuador
+    egypt: Egypt
+    estonia: Estonia
+    finland: Finland
+    france: France
+    georgia: Georgia
+    germany: Germany
+    germany_bavaria: 'Germany: Bavaria'
+    germany_saxony: 'Germany: Saxony'
+    greece: Greece
+    guatemala: Guatemala
+    guinea: Guinea
+    holy_see: Holy See
+    honduras: Honduras
+    hong_kong: Hong Kong
+    hungary: Hungary
+    iceland: Iceland
+    india: India
+    indonesia: Indonesia
+    iran: Iran, Islamic Republic of
+    iraq: Iraq
+    ireland: Ireland
+    israel: Israel
+    italy: Italy
+    italy_trentino_alto_adige: 'Italy: Trentino-Alto Adige'
+    japan: Japan
+    korea: Korea, Republic of
+    latvia: Latvia
+    lithuania: Lithuania
+    luxembourg: Luxembourg
+    malta: Malta
+    mexico: Mexico
+    moldavia: Moldavia
+    monaco: Monaco
+    montenegro: Montenegro
+    netherlands: Netherlands
+    new_zealand: New Zealand
+    northern_ireland: Northern Ireland
+    norway: Norway
+    papua_new_guinea: Papua New Guinea
+    paraguay: Paraguay
+    peru: Peru
+    philippines: Philippines
+    poland: Poland
+    portugal: Portugal
+    puerto_rico: Puerto Rico
+    romania: Romania
+    russian_federation: Russian Federation
+    saudi_arabia: Saudi Arabia
+    serbia: Serbia
+    slovakia: Slovakia
+    slovenia: Slovenia
+    south_africa: South Africa
+    spain: Spain
+    sweden: Sweden
+    switzerland: Switzerland
+    switzerland_vaud: 'Switzerland: Vaud'
+    syrian_arab_republic: Syrian Arab Republic
+    taiwan: Taiwan (Province of China)
+    trinidad_tobego: Trinidad and Tobago
+    turkey: Turkey
+    uk: United Kingdom
+    ukraine: Ukraine
+    uruguay: Uruguay
+    usa: United States of America
+    venezuela: Venezuela, Bolivarian Republic of
+    vietnam: Vietnam
+  records:
+    a_major: A major
+    a_minor: A minor
+    abbreviations: Abbreviations
+    abbreviations_terminology: Abbreviations and terminology
+    access_restrictions: Access restrictions
+    accession_number: Accession number
+    added_entry_name: Added entry name
+    additional_author: Additional author
+    additional_bibliographic_information: Additional bibliographic information
+    additional_biographical_information: Additional biographical information
+    additional_choir_voice: Additional choir voice
+    additional_institution: Additional institution
+    additional_personal_name: Additional personal name
+    additional_personal_name_lit: Additional personal name
+    additional_solo_voice: Additional solo voice
+    additional_title: Additional title
+    additional_title_lit: Additional title
+    administration: Administration
+    af_major: A♭ major
+    af_minor: A♭ minor
+    aide: Aide
+    aids: Aids
+    alleged: Alleged
+    alternate_spelling: Alternate spelling
+    archive: Archive
+    arrangement: Arrangement
+    arrangement_statement: Arrangement statement
+    arranger: Arranger
+    artist: Artist
+    artistic_production: Artistic production
+    as_major: A♯ major
+    as_minor: A♯ minor
+    ascertained: Ascertained
+    assignee: Assignee
+    associated_institution: Associated institution
+    associated_name: Associated name
+    associated_name_lit: Associated name
+    associated_place: Associated Place
+    attribution_qualifier: Attribution qualifier
+    authentication_code: Authentication code
+    author: Author
+    author_editor: Author/Editor
+    authorities: Authorities
+    authority_agency: Authority agency
+    authority_reference: Authority reference
+    autography: Autography
+    b_major: B major
+    b_minor: B minor
+    baptismal_name: Baptismal name
+    basic_functions: Basic functions
+    basso_continuo: Basso continuo
+    bf_major: B♭ major
+    bf_minor: B♭ minor
+    bibliographic_reference: Bibliographic reference
+    binder: Binder
+    binding_note: Binding note
+    birth_name: Birth name
+    book_format: Book format
+    bookseller: Bookseller
+    bound_with: Bound with
+    brass_instruments: Brass instruments
+    brief: Brief
+    brother_of: Brother of
+    byname: Byname
+    c_major: C major
+    c_minor: C minor
+    c_minus_1: C-1
+    c_minus_2: C-2
+    c_minus_3: C-3
+    c_minus_4: C-4
+    c_minus_5: C-5
+    c_plus_1: C+1
+    c_plus_2: C+2
+    c_plus_3: C+3
+    c_plus_4: C+4
+    c_plus_5: C+5
+    catalog_opus_number: Catalog number/Opus number
+    catalog_works: Catalog of works
+    cataloging_agency: Cataloging agency
+    cataloging_collection_convoluta: Cataloging collection and convoluta
+    cataloging_collections: Cataloging collections
+    cataloging_forms: Cataloging forms
+    cataloging_language: Cataloging language
+    cataloging_level: Cataloging level
+    cataloging_musical_sources: Cataloging musical sources
+    cataloging_source: Cataloging source
+    category: Category
+    censor: Censor
+    cf_major: C♭ major
+    cf_minor: C♭ minor
+    child_of: Child of
+    choir_voice: Choir voice
+    choreographer: Choreographer
+    chronological_subdivision: Chronological subdivision
+    chronological_term: Chronological term
+    city: City
+    clef: Clef
+    co-composer: Co-composer
+    coded_date: Coded date
+    coded_instrumentation: Coded instrumentation
+    collaborator: Collaborator
+    colophon: Colophon
+    common_clefs: Common clefs
+    compiler: Compiler
+    composer: Composer
+    composer_author: Composer/Author
+    composer_cross_reference: Composer cross-reference
+    computer_printout: Computer printout
+    conceptor: Conceptor
+    conductor: Conductor
+    confused_with: Confused with
+    conjectural: Conjectural
+    contact: Contact
+    contact_area: Contact area
+    content: Content
+    content_description: Content description
+    contents_note: Contents note
+    contributor: Contributor
+    control_fields: Control fields
+    control_number_identifier: Control number identifier
+    copy_examined: Copy examined for cataloging
+    copyist: Copyist
+    copyright_holder: Copyright holder
+    costume_designer: Costume designer
+    countries_places: Countries and Places
+    country: Country
+    country_active: Country active
+    country_activity: Country of activity
+    country_code: Country code
+    country_of_publication: Country of publication
+    county_province: County or province
+    creation_production_note: Creation/production note
+    cs_major: C♯ major
+    cs_minor: C♯ minor
+    d_major: D major
+    d_minor: D minor
+    dancer: Dancer
+    date: Date
+    date_of_acquisition: Date of acquisition
+    date_of_creation: Date of creation
+    date_time_last_transaction: Date and time of last transaction
+    date_type: Date type
+    dates: Dates
+    dedicatee: Dedicatee
+    department: Department
+    depositor: Depositor
+    description: Description
+    description_area: Description area
+    description_summary: Description summary
+    designer: Designer
+    df_major: D♭ major
+    df_minor: D♭ minor
+    digitized_music: Digitized music
+    digitized_source: Digitized source
+    dimensions: Dimensions
+    diplomatic_title: Diplomatic title
+    dissertation_note: Dissertation note
+    distribution: Distribution
+    distributor: Distributor
+    documentation_center: Documentation center
+    donor: Donor
+    doubtful: Doubtful
+    dramatic_roles_original: Dramatic role named, original spelling
+    dramatic_roles_standardized: Dramatic role named, standardized
+    ds_major: D♯ major
+    ds_minor: D♯ minor
+    dubious: Dubious
+    e_major: E major
+    e_minor: E minor
+    ecclesiastical_modes: Ecclesiastical modes
+    edition: Edition
+    edition_imprint_fields: Edition, imprint, etc. fields
+    edition_statement: Edition statement
+    editor: Editor
+    ef_major: E♭ major
+    ef_minor: E♭ minor
+    engraver: Engraver
+    engraving: Engraving
+    event_organizer: Event organizer
+    event_place: Event place
+    excerpts: Excerpts
+    extent: Extent
+    extent_parts: Extent (parts)
+    external_resource: External resource
+    external_resource_uri: External resource URI
+    external_resource_url: External resource URL
+    f_major: F major
+    f_minor: F minor
+    f_minus_1: F-1
+    f_minus_2: F-2
+    f_minus_3: F-3
+    f_minus_4_bass: F-4 (bass clef)
+    f_minus_5: F-5
+    f_plus_1: F+1
+    f_plus_2: F+2
+    f_plus_3: F+3
+    f_plus_4: F+4
+    f_plus_5: F+5
+    facsimile: Facsimile
+    family_name: Family Name
+    father_of: Father of
+    figured_bass_scores: Figured bass in scores and/or other parts
+    fijian: Fijian
+    fingerprint_identifier: Fingerprint identifier
+    first_second_group: First/second group
+    form_subdivision: Form subdivision
+    format_extent: Format, extent
+    former_owner: Former owner
+    fragments: Fragments
+    friulano: Friulano
+    fs_major: F♯ major
+    fs_minor: F♯ minor
+    full: Full
+    function: Function
+    further_information: Further information
+    g_major: G major
+    g_minor: G minor
+    g_minus_1: G-1
+    g_minus_2_octave: g-2 (octave treble clef)
+    g_minus_2_treble: G-2 (treble clef)
+    g_minus_3: G-3
+    g_minus_4: G-4
+    g_minus_5: G-5
+    g_plus_1: G+1
+    g_plus_2: G+2
+    g_plus_3: G+3
+    g_plus_4: G+4
+    g_plus_5: G+5
+    gender: Gender
+    general_abbreviations: General abbreviations and terms
+    general_cataloguing_guidelines: General cataloging guidelines
+    general_note: General note
+    general_note_incipits: General note for music incipit
+    general_note_institution: General note
+    general_note_personal: General note
+    geographic_name: Geographic name
+    geographic_subdivision: Geographic subdivision
+    gf_major: G♭ major
+    gf_minor: G♭ minor
+    gs_major: G♯ major
+    gs_minor: G♯ minor
+    heading: Heading
+    heading_composer_name: Heading - composer name
+    heading_personal_name: Heading - Personal name
+    heading_personal_name1: Heading-Personal name
+    help_transposing_instruments: Help for transposing instruments
+    history_institution: History of institution
+    holdings_location: Holdings, location, etc. fields
+    identity: Identity
+    identity_area: Identity area
+    iiif_manifest: IIIF manifest
+    illustrator: Illustrator
+    images: Images
+    import: Import
+    imprint: Imprint
+    incipit: Incipit
+    incipit_number: Incipit number
+    incipits: Incipits
+    index_terms: Index terms
+    information_found: Information found
+    initial: Initial
+    initial_entry: Initial entry
+    initials: Initials
+    insertions: Insertions
+    inserts: Inserts
+    institution: Institution
+    institutions: Institutions
+    instrumentalist: Instrumentalist
+    internal_note: Internal note
+    introduction: Introduction
+    isbn: ISBN
+    ismn: ISMN
+    issn: ISSN
+    item_in_collection: Item in this collection
+    item_part_of: Item part of
+    items_in_source: Items in this source
+    japanese: Japanese
+    key: Key
+    key_or_mode: Key or mode
+    key_signature: Key signature
+    keyboards: Keyboards
+    keys: Keys
+    language_code: Language code
+    language_codes: Language codes
+    language_libretto: Language of libretto
+    language_note: Language note
+    language_of_cataloging: Language of cataloging
+    language_original_text: Language of original text
+    language_text: Language of text
+    latitude: Latitude
+    leader: Leader
+    library: Library
+    library_information: Library information
+    library_information_relations: Library information and relations
+    library_siglum: Library siglum
+    librettist: Librettist
+    licensee: Licensee
+    life_dates: Life dates
+    link_type: Link type
+    linkage: Linkage
+    linking_entry_fields: Linking entry fields
+    literature: Literature
+    lithograph: Lithograph
+    lithographer: Lithographer
+    lithography: Lithography
+    liturgical_festival: Liturgical festival
+    liturgical_festivals: Liturgical festivals
+    local_id_number: Local ID no.
+    local_note_field: Local note field
+    local_notes_field: Local notes field
+    local_number: Local number
+    location: Location
+    location_and_address: Location and address
+    location_insertion: Location of insertion
+    location_on_source: Locations on the source
+    location_performance: Location of performance
+    location_printer: Location of printer
+    longitude: Longitude
+    lyricist: Lyricist
+    main_entry_fields: Main entry fields
+    married_name: Married name
+    married_to: Married to
+    married_with: Married with
+    material_description: Material description
+    material_examined: Material examined
+    material_held: Material held
+    material_not_examined: Material not examined
+    media_type: Media type
+    mensural_clefs: Mensural clefs
+    method_of_acquisition: Method of acquisition
+    misattributed: Misattributed
+    miscellaneous: Miscellaneous
+    mode_10t: 'Mode: 10t – Hypoaeolian'
+    mode_10tt: 'Mode: 10tt – Hypoaeolian, transposed'
+    mode_11t: 'Mode: 11t – Ionian'
+    mode_11tt: 'Mode: 11tt – Ionian, transposed'
+    mode_12t: 'Mode: 12t – Hypoionian'
+    mode_12tt: 'Mode: 12tt – Hypoionian, transposed'
+    mode_1t: 'Mode:  1t – Dorian'
+    mode_1tt: 'Mode:  1tt – Dorian, transposed'
+    mode_2t: 'Mode:  2t – Hypodorian'
+    mode_2tt: 'Mode:  2tt – Hypodorian, transposed'
+    mode_3t: 'Mode:  3t – Phrygian'
+    mode_3tt: 'Mode:  3tt – Phrygian, transposed'
+    mode_4t: 'Mode:  4t – Hypophrygian'
+    mode_4tt: 'Mode:  4tt – Hypophrygian, transposed'
+    mode_5t: 'Mode:  5t – Lydian'
+    mode_5tt: 'Mode:  5tt – Lydian, transposed'
+    mode_6t: 'Mode:  6t – Hypolydian'
+    mode_6tt: 'Mode:  6tt – Hypolydian, transposed'
+    mode_7t: 'Mode:  7t – Mixolydian'
+    mode_7tt: 'Mode:  7tt – Mixolydian, transposed'
+    mode_8t: 'Mode:  8t – Hypomixolydian'
+    mode_8tt: 'Mode:  8tt – Hypomixolydian, transposed'
+    mode_9t: 'Mode:  9t – Aeolian'
+    mode_9tt: 'Mode:  9tt – Aeolian, transposed'
+    modifying_agency: Modifying agency
+    monogram: Monogram
+    mother_of: Mother of
+    movement_number: Movement number
+    multiple: Multiple
+    multiple_copies: Multiple copies
+    multiple_single_dates: Multiple single dates
+    museum: Museum
+    music_incipit: Music incipit
+    name: Name
+    name_family: Name of family
+    name_printer: Name of printer
+    name_variant: Name variant
+    name_variants: Name variants
+    named_dramatic_roles: Named dramatic role
+    nationality: Nationality
+    nickname: Nickname
+    no_linguistic_content: No linguistic content
+    non_migrated_bound: Non-migrated bound with value from 563
+    note_external_resource: Note about external resource
+    note_fields: Note fields
+    note_on_performance: Note on performance
+    now_in: Now in
+    number: Number
+    number_page: Number/page
+    number_part_section: Number of part/section of a work
+    number_volume_part: Number of volume/part
+    numbers_code_fields: Numbers and code fields
+    octoechos1: 'Octoechos 1: Ēchos prōtos (First mode of Byzantine music)'
+    octoechos2: 'Octoechos 2: Ēchos deuteros (Second mode of Byzantine music)'
+    octoechos3: 'Octoechos 3: Ēchos tritos (Third mode of Byzantine music)'
+    octoechos4: 'Octoechos 4: Ēchos tetartos (Fourth mode of Byzantine music)'
+    octoechos5: 'Octoechos 5: Ēchos plagios prōtos (First plagal mode of Byzantine
+      music)'
+    octoechos6: 'Octoechos 6: Ēchos plagios deuteros (Second plagal mode of Byzantine
+      music)'
+    octoechos7: 'Octoechos 7: Ēchos barys (Third plagal mode of Byzantine music)'
+    octoechos8: 'Octoechos 8: Ēchos plagios tetartos (Fourth plagal mode of Byzantine
+      music)'
+    online_finding_aids: Online finding aids
+    opera_houses_concert_halls: Opera houses and concert halls
+    opus_number: Opus number
+    opus_thematic_index_number: Opus/Thematic index number
+    order_name: Order Name
+    origin: Origin
+    original_cataloging_agency: Original cataloging agency
+    other: Other
+    other_form: Other form
+    other_form_of_name: Other form of name
+    other_function: Other function
+    other_help: Other help
+    other_instruments: Other instruments
+    other_life_dates: Other life dates
+    other_physical_details: Other physical details
+    other_searchform: Other Searchform
+    other_shelfmark: Other shelfmark
+    other_standard_identifier: Other standard identifier
+    other_variant: Other variant
+    paper_maker: Paper maker
+    papermaker: Papermaker
+    parallel_form: Paralell form of name
+    parent_record: Parent record
+    parts_held: Parts held
+    parts_held_extent: Parts held and extent
+    patron: Patron
+    people_institutions: People and institutions
+    percussion: Percussion
+    performance: Performance
+    performances: Performances
+    performer: Performer
+    performer_note: Performer note
+    person: Person
+    person_name: Person Name
+    personal_name: Personal name
+    personal_names: Personal names
+    photoreproductive_process: Photoreproductive process (bluprint)
+    physical_description: Physical description
+    physical_description_fields: Physical description, etc. fields
+    place: Place
+    place_active: Place active
+    place_activity: Place of activity
+    place_birth: Place of birth
+    place_death: Place of death
+    place_origin: Place of origin
+    place_publication: Place of publication
+    places: Places
+    plate_number: Plate number
+    plucked_instruments: Plucked instruments
+    postal_code: Postal code
+    postal_place: Postal place
+    preceding_entry: Preceding entry
+    printer: Printer
+    printing_technique: Printing technique
+    production: Production
+    production_personnel: Production personnel
+    profession_or_function: Profession or function
+    provenance: Provenance
+    provenance_notes: Provenance notes
+    pseudonym: Pseudonym
+    public_note: Public note
+    publisher: Publisher
+    publisher_copyist: Publisher, copyist
+    publishing_printing_production: Publishing, printing and production information
+    range_dates: Range of dates
+    record_actions: Record actions
+    record_audit: RECORD AUDIT
+    record_origin: Record origin
+    record_status: Record status
+    reference_record_id: REFERENCE RECORD ID
+    references: References
+    references_and_notes: References and notes
+    region_active: Region active
+    region_of_activity: Region of activity
+    related_institution: Related institution
+    related_personal_name: Related personal name
+    related_place: Related place
+    related_resources: Related resources
+    related_titles: Related Titles
+    related_to: Related to
+    related_work: Related work
+    relation: Relation
+    relations: Relations
+    religious_name: Religious name
+    religious_order: Religious order
+    reproduction: Reproduction
+    research_institute: Research institute
+    retrospective_conversion: Retrospective conversion
+    rism_id_number: RISM ID number
+    role: Role
+    scoring_in_movement: Scoring in movement
+    scoring_summary: Scoring summary
+    scribe: Scribe
+    secondary_literature: Secondary literature
+    series: Series
+    series_added_entry: Series added entry fields
+    series_statement: Series statement fields
+    set: Set
+    shelfmark: Shelfmark
+    shelfmark_olim: Shelfmark (olim)
+    short_title: Short title
+    sigla: Sigla
+    siglum: Siglum
+    single_date: Single date
+    sister_of: Sister of
+    sketches: Sketches
+    solo_voice: Solo voice
+    soloist_instrument: Soloist intrument
+    source_data_found: Source data found
+    source_data_not_found: Source data not found
+    source_description: Source of description note
+    source_details: Source details
+    source_number_code: Source of number or code
+    source_of_acquisition_note: Source of acquisition note
+    source_type: Source type
+    special_production_technique: Special production technique
+    standard: Standard
+    standard_musical_terms: Standard music terms
+    standard_number_code: Standard number or code
+    standard_texts_sacred_works: Standard texts of sacred works
+    standard_watermarks: Standard watermarks
+    standardized_title: Standardized title
+    standardized_titles_printed_music: Standardized titles for printed music
+    standardized_titles_subject_headings: Standardized titles - Subject headings
+    street_address: Street address
+    strings: Strings
+    subheading: Subheading
+    subheading_general: Subheading General subdivision
+    subject_access_fields: Subject access fields
+    subject_heading: Subject heading
+    subject_headings: Subject headings
+    subordinate_unit: Subordinate unit
+    succeeding_entry: Succeeding entry
+    summary: Summary
+    supplementary_material: Supplementary material
+    technical_errors: Technical errors
+    technical_production: Technical production
+    temp_val: Temp val
+    templates: Templates
+    terms_voices_instruments: RISM Instrument abbreviations
+    text_author: Text author
+    text_incipit: Text incipit
+    third_fourth_group: Third/fourth group
+    time_signature: Time signature
+    title: Title
+    title_content_description: Title and content description
+    title_item: Title of item
+    title_movement_tempo: Title of movement, tempo
+    title_of_work: Title of work
+    title_on_source: Title on source
+    title_periodical_book_series: Title of periodical, book, or series
+    title_related_fields: Title and title-related fields
+    title_section_part: Title of section or part
+    title_variants: Title variants
+    titles_text_incipits: Titles/text incipits
+    topical_term: Topical Term
+    total_scoring: Total scoring
+    transcribing_agency: Transcribing agency
+    translation: Translation
+    translator: Translator
+    transparency: Transparency
+    type: Type
+    type_institution: Type of institution
+    type_name_variant: Type of name variant
+    type_publication: Type of publication
+    type_relationship: Type of relationship
+    typescript: Typescript
+    typography: Typography
+    unknown: Unknown
+    unparsed_fingerprint: Unparsed fingerprint
+    variant_ms_title: Variant title on manuscript
+    variant_source_title: Variant title on source
+    variations: Variations
+    vocalist: Vocalist
+    voice_instrument: Voice/instrument
+    volume_year_page: Volume, year, page
+    watermark_description: Watermark description
+    woodwinds: Woodwinds
+    work: Work
+    work_number: Work number
+    year: Year
+    years_birth_death: Years of birth and death

--- a/config/locales/marc_records/es.yml
+++ b/config/locales/marc_records/es.yml
@@ -1,0 +1,786 @@
+es:
+  general:
+    e_mail: E-mail
+    editor_help: Ayuda del editor
+    faq: Preguntas frecuentes
+    female: femenino
+    how_do_i: ¿Cómo hago ...? Sugerencias y trucos
+    index_marc_fields: Índice de campos MARC
+    male: masculino
+    marc_tag_index: Índice de etiquetas MARC
+    'no': 'No'
+    rism: RISM
+    rism_best_practices: Mejores prácticas en RISM
+    rism_instrument_abbreviations: Abreviaturas de instrumentos de RISM
+    rism_series: Serie RISM
+    rism_series_a_b_references: Referencias a las Series RISM A/I y B
+    rism_series_number: Número de serie RISM
+    rule_type: Tipo de regla
+    scope_printed_music_rism: Cobertura de la música impresa en RISM
+    searching: Búsqueda
+    status: Estado
+    undetermined: Indeterminado
+    ungrouped_fields: Campos no agrupados
+    unknown_fields: Campos desconocidos
+    unused: EN DESUSO - SERÁ REMOVIDO
+    uri: URI
+    url: URL
+    using_muscat: Uso de Muscat
+    validity: Validez
+    verified: Verificada
+    when_to_input_new_record: Cuándo crear un nuevo registro (música impresa)
+    workflow: Flujo de trabajo
+    'yes': Sí
+  languages:
+    afrikaans: Afrikáans
+    arabic: Árabe
+    aragonese: Aragonés
+    armenian: Armenio
+    basque: Vasco
+    bosnian: Bosnio
+    bulgarian: Búlgaro
+    catalan: Catalán
+    celtic_other: Céltico (otros)
+    chinese: Chino
+    creoles_pidgins_other: Creoles y Pidgins (otros)
+    croatian: Croata
+    czech: Checo
+    danish: Danés
+    dutch: Holandés
+    english: Inglés
+    estonian: Estonio
+    ethiopic: Etiópico
+    finnish: Finés
+    french: Francés
+    french_middle: Francés, Medio (ca. 1300-1600)
+    french_old: Francés, antiguo (ca. 842-1300)
+    gallician: Galego
+    german: Alemán
+    german_old_high: Alemán culto antiguo (aprox. 750-1050)
+    germanic: Germánico
+    greek_ancient: Griego, Antiguo (hasta 1453)
+    greek_modern: Griego moderno (1453-)
+    hebrew: Hebreo
+    hungarian: Húngaro
+    icelandic: Islandés
+    insari_sami: Inari Sami
+    irish: Irlandés
+    italian: Italiano
+    korean: Coreano
+    latin: Latín
+    latvian: Letón
+    lithuanian: Lituano
+    low_german: Bajo alemán
+    lower_sorbian: Sorbio, Bajo Sorbio
+    luxembourgish: Luxemburgués
+    macedonian: Macedonio
+    maori: Maorí
+    middle_english: Inglés medio
+    middle_high_german: Alto alemán medio
+    mongolian: Mongol
+    neapolitan: Napolitano
+    north_frisian: Frisón septentrional
+    norwegian: Noruego
+    occitan: Occitano
+    oirat: Oirato
+    old_church_slavonic: Antiguo eslavo eclesiástico
+    persian: Persa
+    polish: Polaco
+    portugese: Portugués
+    romani: Romaní
+    romanian: Rumano
+    romansh: Reto-romano
+    russian: Ruso
+    sanskrit: Sánscrito
+    scots: Scozzese
+    serbian: Serbio
+    sichuan_yi: Sichuan Yi
+    sicilian: Siciliano
+    slavic: Eslavo
+    slovak: Eslovaco
+    slovenian: Esloveno
+    sorbian: Sorbio
+    spanish: Español
+    swedish: Sueco
+    swiss_german: Suizo-alemán
+    tagalog: Tagalog
+    tartar: Tártaro
+    thai: Tailandés
+    tibetan: Tibetano
+    tsimshian: Tsimshian
+    turkish: Turco
+    ukrainian: Ucraniano
+    upper_sorbian: Sorbio, Alto Sorbio
+    vietnamese: Vietnamita
+    welsh: Galés
+    west_frisian: Frisón occidental
+    yiddish: Yidis
+  places:
+    algeria: Argelia
+    andorra: ANDORRA
+    argentina: Argentina
+    armenia: Armenia
+    australia: Australia
+    austria: Austria
+    austria_carinthia: 'Austria: Carintia'
+    austria_lower_austria: 'Austria: Baja Austria'
+    austria_salzburg: 'Austria: Salzburgo'
+    austria_styria: 'Austria: Estiria'
+    austria_tyrol: 'Austria: Tirol'
+    austria_upper_austria: 'Austria: Alta Austria'
+    austria_vienna: 'Austria: Viena'
+    belgium: Bélgica
+    benin: Benín
+    brazil: Brasil
+    bulgaria: Bulgaria
+    cambodia: Camboya
+    canada: Canadá
+    chile: Chile
+    china: China
+    colombia: Colombia
+    croatia: Croacia
+    cuba: Cuba
+    czech_republic: República Checa
+    denmark: Dinamarca
+    ecuador: Ecuador
+    egypt: Egipto
+    estonia: Estonia
+    finland: Finlandia
+    france: Francia
+    georgia: Georgia
+    germany: Alemania
+    germany_bavaria: 'Alemania: Bavaria'
+    germany_saxony: 'Alemania: Sajonia'
+    greece: Grecia
+    guatemala: ''
+    guinea: Guinea
+    holy_see: Santa Sede
+    honduras: Honduras
+    hong_kong: Hong Kong
+    hungary: Hungría
+    iceland: Islandia
+    india: India
+    indonesia: Indonesia
+    iran: Irán, República Islámica de
+    iraq: ''
+    ireland: Irlanda
+    israel: Israel
+    italy: Italia
+    italy_trentino_alto_adige: 'Italia: Trentino-Alto Adigio'
+    japan: Japón
+    korea: Corea, República de
+    latvia: Letonia
+    lithuania: Lituania
+    luxembourg: Luxemburgo
+    malta: Malta
+    mexico: México
+    moldavia: Moldavia
+    monaco: Mónaco
+    montenegro: Montenegro
+    netherlands: Países Bajos
+    new_zealand: Nueva Zelanda
+    northern_ireland: Irlanda del Norte
+    norway: Noruega
+    papua_new_guinea: Papúa Nueva Guinea
+    paraguay: Paraguay
+    peru: Perú
+    philippines: Filipinas
+    poland: Polonia
+    portugal: Portugal
+    puerto_rico: Puerto Rico
+    romania: Rumania
+    russian_federation: Federación Rusa
+    saudi_arabia: Arabia Saudita
+    serbia: Serbia
+    slovakia: Eslovaquia
+    slovenia: Eslovenia
+    south_africa: Sudáfrica
+    spain: España
+    sweden: Suecia
+    switzerland: Suiza
+    switzerland_vaud: 'Suiza: cantón de Vaud'
+    syrian_arab_republic: República Árabe Siria
+    taiwan: Taiwán (Provincia de China)
+    trinidad_tobego: Trinidad y Tobago
+    turkey: Turquía
+    uk: Reino Unido
+    ukraine: Ucrania
+    uruguay: Uruguay
+    usa: Estados Unidos de América
+    venezuela: Venezuela, República Bolivariana de
+    vietnam: Vietnam
+  records:
+    a_major: La Mayor
+    a_minor: La menor
+    abbreviations: Abreviaturas
+    abbreviations_terminology: Abreviaturas y terminología
+    access_restrictions: Restricciones de acceso
+    accession_number: Número de accesión
+    added_entry_name: ''
+    additional_author: Autor adicional
+    additional_bibliographic_information: Información bibliográfica adicional
+    additional_biographical_information: Información biográfica adicional
+    additional_choir_voice: Voz en coro adicional
+    additional_institution: Institución adicional
+    additional_personal_name: Nombre personal adicional
+    additional_personal_name_lit: Nombre personal adicional
+    additional_solo_voice: Voz solista adicional
+    additional_title: Título adicional
+    additional_title_lit: Título adicional
+    administration: Administración
+    af_major: La bemol Mayor
+    af_minor: La bemol menor
+    aide: Asistencia
+    aids: Asistencia
+    alleged: Supuesta
+    alternate_spelling: Ortografía alternativa
+    archive: Archivo
+    arrangement: Arreglo
+    arrangement_statement: Declaración de arreglo
+    arranger: Arreglador
+    artist: Artista
+    artistic_production: Producción artística
+    as_major: La sostenido Mayor
+    as_minor: La sostenido menor
+    ascertained: Certificada
+    assignee: Asignatario
+    associated_institution: Institución asociada
+    associated_name: Nombre asociado
+    associated_name_lit: Nombre asociado
+    associated_place: Lugar asociado
+    attribution_qualifier: Calificador de atribución
+    authentication_code: Código de autenticación
+    author: Autor
+    author_editor: Autor/editor
+    authorities: Autoridades
+    authority_agency: Agencia de autoridad
+    authority_reference: Referencia de autoridad
+    autography: Autografía
+    b_major: Si Mayor
+    b_minor: Si menor
+    baptismal_name: Nombre bautismal
+    basic_functions: Funciones básicas
+    basso_continuo: Bajo continuo
+    bf_major: Si bemol Mayor
+    bf_minor: Si bemol menor
+    bibliographic_reference: Referencia bibliográfica
+    binder: Encuadernador
+    binding_note: Nota de encuadernación
+    birth_name: Nombre de nacimiento
+    book_format: Formato de libro
+    bookseller: Librero
+    bound_with: Encuadernado con
+    brass_instruments: Vientos-metal
+    brief: ''
+    brother_of: Hermano de
+    byname: Apodo
+    c_major: Do Mayor
+    c_minor: Do menor
+    c_minus_1: C-1
+    c_minus_2: C-2
+    c_minus_3: C-3
+    c_minus_4: C-4
+    c_minus_5: C-5
+    c_plus_1: C+1
+    c_plus_2: C+2
+    c_plus_3: C+3
+    c_plus_4: C+4
+    c_plus_5: C+5
+    catalog_opus_number: ''
+    catalog_works: Catálogo de obras
+    cataloging_agency: Agencia catalogadora
+    cataloging_collection_convoluta: Catalogación de colecciones y volúmenes compuestos
+    cataloging_collections: Catalogación de colecciones
+    cataloging_forms: Formularios de catalogación
+    cataloging_language: Idioma de catalogación
+    cataloging_level: Nivel de catalogación
+    cataloging_musical_sources: Catalogación de fuentes musicales
+    cataloging_source: Fuente de la catalogación
+    category: Categoría
+    censor: Censor
+    cf_major: Do bemol Mayor
+    cf_minor: Do bemol menor
+    child_of: hijo/a de
+    choir_voice: Voz en coro
+    choreographer: Coreógrafo
+    chronological_subdivision: Subdivisión cronológica
+    chronological_term: Término cronológico
+    city: Ciudad
+    clef: Clave
+    co-composer: Co-compositor
+    coded_date: Fecha codificada
+    coded_instrumentation: Intrumentación codificada
+    collaborator: Colaborador
+    colophon: Colofón
+    common_clefs: Claves comunes
+    compiler: Compilador
+    composer: Compositor
+    composer_author: Compositor/Autor
+    composer_cross_reference: Referencia cruzada de compositor
+    computer_printout: Impreso de computadora
+    conceptor: Autor del concepto
+    conductor: Director musical
+    confused_with: Confundido/a con
+    conjectural: Conjetural
+    contact: Contacto
+    contact_area: Contacto
+    content: Contenido
+    content_description: Descripción del contenido
+    contents_note: Nota sobre el contenido
+    contributor: Colaborador
+    control_fields: Campos de control
+    control_number_identifier: Identificador del número de control
+    copy_examined: Copia examinada para la catalogación
+    copyist: Copista
+    copyright_holder: Titular de los derechos de copia
+    costume_designer: Vestuarista
+    countries_places: Países y lugares
+    country: País
+    country_active: País de actividad
+    country_activity: País de actividad
+    country_code: Código de país
+    country_of_publication: País de publicación
+    county_province: País o provincia
+    creation_production_note: Nota de producción/creación
+    cs_major: Do sostenido Mayor
+    cs_minor: Do sostenido menor
+    d_major: Re Mayor
+    d_minor: Re menor
+    dancer: Bailarín(a)
+    date: Fecha
+    date_of_acquisition: Fecha de adquisición
+    date_of_creation: Fecha de creación
+    date_time_last_transaction: Fecha y hora de la última transacción
+    date_type: Tipo de fecha
+    dates: Fechas
+    dedicatee: Dedicatario(a)
+    department: Departamento
+    depositor: Depositante
+    description: Decripción
+    description_area: Descripción
+    description_summary: Descripción sumaria
+    designer: Diseñador
+    df_major: Re bemol Mayor
+    df_minor: Re bemol menor
+    digitized_music: Música digitalizada
+    digitized_source: Fuente digitalizada
+    dimensions: Dimensiones
+    diplomatic_title: Título diplomático
+    dissertation_note: Nota de disertación
+    distribution: Distribución
+    distributor: Distribuidor
+    documentation_center: ''
+    donor: Donante
+    doubtful: Dudosa
+    dramatic_roles_original: Nombres de personajes, ortografía original
+    dramatic_roles_standardized: Nombres de personajes, normalizados
+    ds_major: Re sostenido Mayor
+    ds_minor: Re sostenido menor
+    dubious: Dudoso
+    e_major: Mi Mayor
+    e_minor: Mi menor
+    ecclesiastical_modes: Modos eclesiásticos
+    edition: Edición
+    edition_imprint_fields: Campos para los datos editoriales
+    edition_statement: Declaración de edición
+    editor: Editor (curador)/Editorial
+    ef_major: Mi bemol Mayor
+    ef_minor: Mi bemol menor
+    engraver: Grabador
+    engraving: Grabado
+    event_organizer: Organizador del evento
+    event_place: Lugar del evento
+    excerpts: Extractos
+    extent: Extensión
+    extent_parts: Extensión (particellas)
+    external_resource: Recurso externo
+    external_resource_uri: URI del recurso externo
+    external_resource_url: URL del recurso externo
+    f_major: Fa Mayor
+    f_minor: Fa menor
+    f_minus_1: F-1
+    f_minus_2: F-2
+    f_minus_3: F-3
+    f_minus_4_bass: F-4 (clave de bajo)
+    f_minus_5: F-5
+    f_plus_1: F+1
+    f_plus_2: F+2
+    f_plus_3: F+3
+    f_plus_4: F+4
+    f_plus_5: F+5
+    facsimile: Facsímil
+    family_name: Apellido
+    father_of: padre de
+    figured_bass_scores: Bajo cifrado
+    fijian: Fijiano
+    fingerprint_identifier: Identificador tipográfico
+    first_second_group: Primero/segundo grupo
+    form_subdivision: Subdivisión de forma
+    format_extent: Formato, extensión
+    former_owner: Propietario anterior
+    fragments: Fragmentos
+    friulano: Friulano
+    fs_major: Fa sostenido Mayor
+    fs_minor: Fa sostenido menor
+    full: Completo
+    function: Función
+    further_information: Información suplementaria
+    g_major: Sol Mayor
+    g_minor: Sol menor
+    g_minus_1: G-1
+    g_minus_2_octave: g-2 (clave de sol octava baja)
+    g_minus_2_treble: G-2(clave aguda estándar)
+    g_minus_3: G-3
+    g_minus_4: G-4
+    g_minus_5: G-5
+    g_plus_1: G+1
+    g_plus_2: G+2
+    g_plus_3: G+3
+    g_plus_4: G+4
+    g_plus_5: G+5
+    gender: Género
+    general_abbreviations: Abreviaturas y términos generales
+    general_cataloguing_guidelines: Lineamientos generales para la catalogación
+    general_note: Nota general
+    general_note_incipits: Nota general
+    general_note_institution: Nota general
+    general_note_personal: Nota general
+    geographic_name: Nombre geográfico
+    geographic_subdivision: Subdivisión geográfica
+    gf_major: Sol bemol Mayor
+    gf_minor: Sol bemol menor
+    gs_major: Sol sostenido menor
+    gs_minor: Sol sostenido menor
+    heading: Encabezado
+    heading_composer_name: Compositor
+    heading_personal_name: Nombre personal
+    heading_personal_name1: Nombre personal principal
+    help_transposing_instruments: Ayuda para instrumentos transpositores
+    history_institution: Historia de la institución
+    holdings_location: Campos de los ejemplares y su ubicación
+    identity: Identidad
+    identity_area: Identidad
+    iiif_manifest: Manifiesto IIIF
+    illustrator: Ilustrador
+    images: Imágenes
+    import: Importación
+    imprint: Datos editoriales
+    incipit: Íncipit
+    incipit_number: Número de íncipit
+    incipits: Íncipits
+    index_terms: Términos de indexación
+    information_found: Información encontrada
+    initial: Iniciales
+    initial_entry: Entrada inicial
+    initials: Iniciales
+    insertions: Inserciones
+    inserts: Inserciones
+    institution: Institución
+    institutions: Instituciones
+    instrumentalist: Instrumentista
+    internal_note: Nota interna
+    introduction: Introducción
+    isbn: ISBN
+    ismn: ISMN
+    issn: ISSN
+    item_in_collection: Ítems en esta fuente
+    item_part_of: Ítem integrante de
+    items_in_source: Ítems en esta fuente
+    japanese: Japonés
+    key: Tonalidad
+    key_or_mode: Tonalidad o modo
+    key_signature: Armadura de clave
+    keyboards: ''
+    keys: Tonalidades
+    language_code: Código de idioma
+    language_codes: Código de idioma
+    language_libretto: Idioma del libreto
+    language_note: Nota de idioma
+    language_of_cataloging: Idioma de catalogación
+    language_original_text: Idioma del texto original
+    language_text: Idioma del texto
+    latitude: Latitud
+    leader: Líder
+    library: Repositorio
+    library_information: Información del repositorio
+    library_information_relations: Información del repositorio y sus relaciones
+    library_siglum: Sigla del repositorio
+    librettist: Libretista
+    licensee: Licenciatario
+    life_dates: Fechas de nacimiento y muerte
+    link_type: Tipo de enlace
+    linkage: Vínculos
+    linking_entry_fields: Campos de entrada de vínculos
+    literature: Bibliografía
+    lithograph: Litógrafo
+    lithographer: Litógrafo
+    lithography: Litografía
+    liturgical_festival: Festividad litúrgica
+    liturgical_festivals: Festividades litúrgicas
+    local_id_number: Número local
+    local_note_field: Campo de nota local
+    local_notes_field: Campo de notas locales
+    local_number: Número local
+    location: Lugar
+    location_and_address: Ubicación y dirección
+    location_insertion: Ubiación de la inserción
+    location_on_source: Ubicaciones en la fuente
+    location_performance: Lugar de interpretación
+    location_printer: Lugar de impresión
+    longitude: Longitud
+    lyricist: Letrista
+    main_entry_fields: Campos principales
+    married_name: Apellido de casada/o
+    married_to: casado/a con
+    married_with: casado/a con
+    material_description: Descripción del material
+    material_examined: Material examinado
+    material_held: Material conservado
+    material_not_examined: Material no examinado
+    media_type: Tipo de medio físico
+    mensural_clefs: Claves mensurales
+    method_of_acquisition: Método de adquisición
+    misattributed: Mal atribuida
+    miscellaneous: Varios
+    mode_10t: 'Modo: 10º tono (Hipoeólico)'
+    mode_10tt: 'Modo: 10º tono (Hipoeólico), transpuesto'
+    mode_11t: 'Modo:  11º tono (Jónico)'
+    mode_11tt: 'Modo:  11º tono (Jónico), transpuesto'
+    mode_12t: 'Modo:  12º tono (Hipojónico)'
+    mode_12tt: 'Modo:  12º tono (Hipojónico), transpuesto'
+    mode_1t: 'Modo: 1º tono (Dórico)'
+    mode_1tt: 'Modo: 1º tono (Dórico), transpuesto'
+    mode_2t: 'Modo:  2º tono (Hipodórico)'
+    mode_2tt: 'Modo:  2º tono (Hipodórico), transpuesto'
+    mode_3t: 'Modo:  3º tono (Frigio)'
+    mode_3tt: 'Modo:  3º tono (Frigio), transpuesto'
+    mode_4t: 'Modo:  4º tono (Hipofrigio)'
+    mode_4tt: 'Modo:  4º tono (Hipofrigio), transpuesto'
+    mode_5t: 'Modo:  5º tono (Lidio)'
+    mode_5tt: 'Modo:  5º tono (Lidio), transpuesto'
+    mode_6t: 'Modo:  6º tono (Hipolidio)'
+    mode_6tt: 'Modo:  6º tono (Hipolidio), transpuesto'
+    mode_7t: 'Modo:  7º tono (Mixolidio)'
+    mode_7tt: 'Modo:  7º tono (Mixolidio), transpuesto'
+    mode_8t: 'Modo:  8º tono (Hipomixolidio)'
+    mode_8tt: 'Modo:  8º tono (Hipomixolidio), transpuesto'
+    mode_9t: 'Modo:  9º tono (Eólico)'
+    mode_9tt: 'Modo:  9º tono (Eólico), transpuesto'
+    modifying_agency: Agencia de la modificación
+    monogram: Monograma
+    mother_of: madre de
+    movement_number: Número de movimiento
+    multiple: Múltiples
+    multiple_copies: Múltiples ejemplares en una institución
+    multiple_single_dates: Fechas múltiples
+    museum: ''
+    music_incipit: Íncipit musical
+    name: Nombre
+    name_family: Apellido
+    name_printer: Nombre del impresor
+    name_variant: Variantes del nombre
+    name_variants: Variantes del nombre
+    named_dramatic_roles: Nombres de personajes
+    nationality: Nacionalidad
+    nickname: Apodo
+    no_linguistic_content: Sin contenido lingüístico
+    non_migrated_bound: Non-migrated bound with value from 563
+    note_external_resource: Nota sobre el recurso externo
+    note_fields: Campos de notas
+    note_on_performance: Nota sobre ocasión de interpretación
+    now_in: Actualmente en
+    number: Número
+    number_page: Número/página
+    number_part_section: Número de parte/sección de una obra
+    number_volume_part: Número de volúmen/parte
+    numbers_code_fields: Números y campos de código
+    octoechos1: 'Octoechos 1: Ēchos prōtos (Primer modo bizantino)'
+    octoechos2: 'Octoechos 2: Ēchos deuteros (Segundo modo bizantino)'
+    octoechos3: 'Octoechos 3: Ēchos tritos (Tercer modo bizantino)'
+    octoechos4: 'Octoechos 4: Ēchos tetartos (Cuarto modo bizantino)'
+    octoechos5: 'Octoechos 5: Ēchos plagios prōtos (Primer modo bizantino plagal)'
+    octoechos6: 'Octoechos 6: Ēchos plagios deuteros (Segundo modo bizantino plagal)'
+    octoechos7: 'Octoechos 7: Ēchos barys (Tercer modo bizantino plagal)'
+    octoechos8: 'Octoechos 8: Ēchos plagios tetartos (Cuarto modo bizantino plagal)'
+    online_finding_aids: Guías del archivo online
+    opera_houses_concert_halls: Teatros de ópera y salas de concierto
+    opus_number: Número de Opus
+    opus_thematic_index_number: Número de Opus/Índice temático
+    order_name: Nombre religioso
+    origin: Origen
+    original_cataloging_agency: Agencia de catalogación original
+    other: Otra función
+    other_form: Ortografía alternativa
+    other_form_of_name: Otra forma del nombre
+    other_function: Otra función
+    other_help: Otra Ayuda
+    other_instruments: Otros instrumentos
+    other_life_dates: Otras fechas de vida
+    other_physical_details: Otros detalles físicos
+    other_searchform: Otra variante
+    other_shelfmark: Otra signatura
+    other_standard_identifier: Otro identificador estándar
+    other_variant: Otra variante
+    paper_maker: Fabricante de papel
+    papermaker: Fabricante de papel
+    parallel_form: Forma paralela de nombre
+    parent_record: Registro madre
+    parts_held: Particellas conservadas
+    parts_held_extent: Particellas conservadas y extensión de las mismas
+    patron: Comitente
+    people_institutions: Personas e instituciones
+    percussion: ''
+    performance: Interpretación
+    performances: Interpretaciones
+    performer: Intérprete
+    performer_note: Nota sobre ocasión de interpretación
+    person: Persona
+    person_name: Nombre personal
+    personal_name: Nombre de pila
+    personal_names: Nombres personales
+    photoreproductive_process: Proceso fotoreproductivo
+    physical_description: Descripción física
+    physical_description_fields: Campos para la descripción Material
+    place: Lugar
+    place_active: Lugar de actividad
+    place_activity: Lugar de actividad
+    place_birth: Lugar de nacimiento
+    place_death: Lugar de fallecimiento
+    place_origin: Lugar de origen
+    place_publication: Lugar de publicación
+    places: Lugares
+    plate_number: Número de plancha
+    plucked_instruments: Cuerdas pulsadas
+    postal_code: Código postal
+    postal_place: Dirección postal
+    preceding_entry: Registro precedente
+    printer: Impresor
+    printing_technique: Técnica de impresión
+    production: Producción
+    production_personnel: Personal de producción
+    profession_or_function: Profesión o función
+    provenance: Procedencia
+    provenance_notes: Nota de procedencia
+    pseudonym: Seudónimo
+    public_note: Nota pública
+    publisher: Editor (publicador)/Editorial (publicadora)
+    publisher_copyist: Editor, copista
+    publishing_printing_production: Información de publicación, impresión y producción
+    range_dates: Rango de fechas
+    record_actions: Acciones del registro
+    record_audit: RECORD AUDIT
+    record_origin: Origen del registro
+    record_status: Estado del registro
+    reference_record_id: ID del Registro de Referencia
+    references: Bibliografía
+    references_and_notes: Referencias y notas
+    region_active: Región de actividad
+    region_of_activity: Región de actividad
+    related_institution: Institución relacionada
+    related_personal_name: Nombre personal relacionado
+    related_place: Lugar relacionado
+    related_resources: Recursos relacionados
+    related_titles: Títulos relacionados
+    related_to: relacionado/a con
+    related_work: Obra relacionada
+    relation: Relación
+    relations: Relaciones
+    religious_name: Nombre religioso
+    religious_order: Orden religiosa
+    reproduction: Reproducción
+    research_institute: Institución
+    retrospective_conversion: Conversión retrospectiva
+    rism_id_number: Número de ID de RISM
+    role: Personaje
+    scoring_in_movement: Plantilla/orgánico del movimiento
+    scoring_summary: Resumen de Plantilla/Orgánico
+    scribe: Copista
+    secondary_literature: Bibliografía secundaria
+    series: Serie
+    series_added_entry: Entradas adicionales de la serie
+    series_statement: Información de serie
+    set: Grupo de materiales
+    shelfmark: Signatura
+    shelfmark_olim: Signatura antigua (olim)
+    short_title: Título breve
+    sigla: Sigla
+    siglum: Sigla
+    single_date: Fecha única
+    sister_of: hermana de
+    sketches: Bosquejos
+    solo_voice: Voz solista
+    soloist_instrument: Instrumento solista
+    source_data_found: Fuente de los datos encontrados
+    source_data_not_found: Fuente de los datos no encontrados
+    source_description: Copia examinada para la catalogación
+    source_details: Detalles de la fuente
+    source_number_code: Fuente de número o código
+    source_of_acquisition_note: Nota sobre la fuente de adquisición
+    source_type: Tipo de fuente
+    special_production_technique: Técnica de producción específica
+    standard: Estándar
+    standard_musical_terms: Términos musicales estándar
+    standard_number_code: Número o código estándar
+    standard_texts_sacred_works: Textos estándar de obras sacras
+    standard_watermarks: Marcas de agua estándar
+    standardized_title: Título uniforme
+    standardized_titles_printed_music: Títulos uniformes para música impresa
+    standardized_titles_subject_headings: Títulos uniformes – Descriptores
+    street_address: Calle y número
+    strings: Cuerdas
+    subheading: Tipo especial de fuente
+    subheading_general: Subdivisión general
+    subject_access_fields: Campos de los puntos de acceso
+    subject_heading: Descriptor
+    subject_headings: Descriptores
+    subordinate_unit: Unidad subordinada
+    succeeding_entry: Entrada siguiente
+    summary: Resumen
+    supplementary_material: Material suplementario
+    technical_errors: Problemas técnicos
+    technical_production: Producción técnica
+    temp_val: Temp val
+    templates: Plantillas
+    terms_voices_instruments: Terminología para voces e instrumentos
+    text_author: Autor del texto
+    text_incipit: Íncipit literario
+    third_fourth_group: Tercero/cuarto grupo
+    time_signature: Indicación de compás
+    title: Título
+    title_content_description: Título y descripción del contenido
+    title_item: Título del ítem
+    title_movement_tempo: Título del movimiento, tempo
+    title_of_work: Título de la obra
+    title_on_source: Título en fuente (diplomático)
+    title_periodical_book_series: Título del periódico, libro o serie
+    title_related_fields: Título y campos relacionados
+    title_section_part: Título de la sección o parte
+    title_variants: Variantes del título
+    titles_text_incipits: Títulos/íncipits literarios
+    topical_term: Término temático
+    total_scoring: Plantilla/orgánico total
+    transcribing_agency: Agencia de la transcripción
+    translation: Traducción
+    translator: Traductor
+    transparency: Transparencia
+    type: Tipo
+    type_institution: Tipo de institución
+    type_name_variant: Tipo de variante de nombre
+    type_publication: Tipo de publicación
+    type_relationship: Tipo de relación
+    typescript: Escrito mecanografiado
+    typography: Tipografía
+    unknown: Desconcido
+    unparsed_fingerprint: Identificador tipográfico no disgregado
+    variant_ms_title: Variante de título en fuente
+    variant_source_title: Variante de título en fuente
+    variations: Variaciones
+    vocalist: Cantante
+    voice_instrument: Voz/instrumento
+    volume_year_page: Volumen, año, página
+    watermark_description: Descripción de las filigranas
+    woodwinds: Vientos-madera
+    work: Obra
+    work_number: Número de obra
+    year: Año
+    years_birth_death: Años de nacimiento y muerte

--- a/config/locales/marc_records/fr.yml
+++ b/config/locales/marc_records/fr.yml
@@ -1,0 +1,790 @@
+fr:
+  general:
+    e_mail: E-mail
+    editor_help: Aide pour l'editor
+    faq: Foire aux questions
+    female: femme
+    how_do_i: Comment puis-je ... Trucs et astuces
+    index_marc_fields: Index des champs MARC
+    male: homme
+    marc_tag_index: Index des codes MARC
+    'no': Non
+    rism: RISM
+    rism_best_practices: Meilleures pratiques RISM
+    rism_instrument_abbreviations: Abréviations RISM pour les instruments (suite)
+    rism_series: Série RISM
+    rism_series_a_b_references: Référence au RISM A/I et B
+    rism_series_number: Numéro RISM
+    rule_type: Règle de cat.
+    scope_printed_music_rism: Portée de la documentation des impressions musicales
+      dans RISM
+    searching: Recherche
+    status: Status
+    undetermined: Indéterminé
+    ungrouped_fields: Champs non regroupés
+    unknown_fields: Champs non reconnus
+    unused: UNUSED - WILL BE REMOVED
+    uri: URI
+    url: URL
+    using_muscat: Aide de Muscat
+    validity: Validité
+    verified: Vérifié
+    when_to_input_new_record: Quand saisir une nouvelle notice (musique imprimée)
+    workflow: Flux de travail
+    'yes': Oui
+  languages:
+    afrikaans: Afrikaans
+    arabic: Arabe
+    aragonese: Aragonais
+    armenian: Arménien
+    basque: Basque
+    bosnian: Bosnien
+    bulgarian: Bulgare
+    catalan: Catalan
+    celtic_other: Celtique (autre)
+    chinese: Chinois
+    creoles_pidgins_other: Langues créoles et pidgins (autres)
+    croatian: Croate
+    czech: Tchèque
+    danish: Danois
+    dutch: Néerlandais
+    english: Anglais
+    estonian: Estonien
+    ethiopic: Éthiopien
+    finnish: Finlandais
+    french: Français
+    french_middle: Français, Moyen (env. 1300-1600)
+    french_old: Français, ancien (ca. 842-1300)
+    gallician: Galician
+    german: Allemand
+    german_old_high: Allemand, ancien haut (vers 750-1050)
+    germanic: Germanique
+    greek_ancient: Grec ancien (jusqu'en 1453)
+    greek_modern: Grec moderne (1453-)
+    hebrew: Hébraïque
+    hungarian: Hongrois
+    icelandic: Islandais
+    insari_sami: Inari Sami
+    irish: Irlandais
+    italian: Italien
+    korean: Coréen
+    latin: Latin
+    latvian: Letton
+    lithuanian: Lituanien
+    low_german: Bas allemand
+    lower_sorbian: Sorabe, Sorabe inférieur
+    luxembourgish: Luxembourgeois
+    macedonian: Macédonien
+    maori: Maori
+    middle_english: Anglais médiéval
+    middle_high_german: Allemand médiéval
+    mongolian: Mongole
+    neapolitan: Néapolitain
+    north_frisian: Frison du Nord
+    norwegian: Norvégien
+    occitan: Occitan
+    oirat: Oïrate
+    old_church_slavonic: Slave ancien ecclésiastique
+    persian: Persan
+    polish: Polonais
+    portugese: Portugais
+    romani: Romani
+    romanian: Roumain
+    romansh: Rhéto-roman
+    russian: Russe
+    sanskrit: Sanskrite
+    scots: Écosse
+    serbian: Serbe
+    sichuan_yi: Sichuan Yi
+    sicilian: Sicilien
+    slavic: Slave
+    slovak: Slovaque
+    slovenian: Slovène
+    sorbian: Sorabe
+    spanish: Espagnol
+    swedish: Suédois
+    swiss_german: Suisse allemand
+    tagalog: Tagalog
+    tartar: Tatar
+    thai: Thaï
+    tibetan: Tibétain
+    tsimshian: Tsimshian
+    turkish: Turque
+    ukrainian: Ukrainien
+    upper_sorbian: Sorabe, Sorabe supérieur
+    vietnamese: Vietnamien
+    welsh: Gallois
+    west_frisian: Frison occidental
+    yiddish: Yiddish
+  places:
+    algeria: Algeria
+    andorra: Andorre
+    argentina: Argentina
+    armenia: Armenia
+    australia: Australie
+    austria: Autriche
+    austria_carinthia: 'Autriche: Carinthie'
+    austria_lower_austria: 'Autriche: Basse-Autriche'
+    austria_salzburg: 'Autriche: Salzbourg'
+    austria_styria: 'Autriche: Styrie'
+    austria_tyrol: 'Autriche: Tyrol'
+    austria_upper_austria: 'Autriche: Haute-Autriche'
+    austria_vienna: 'Autriche: Vienne'
+    belgium: Belgique
+    benin: Benin
+    brazil: Brésil
+    bulgaria: Bulgarie
+    cambodia: Cambodge
+    canada: Canada
+    chile: Chili
+    china: Chine
+    colombia: Colombia
+    croatia: Croatie
+    cuba: Cuba
+    czech_republic: République Tchèque
+    denmark: Danemark
+    ecuador: Ecuador
+    egypt: Egypte
+    estonia: Estonie
+    finland: Finlande
+    france: France
+    georgia: Géorgie
+    germany: Allemagne
+    germany_bavaria: 'Allemagne: Bavière'
+    germany_saxony: 'Germany: Saxony'
+    greece: Grèce
+    guatemala: Guatemala
+    guinea: Guinée
+    holy_see: Saint-Siège
+    honduras: Honduras
+    hong_kong: Hong Kong
+    hungary: Hongrie
+    iceland: Islande
+    india: Inde
+    indonesia: Indonésie
+    iran: Iran (République islamique d')
+    iraq: Irak
+    ireland: Irlande
+    israel: Israël
+    italy: Italie
+    italy_trentino_alto_adige: 'Italie: Trentin-Haut-Adige'
+    japan: Japon
+    korea: Corée, République de
+    latvia: Lettonie
+    lithuania: Lituanie
+    luxembourg: Luxembourg
+    malta: Malte
+    mexico: Mexique
+    moldavia: Moldavie
+    monaco: Monaco
+    montenegro: Monténégro
+    netherlands: Pays-Bas
+    new_zealand: Nouvelle-Zélande
+    northern_ireland: Irlande du Nord
+    norway: Norvège
+    papua_new_guinea: Papouasie Nouvelle Guinée
+    paraguay: Paraguay
+    peru: Pérou
+    philippines: Philippines
+    poland: Pologne
+    portugal: Portugal
+    puerto_rico: Puerto Rico
+    romania: Romanie
+    russian_federation: Fédération russe
+    saudi_arabia: Arabie Saoudite
+    serbia: Serbie
+    slovakia: Slovaquie
+    slovenia: Slovénie
+    south_africa: Afrique du Sud
+    spain: Espagne
+    sweden: Suède
+    switzerland: Suisse
+    switzerland_vaud: 'Suisse: Vaud'
+    syrian_arab_republic: République arabe syrienne
+    taiwan: Taiwan, Province de Chine
+    trinidad_tobego: Trinité-et-Tobago
+    turkey: Turquie
+    uk: Royaume-Uni
+    ukraine: Ukraine
+    uruguay: Uruguay
+    usa: États-Unis d'Amérique
+    venezuela: Venezuela, République bolivarienne du
+    vietnam: Vietnam
+  records:
+    a_major: La majeur
+    a_minor: La mineur
+    abbreviations: Abbréviations
+    abbreviations_terminology: Abbréviations et terminologie
+    access_restrictions: Restriction d'accès
+    accession_number: Numéro d'acquisition
+    added_entry_name: Nom additionnel
+    additional_author: Auteur supplémentaire
+    additional_bibliographic_information: Référence bibliographique additionnelle
+    additional_biographical_information: Référence biographique additionnelle
+    additional_choir_voice: Voix de choeur additionnelles
+    additional_institution: Nom supplémentaire de la collectivité
+    additional_personal_name: Nom supplémentaire de la personne
+    additional_personal_name_lit: Nom supplémentaire de la personne
+    additional_solo_voice: Voix seule additionnelle
+    additional_title: Titres uniformes additionnels
+    additional_title_lit: Titres uniformes additionnels
+    administration: Administration
+    af_major: La♭ majeur
+    af_minor: La♭ mineur
+    aide: Aide
+    aids: Aide
+    alleged: Présumé
+    alternate_spelling: Autres formes
+    archive: Archives
+    arrangement: Arrangement
+    arrangement_statement: Mention d'arrangement
+    arranger: Arrangeur
+    artist: Metteur en scène
+    artistic_production: Auteur
+    as_major: La♯ majeur
+    as_minor: La♯ mineur
+    ascertained: Authentifié
+    assignee: Cessionnaire
+    associated_institution: Institutions liées
+    associated_name: Nom associé
+    associated_name_lit: Nom associé
+    associated_place: Endroit associé
+    attribution_qualifier: Qualificatif d'attribution
+    authentication_code: Code d'authentification
+    author: Auteur
+    author_editor: Auteur / directeur
+    authorities: Liste d'autorités
+    authority_agency: Agence d'authorité
+    authority_reference: Référence d'authorité
+    autography: Autographie
+    b_major: Si majeur
+    b_minor: Si mineur
+    baptismal_name: Nom baptismale
+    basic_functions: Fonctions de base
+    basso_continuo: Basso continuo
+    bf_major: Si♭ majeur
+    bf_minor: Si♭ mineur
+    bibliographic_reference: Référence bibliographique
+    binder: Relieur
+    binding_note: Reliure
+    birth_name: Nom de naissance
+    book_format: Format du livre
+    bookseller: Libraire
+    bound_with: Relié en
+    brass_instruments: Cuivres
+    brief: Bref
+    brother_of: Frère de
+    byname: Surnom
+    c_major: Do majeur
+    c_minor: Do mineur
+    c_minus_1: C-1
+    c_minus_2: C-2
+    c_minus_3: C-3
+    c_minus_4: C-4
+    c_minus_5: C-5
+    c_plus_1: C+1
+    c_plus_2: C+2
+    c_plus_3: C+3
+    c_plus_4: C+4
+    c_plus_5: C+5
+    catalog_opus_number: No. de catalogue thématique/Opus
+    catalog_works: Catalogue des oeuvres
+    cataloging_agency: Agence de catalogation
+    cataloging_collection_convoluta: Catalogation de recueils et volumes composés
+    cataloging_collections: Catalogation de recueils
+    cataloging_forms: Formulaire de catalogation
+    cataloging_language: Langage de catalogation
+    cataloging_level: Niveau de catalogation
+    cataloging_musical_sources: Catalogation des sources musicales
+    cataloging_source: Source du catalogage
+    category: Type
+    censor: Censeur
+    cf_major: Do♭ majeur
+    cf_minor: Do♭ mineur
+    child_of: Enfant de
+    choir_voice: Voix de choeur
+    choreographer: Chorégraphe
+    chronological_subdivision: Subdivision chronologique
+    chronological_term: Datation
+    city: Ville
+    clef: Clé
+    co-composer: Compositeur secondaire
+    coded_date: Date et lieu d'un événement
+    coded_instrumentation: Instrumentation codée
+    collaborator: Collaborateur
+    colophon: Colophon
+    common_clefs: Clés communes
+    compiler: Compilateur
+    composer: Compositeur
+    composer_author: Compositeur/Auteur
+    composer_cross_reference: Renvoi à un autre compositeur
+    computer_printout: Impression informatique
+    conceptor: Concepteur
+    conductor: Chef d'orchestre
+    confused_with: Confondu avec
+    conjectural: Conjectural
+    contact: Contact
+    contact_area: Contact
+    content: Contenu
+    content_description: Description du contenu
+    contents_note: Note sur le contenu
+    contributor: Collaborateur
+    control_fields: Champs de contrôle
+    control_number_identifier: Identité du numéro de contrôle
+    copy_examined: Copie consultée pour le catalogage
+    copyist: Copiste / Scribe
+    copyright_holder: Titulaire du droit d'auteur
+    costume_designer: Costumier
+    countries_places: Lieux
+    country: Pays
+    country_active: Pays d'activité
+    country_activity: Pays d'activité
+    country_code: Country code
+    country_of_publication: Pays
+    county_province: Canton ou province
+    creation_production_note: Note sur la création/production
+    cs_major: Do♯ majeur
+    cs_minor: Do♯ mineur
+    d_major: Ré majeur
+    d_minor: Ré minor
+    dancer: Danceur
+    date: Date
+    date_of_acquisition: Date d'acquisition
+    date_of_creation: Date de création
+    date_time_last_transaction: Date/heure de la dernière transaction
+    date_type: Type de date
+    dates: Dates
+    dedicatee: Dédicataire
+    department: Section
+    depositor: Dépositeur
+    description: Description
+    description_area: Description
+    description_summary: Description brève
+    designer: Décorateur
+    df_major: Ré♭ majeur
+    df_minor: Ré♭ mineur
+    digitized_music: Source numérisée
+    digitized_source: Source numérisée
+    dimensions: Dimension
+    diplomatic_title: Titre diplomatique
+    dissertation_note: Note à la thèse
+    distribution: Instrumentation
+    distributor: Distributeur
+    documentation_center: Centre de documentation
+    donor: Donateur
+    doubtful: Douteux
+    dramatic_roles_original: Noms originaux des personnages
+    dramatic_roles_standardized: Noms standardisés des personnages
+    ds_major: Ré♯ majeur
+    ds_minor: Ré♯ mineur
+    dubious: Douteux
+    e_major: Mi majeur
+    e_minor: Mi mineur
+    ecclesiastical_modes: Modes ecclésiastiques
+    edition: Edition
+    edition_imprint_fields: Champs pour les données d'édition
+    edition_statement: Edition
+    editor: Editeur
+    ef_major: Mi♭ majeur
+    ef_minor: Mi♭ mineur
+    engraver: Graveur
+    engraving: Gravure
+    event_organizer: Organisateur
+    event_place: Lieu de l'événement
+    excerpts: Extraits
+    extent: Extension
+    extent_parts: Extension (parties)
+    external_resource: Ressource électronique externe
+    external_resource_uri: URI de la ressource électronique externe
+    external_resource_url: URI de la ressource électronique externe
+    f_major: Fa majeur
+    f_minor: Fa mineur
+    f_minus_1: F-1
+    f_minus_2: F-2
+    f_minus_3: F-3
+    f_minus_4_bass: F-4 (clé fa)
+    f_minus_5: F-5
+    f_plus_1: F+1
+    f_plus_2: F+2
+    f_plus_3: F+3
+    f_plus_4: F+4
+    f_plus_5: F+5
+    facsimile: Facsimilé
+    family_name: Nom de famille
+    father_of: Père de
+    figured_bass_scores: Basse chiffrée
+    fijian: Fidjien
+    fingerprint_identifier: Indentificateur d'empreintes
+    first_second_group: Premier/deuxième groupe de caractères
+    form_subdivision: Subdivision de forme
+    format_extent: Type de source, extension
+    former_owner: Propriétaire précédent
+    fragments: Fragments
+    friulano: Frioulan
+    fs_major: Fa♯ majeur
+    fs_minor: Fa♯ mineur
+    full: Complète
+    function: Fonction
+    further_information: Information supplémentaire
+    g_major: Sol majeur
+    g_minor: Sol mineur
+    g_minus_1: G-1
+    g_minus_2_octave: g-2 (octave basse)
+    g_minus_2_treble: G-2 (clé de sol)
+    g_minus_3: G-3
+    g_minus_4: G-4
+    g_minus_5: G-5
+    g_plus_1: G+1
+    g_plus_2: G+2
+    g_plus_3: G+3
+    g_plus_4: G+4
+    g_plus_5: G+5
+    gender: Sexe
+    general_abbreviations: Abbréviations générales et terminologie
+    general_cataloguing_guidelines: Règle de catalogage générales
+    general_note: Remarque générale
+    general_note_incipits: Remarque générale
+    general_note_institution: Remarque générale
+    general_note_personal: Remarque générale
+    geographic_name: Nom géographique
+    geographic_subdivision: Subdivision géographique
+    gf_major: Sol♭ majeur
+    gf_minor: Sol♭ mineur
+    gs_major: Sol♯ majeur
+    gs_minor: Sol♯ mineur
+    heading: Nom de personne
+    heading_composer_name: Compositeur
+    heading_personal_name: Compositeur/Auteur
+    heading_personal_name1: Compositeur/Auteur
+    help_transposing_instruments: Aide pour les instruments transpositeurs
+    history_institution: Historique de l'institution
+    holdings_location: Données sur la collection, le fonds, etc.
+    identity: Identité
+    identity_area: Identité
+    iiif_manifest: Manifeste IIIF
+    illustrator: Illustrateur
+    images: Images
+    import: Dates importés
+    imprint: Données d'édition
+    incipit: Incipit musical
+    incipit_number: No. d'incipit
+    incipits: Incipits
+    index_terms: Termes
+    information_found: Référence pour l'information
+    initial: Initiale
+    initial_entry: Première notice
+    initials: Initiale
+    insertions: Insertions
+    inserts: Insertions
+    institution: Institution
+    institutions: Institution
+    instrumentalist: Instrumentiste
+    internal_note: Note non publique
+    introduction: Introduction
+    isbn: ISBN
+    ismn: ISMN
+    issn: ISSN
+    item_in_collection: Contenu de la collection
+    item_part_of: Fait partie de
+    items_in_source: Contenu de la collection
+    japanese: Japonais
+    key: Tonalité
+    key_or_mode: Tonalité, mode
+    key_signature: Armure
+    keyboards: Instruments à clavier
+    keys: Tonalités
+    language_code: Code de langue
+    language_codes: Codes de langue
+    language_libretto: Langue du livret
+    language_note: Note sur la langue
+    language_of_cataloging: Langue de catalogage
+    language_original_text: Langue du texte original
+    language_text: Langue du texte chanté
+    latitude: Latitude
+    leader: Guide
+    library: Bibliothèque
+    library_information: Bibliothèque
+    library_information_relations: Bibliothèque et relations
+    library_siglum: Sigle de bibliothèque
+    librettist: Librettiste
+    licensee: Licencié
+    life_dates: Dates de vie
+    link_type: Type de lien
+    linkage: Liens
+    linking_entry_fields: Note sur les liens
+    literature: Références
+    lithograph: Litographe
+    lithographer: Litographe
+    lithography: Lithographie
+    liturgical_festival: Fête liturgique
+    liturgical_festivals: Fêtes liturgiques
+    local_id_number: No. local
+    local_note_field: Note locale
+    local_notes_field: Note non publique
+    local_number: No. local
+    location: Lieu
+    location_and_address: Lieu et adresse
+    location_insertion: Remarque sur l'endroit de l'insertion
+    location_on_source: Endroit sur la source
+    location_performance: Lieu d'une exécution
+    location_printer: Lieu d'impression
+    longitude: Longitude
+    lyricist: Parolier
+    main_entry_fields: Champs principales
+    married_name: Nom de mariage
+    married_to: Marié/e avec
+    married_with: Marié/e avec
+    material_description: Description du matériel
+    material_examined: Matériaux examinés
+    material_held: Matériaux préservées
+    material_not_examined: Matériaux non examinés
+    media_type: Moyen physique
+    mensural_clefs: Clés anciennes
+    method_of_acquisition: Méthode d'acquisition
+    misattributed: Erroné
+    miscellaneous: Divers
+    mode_10t: 'Mode: 10t – Hypoéolien'
+    mode_10tt: 'Mode: 10tt – Hypoéolien, transposé'
+    mode_11t: 'Mode: 11t – Ionien'
+    mode_11tt: 'Mode: 11tt – Ionien, transposé'
+    mode_12t: 'Mode: 12t – Hypoionien'
+    mode_12tt: 'Mode: 12tt – Hypoionien, transposé'
+    mode_1t: 'Mode:  1t – Dorien'
+    mode_1tt: 'Mode:  1tt – Dorien, transposé'
+    mode_2t: 'Mode:  2t – Hypodorien'
+    mode_2tt: 'Mode:  2tt – Hypodorien, transposé'
+    mode_3t: 'Mode:  3t – Phrygien'
+    mode_3tt: 'Mode:  3tt – Phrygien, transposé'
+    mode_4t: 'Mode:  4t – Hypophrygien'
+    mode_4tt: 'Mode:  4tt – Hypophrygien, transposé'
+    mode_5t: 'Mode:  5t – Lydien'
+    mode_5tt: 'Mode:  5tt – Lydien, transposé'
+    mode_6t: 'Mode:  6t – Hypolydien'
+    mode_6tt: 'Mode:  6tt – Hypolydien, transposé'
+    mode_7t: 'Mode:  7t – Mixolydien'
+    mode_7tt: 'Mode:  7tt – Mixolydien, transposé'
+    mode_8t: 'Mode:  8t – Hypomixolydien'
+    mode_8tt: 'Mode:  8tt – Hypomixolydien, transposé'
+    mode_9t: 'Mode:  9t – Eolien'
+    mode_9tt: 'Mode:  9tt – Eolien, transposé'
+    modifying_agency: Organisme de la modification
+    monogram: Monogramme
+    mother_of: Mère de
+    movement_number: Numéro du mouvement
+    multiple: Multiple
+    multiple_copies: Exemplaire multiples
+    multiple_single_dates: Dates uniques multiples
+    museum: Musée
+    music_incipit: Incipit musical
+    name: Nom
+    name_family: Nom de famille
+    name_printer: Imprimeur, imprimerie
+    name_variant: Variantes du nom
+    name_variants: Variantes du nom
+    named_dramatic_roles: Personnages nommés
+    nationality: Code du pays
+    nickname: Surnom
+    no_linguistic_content: Sans contenu linguistique
+    non_migrated_bound: Non-migrated bound with value from 563
+    note_external_resource: Remarque sur la ressource externe
+    note_fields: Champs de note
+    note_on_performance: Remarque sur les interprètes
+    now_in: Maintenant à
+    number: Nombre
+    number_page: Numéro/page
+    number_part_section: Numéro de partie / section d'une œuvre
+    number_volume_part: Numéro du volume ou de la partie
+    numbers_code_fields: Numéros et codes
+    octoechos1: 'Octoechos 1: Ēchos prōtos (premier mode dans la musique byzantine)'
+    octoechos2: 'Octoechos 2: Ēchos deuteros (deuxième mode dans la musique byzantine)'
+    octoechos3: 'Octoechos 3: Ēchos tritos (troisième mode dans la musique byzantine)'
+    octoechos4: 'Octoechos 4: Ēchos tetartos (quatrième mode dans la musique byzantine)'
+    octoechos5: 'Octoechos 5: Ēchos plagios prōtos (premier mode plagal dans la musique
+      byzantine)'
+    octoechos6: 'Octoechos 6: Ēchos plagios deuteros (deuxième mode plagal dans la
+      musique byzantine)'
+    octoechos7: 'Octoechos 7: Ēchos barys (troisième mode plagal dans la musique byzantine)'
+    octoechos8: 'Octoechos 8: Ēchos plagios tetartos (quatrième mode plagal dans la
+      musique byzantine)'
+    online_finding_aids: Instruments de recherche online
+    opera_houses_concert_halls: Théâtres et salles de concert
+    opus_number: No. de Opus
+    opus_thematic_index_number: Numéro de opus / du catalogue des oeuvres
+    order_name: Nom d'ordre
+    origin: Origine
+    original_cataloging_agency: Organisme du catalogage original
+    other: Autre function
+    other_form: Autres formes
+    other_form_of_name: Autre forme de nom
+    other_function: Autre fonction
+    other_help: Autres aides
+    other_instruments: Autres instruments
+    other_life_dates: Autres dates
+    other_physical_details: Autres détails du matériau
+    other_searchform: Autre forme de recherche
+    other_shelfmark: Autre cote
+    other_standard_identifier: Référence d'authorité
+    other_variant: Autre forme de recherche
+    paper_maker: Papetier
+    papermaker: Papetier
+    parallel_form: Forme de nom parallèle
+    parent_record: Notice principale
+    parts_held: Parties existantes
+    parts_held_extent: Parties, extension
+    patron: Mécène
+    people_institutions: Personnes et institutions
+    percussion: Percussions
+    performance: Exécuteurs
+    performances: Exécutions
+    performer: Interprète
+    performer_note: Remarque sur les interprètes
+    person: Personne
+    person_name: Nom de la personne
+    personal_name: Nom de la personne
+    personal_names: Noms de personne
+    photoreproductive_process: Reproduction photo (blueprint)
+    physical_description: Description matérielle
+    physical_description_fields: Champs pour la description matérielle
+    place: Lieu
+    place_active: Lieu d'activité
+    place_activity: Lieu d'activité
+    place_birth: Lieu de naissance
+    place_death: Lieu de décès
+    place_origin: Lieu d'origine
+    place_publication: Endroit
+    places: Lieux
+    plate_number: Numéro de plaque
+    plucked_instruments: Instruments à cordes pincées
+    postal_code: Code postal
+    postal_place: Endroit postal
+    preceding_entry: Notice précédente
+    printer: Imprimeur
+    printing_technique: Technique d'impression
+    production: Production
+    production_personnel: Personnel de réalisation
+    profession_or_function: Profession ou fonction
+    provenance: Provenance
+    provenance_notes: Note de provenance
+    pseudonym: Pseudonyme
+    public_note: Note publique
+    publisher: Editeur
+    publisher_copyist: Copiste ou maison d'édition
+    publishing_printing_production: Copie ou données d'édition
+    range_dates: Intervalle de dates
+    record_actions: Actions pour la notice
+    record_audit: RECORD AUDIT
+    record_origin: Origine de la notice
+    record_status: Etat de la notice
+    reference_record_id: Numéro d'identification de la notice de référence
+    references: Références
+    references_and_notes: Références et notes
+    region_active: Région d'activité
+    region_of_activity: Région d'activité
+    related_institution: Institution liée
+    related_personal_name: Nom de personne lié
+    related_place: Lieu lié
+    related_resources: Liens
+    related_titles: Titres liés
+    related_to: Parent de
+    related_work: Ouvrage lié
+    relation: Relation
+    relations: Relations
+    religious_name: Nom d'ordre
+    religious_order: Ordre/titre
+    reproduction: Reproduction
+    research_institute: Institution de recherche
+    retrospective_conversion: Conversion retrospective
+    rism_id_number: No. RISM
+    role: Personnage
+    scoring_in_movement: Instrumentation du mouvement
+    scoring_summary: Instrumentation
+    scribe: Copiste / scribe
+    secondary_literature: Références
+    series: Série
+    series_added_entry: Champs de collection
+    series_statement: Mentions de collection
+    set: Groupe de matériaux
+    shelfmark: Cote
+    shelfmark_olim: Ancienne cote (olim)
+    short_title: Titre abrégé
+    sigla: Sigle
+    siglum: Sigle
+    single_date: Date unique
+    sister_of: Soeur de
+    sketches: Esquisses
+    solo_voice: Voix seule
+    soloist_instrument: Instrument soliste
+    source_data_found: Source des données
+    source_data_not_found: Source consultée sans résultat
+    source_description: Copie consultée pour le catalogage
+    source_details: Détail de la source
+    source_number_code: Agence d'authorité
+    source_of_acquisition_note: Source d'acquisition
+    source_type: Type de source
+    special_production_technique: Technique de production spéciale
+    standard: Standard
+    standard_musical_terms: Terminologie musicale standardisée
+    standard_number_code: Référence d'authorité
+    standard_texts_sacred_works: Textes standardisés d'oeuvres sacrées
+    standard_watermarks: Description standardisé de filigrane
+    standardized_title: Titre uniforme
+    standardized_titles_printed_music: Titre uniforme pour imprimés musicales
+    standardized_titles_subject_headings: Titre uniforme - Descripteurs
+    street_address: Adresse
+    strings: Cordes
+    subheading: Sous-vedette de forme
+    subheading_general: Subdivision générale
+    subject_access_fields: Entrées de sujets
+    subject_heading: Sujet
+    subject_headings: Sujet
+    subordinate_unit: Collectivité subordonnée
+    succeeding_entry: Notice suivante
+    summary: Résumé
+    supplementary_material: Matériel supplémentaire
+    technical_errors: Problème technique
+    technical_production: Production
+    temp_val: Temp val
+    templates: Modèles
+    terms_voices_instruments: Abréviations RISM pour les instruments
+    text_author: Parolier
+    text_incipit: Incipit du texte
+    third_fourth_group: Troisième/quatrième groupe de caractères
+    time_signature: Indication de mesure
+    title: Titre
+    title_content_description: Titre et description du contenu
+    title_item: Titre
+    title_movement_tempo: Titre, tempo
+    title_of_work: Titre de l'oeuvre
+    title_on_source: Titre diplomatique
+    title_periodical_book_series: Titre de la revue ou du recueil
+    title_related_fields: Titre et champs associés
+    title_section_part: Nom de la partie/section
+    title_variants: Variantes du titre
+    titles_text_incipits: Titres / incipits du texte
+    topical_term: Terme thématique
+    total_scoring: Instrumentation
+    transcribing_agency: Organisme de la transcription
+    translation: Traduction
+    translator: Traducteur
+    transparency: Transparent
+    type: Type
+    type_institution: Type d'institution
+    type_name_variant: Description de la variante du nom
+    type_publication: Type de publication
+    type_relationship: Relation
+    typescript: Tapuscrit
+    typography: Typographie
+    unknown: Inconnu
+    unparsed_fingerprint: Empreinte non analysée
+    variant_ms_title: Variante du titre diplomatique
+    variant_source_title: Variante du titre diplomatique
+    variations: Variations
+    vocalist: Vocaliste
+    voice_instrument: Voix/instrument
+    volume_year_page: Volume, année, page
+    watermark_description: Filigrane
+    woodwinds: Bois
+    work: Oeuvre
+    work_number: Numéro de l'œuvre
+    year: Année
+    years_birth_death: Dates de naissance et de mort

--- a/config/locales/marc_records/it.yml
+++ b/config/locales/marc_records/it.yml
@@ -1,0 +1,790 @@
+it:
+  general:
+    e_mail: E-mail
+    editor_help: Guida all'editor
+    faq: Domande frequenti
+    female: femmina
+    how_do_i: Come faccio ... Suggerimenti e trucchi
+    index_marc_fields: Indice dei campi MARC
+    male: maschio
+    marc_tag_index: Indice dei codici MARC
+    'no': 'No'
+    rism: RISM
+    rism_best_practices: Miglior pratica RISM
+    rism_instrument_abbreviations: Abbreviazioni RISM per gli strumenti (continua)
+    rism_series: Serie RISM
+    rism_series_a_b_references: Rimandi a RISM A/I e RISM B
+    rism_series_number: Numero RISM
+    rule_type: Regole di cat.
+    scope_printed_music_rism: Copertura delle edizioni musicali a stampa in RISM
+    searching: Ricerca
+    status: Status
+    undetermined: Indeterminato
+    ungrouped_fields: Campi non raggruppati
+    unknown_fields: Campi sconoscuti
+    unused: INUTILIZZATO - VERRÀ RIMOSSO
+    uri: URI
+    url: URL
+    using_muscat: Guida a Muscat
+    validity: Validità
+    verified: Verificata
+    when_to_input_new_record: Quando inserire una nuova scheda (edizioni musicali
+      a stampa)
+    workflow: Workflow
+    'yes': Sì
+  languages:
+    afrikaans: Afrikaans
+    arabic: Arabo
+    aragonese: Aragonese
+    armenian: Armeno
+    basque: Basco
+    bosnian: Bosniaco
+    bulgarian: Bulgaro
+    catalan: Catalano
+    celtic_other: Celtico (altro)
+    chinese: Cinese
+    creoles_pidgins_other: Lingue creole e pidgin (altre)
+    croatian: Croato
+    czech: Ceco
+    danish: Danese
+    dutch: Olandese
+    english: Inglese
+    estonian: Estone
+    ethiopic: Etiope
+    finnish: Finlandese
+    french: Francese
+    french_middle: Francese, medio (ca. 1300-1600)
+    french_old: Francese, antico (ca. 842-1300)
+    gallician: Galiziano
+    german: Tedesco
+    german_old_high: Tedesco, antico alto (ca. 750-1050)
+    germanic: Germanico
+    greek_ancient: Greco antico (fino al 1453)
+    greek_modern: Greco moderno (1453-)
+    hebrew: Ebreo
+    hungarian: Ungherese
+    icelandic: Islandese
+    insari_sami: Inari Sami
+    irish: Irlandese
+    italian: Italiano
+    korean: Coreano
+    latin: Latino
+    latvian: Lettone
+    lithuanian: Lituano
+    low_german: Basso sassone
+    lower_sorbian: Sorabo inferiore
+    luxembourgish: Lussemburghese
+    macedonian: Macedone
+    maori: Māori
+    middle_english: Lingua inglese medievale
+    middle_high_german: Tedesco medievale
+    mongolian: Mongolo
+    neapolitan: Napoletano
+    north_frisian: Dialetto frisone settentrionale
+    norwegian: Norvegese
+    occitan: Occitano
+    oirat: Oirato
+    old_church_slavonic: Lingua slava ecclesiastica antica
+    persian: Persiano
+    polish: Polacco
+    portugese: Portoghese
+    romani: Romani
+    romanian: Romeno
+    romansh: Romancio
+    russian: Russo
+    sanskrit: Sanscrito
+    scots: Scozzese
+    serbian: Serbo
+    sichuan_yi: Sichuan Yi
+    sicilian: Siciliano
+    slavic: Slavico
+    slovak: Slovacco
+    slovenian: Sloveno
+    sorbian: Sorabo
+    spanish: Spagnolo
+    swedish: Svedese
+    swiss_german: Svizzero tedesco
+    tagalog: Tagalog
+    tartar: Tataro
+    thai: Thailandese
+    tibetan: Tibetano
+    tsimshian: Tsimshian
+    turkish: Turco
+    ukrainian: Ucraino
+    upper_sorbian: Sorabo superiore
+    vietnamese: Vietnamita
+    welsh: Gallese
+    west_frisian: Dialetto frisone occidentale
+    yiddish: Yiddish
+  places:
+    algeria: Algeria
+    andorra: Andorra
+    argentina: Argentina
+    armenia: Armenia
+    australia: Australia
+    austria: Austria
+    austria_carinthia: 'Austria: Carinzia'
+    austria_lower_austria: 'Austria: Austria Inferiore'
+    austria_salzburg: 'Austria: Salisburgo'
+    austria_styria: 'Austria: Stiria'
+    austria_tyrol: 'Austria: Tirolo'
+    austria_upper_austria: 'Austria: Austria Superiore'
+    austria_vienna: 'Austria: Vienna'
+    belgium: Belgio
+    benin: Benin
+    brazil: Brasile
+    bulgaria: Bulgaria
+    cambodia: Cambogia
+    canada: Canada
+    chile: Chile
+    china: Cina
+    colombia: Colombia
+    croatia: Croazia
+    cuba: Cuba
+    czech_republic: Repubblica Ceca
+    denmark: Danimarca
+    ecuador: Ecuador
+    egypt: Egitto
+    estonia: Estonia
+    finland: Finlandia
+    france: Francia
+    georgia: Georgia
+    germany: Germania
+    germany_bavaria: 'Germania: Baviera'
+    germany_saxony: 'Germania: Sassonia'
+    greece: Grecia
+    guatemala: Guatemala
+    guinea: Guinea
+    holy_see: Santa Sede
+    honduras: Honduras
+    hong_kong: Hong Kong
+    hungary: Ungheria
+    iceland: Islanda
+    india: India
+    indonesia: Indonesia
+    iran: Iran, Repubblica Islamica dell'
+    iraq: Iraq
+    ireland: Irlanda
+    israel: Israele
+    italy: Italia
+    italy_trentino_alto_adige: 'Italia: Trentino-Alto Adige'
+    japan: Giappone
+    korea: Corea, Repubblica di
+    latvia: Lettonia
+    lithuania: Lituania
+    luxembourg: Lussemburgo
+    malta: Malta
+    mexico: Messico
+    moldavia: Moldavia
+    monaco: Monaco
+    montenegro: Montenegro
+    netherlands: Paesi Bassi
+    new_zealand: Nuova Zelanda
+    northern_ireland: Irlanda del Nord
+    norway: Norvegia
+    papua_new_guinea: Papua Nuova Guinea
+    paraguay: Paraguay
+    peru: Perù
+    philippines: Filippine
+    poland: Polonia
+    portugal: Portogallo
+    puerto_rico: Puerto Rico
+    romania: Romania
+    russian_federation: Federazione Russa
+    saudi_arabia: Arabia Saudita
+    serbia: Serbia
+    slovakia: Slovacchia
+    slovenia: Slovenia
+    south_africa: Sudafrica
+    spain: Spagna
+    sweden: Svezia
+    switzerland: Svizzera
+    switzerland_vaud: 'Svizzera: Vaud'
+    syrian_arab_republic: Repubblica Araba Siriana
+    taiwan: Taiwan (provincia della Cina)
+    trinidad_tobego: Trinidad e Tobago
+    turkey: Turchia
+    uk: Regno Unito
+    ukraine: Ucraina
+    uruguay: Uruguay
+    usa: Stati Uniti d'America
+    venezuela: Venezuela, Repubblica Bolivariana del
+    vietnam: Vietnam
+  records:
+    a_major: La maggiore
+    a_minor: La minore
+    abbreviations: Abbreviazioni
+    abbreviations_terminology: Abbreviazioni e terminologia
+    access_restrictions: Restrizioni all'accesso
+    accession_number: Numero di acquisizione
+    added_entry_name: Nomi aggiuntivi
+    additional_author: Autore aggiuntivo
+    additional_bibliographic_information: Informazioni bibliografiche addizionali
+    additional_biographical_information: Informazioni biografiche addizionali
+    additional_choir_voice: Voci di coro aggiuntive
+    additional_institution: Nome di ente aggiuntivo
+    additional_personal_name: Nome aggiuntivo di persona
+    additional_personal_name_lit: Nome aggiuntivo di persona
+    additional_solo_voice: Voce solista aggiuntiva
+    additional_title: Titolo uniforme alternativo
+    additional_title_lit: Titolo uniforme alternativo
+    administration: Amministrazione
+    af_major: La♭ maggiore
+    af_minor: La♭ minore
+    aide: Assistenza
+    aids: Assistenza
+    alleged: Presunta
+    alternate_spelling: Ortografia alternativa
+    archive: Archivio
+    arrangement: Arrangiamento
+    arrangement_statement: Arrangiamento
+    arranger: Arrangiatore
+    artist: Scenografo
+    artistic_production: Autore
+    as_major: La♯ maggiore
+    as_minor: La♯ minore
+    ascertained: Accertata
+    assignee: Concessionario
+    associated_institution: Istituzioni correlate
+    associated_name: Nome associato
+    associated_name_lit: Nome associato
+    associated_place: Luogo associato
+    attribution_qualifier: Qualificazione d'attribuzione
+    authentication_code: Codice di autenticazione
+    author: Autore
+    author_editor: Autore / curatore
+    authorities: Voci di autorità
+    authority_agency: Agenzia autorità
+    authority_reference: Riferimento all'autorità
+    autography: Autografia
+    b_major: Si maggiore
+    b_minor: Si minore
+    baptismal_name: Nome di battesimo
+    basic_functions: Funzioni base
+    basso_continuo: Basso continuo
+    bf_major: Si♭ maggiore
+    bf_minor: Si♭ minore
+    bibliographic_reference: Riferimenti bibliografici
+    binder: Rilegatore
+    binding_note: Rilegatura
+    birth_name: Nome da nubile/celibe
+    book_format: Formato librario
+    bookseller: Libraio musicale
+    bound_with: Rilegato con
+    brass_instruments: Ottoni
+    brief: Breve
+    brother_of: Fratello di
+    byname: Soprannome
+    c_major: Do maggiore
+    c_minor: Do minore
+    c_minus_1: C-1
+    c_minus_2: C-2
+    c_minus_3: C-3
+    c_minus_4: C-4
+    c_minus_5: C-5
+    c_plus_1: C+1
+    c_plus_2: C+2
+    c_plus_3: C+3
+    c_plus_4: C+4
+    c_plus_5: C+5
+    catalog_opus_number: Catalogo/Numero d'opera
+    catalog_works: Catalogo delle opere
+    cataloging_agency: Agenzia di catalogazione
+    cataloging_collection_convoluta: Catalogazione di raccolte e volumi compositi
+    cataloging_collections: Catalogazione delle raccolte
+    cataloging_forms: Formulari di catalogazione
+    cataloging_language: Lingua di catalogazione
+    cataloging_level: Livello di catalogazione
+    cataloging_musical_sources: Catalogazione delle fonti musicali
+    cataloging_source: Fonte della catalogazione
+    category: Tipo
+    censor: Censore
+    cf_major: Do♭ maggiore
+    cf_minor: Do♭ minore
+    child_of: Figlio/figlia di
+    choir_voice: Voci di coro
+    choreographer: Coreografo
+    chronological_subdivision: Suddivisione cronologica
+    chronological_term: Date
+    city: Città
+    clef: Chiave
+    co-composer: Compositore secondario
+    coded_date: Data e luogo di un evento
+    coded_instrumentation: Codice della strumentazione
+    collaborator: Collaboratore
+    colophon: Colofone
+    common_clefs: Chiavi comuni
+    compiler: Compilatore
+    composer: Compositore
+    composer_author: Compositore/Autore
+    composer_cross_reference: Rimando ad altro compositore
+    computer_printout: Stampata da computer
+    conceptor: Autore della fonte letteraria
+    conductor: Direttore d'orchestra
+    confused_with: Confuso/confusa con
+    conjectural: Congetturale
+    contact: Contatto
+    contact_area: Contatto
+    content: Contenuto
+    content_description: Descrizione del contenuto
+    contents_note: Nota di contenuto
+    contributor: Collaboratore
+    control_fields: Campi di controllo
+    control_number_identifier: Identificatore del numero di controllo
+    copy_examined: Copa esaminata per la catalogazione
+    copyist: Copista
+    copyright_holder: Titolare dei diritti d'autore
+    costume_designer: Costumista
+    countries_places: Luoghi
+    country: Paese
+    country_active: Paese di attività
+    country_activity: Paese di attività
+    country_code: Codice del Paese
+    country_of_publication: Paese
+    county_province: Cantone o provincia
+    creation_production_note: Nota sulle responsabilità di creazione/produzione
+    cs_major: Do♯ maggiore
+    cs_minor: Do♯ minore
+    d_major: Re maggiore
+    d_minor: Re minore
+    dancer: Ballerino
+    date: Data
+    date_of_acquisition: Data d'acquisto
+    date_of_creation: Data di creazione
+    date_time_last_transaction: Data e ora dell'ultima transazione
+    date_type: Tipo di datazione
+    dates: Date
+    dedicatee: Dedicatario
+    department: Dipartimento
+    depositor: Depositante
+    description: Descrizione
+    description_area: Descrizione
+    description_summary: Descrizione sommaria
+    designer: Progettista
+    df_major: Re♭ maggiore
+    df_minor: Re♭ minore
+    digitized_music: Fonte digitalizzata
+    digitized_source: Fonte digitalizzata
+    dimensions: Dimensioni
+    diplomatic_title: Titolo diplomatico
+    dissertation_note: Nota alla dissertazione
+    distribution: Organico
+    distributor: Distributore
+    documentation_center: Centro di documentazione
+    donor: Donatore
+    doubtful: Dubbia
+    dramatic_roles_original: Nomi originali dei personaggi
+    dramatic_roles_standardized: Nomi standardizzati dei personaggi
+    ds_major: Re♯ maggiore
+    ds_minor: Re♯ minore
+    dubious: Dubbio
+    e_major: Mi maggiore
+    e_minor: Mi minore
+    ecclesiastical_modes: Modi ecclesiastici
+    edition: Edizione
+    edition_imprint_fields: Campi per i dati editoriali
+    edition_statement: Edizione
+    editor: Curatore
+    ef_major: Mi♭ maggiore
+    ef_minor: Mi♭ minore
+    engraver: Incisore
+    engraving: Incisione
+    event_organizer: Organizzatore
+    event_place: Luogo dell’evento
+    excerpts: Estratti
+    extent: Estensione
+    extent_parts: Estensione (parti)
+    external_resource: Localizzazione e accesso elettronico
+    external_resource_uri: URI per l'accesso elettronico
+    external_resource_url: URL per l'accesso elettronico
+    f_major: Fa maggiore
+    f_minor: Fa minore
+    f_minus_1: F-1
+    f_minus_2: F-2
+    f_minus_3: F-3
+    f_minus_4_bass: F-4 (chiave di basso)
+    f_minus_5: F-5
+    f_plus_1: F+1
+    f_plus_2: F+2
+    f_plus_3: F+3
+    f_plus_4: F+4
+    f_plus_5: F+5
+    facsimile: Facsimile
+    family_name: Nome di famiglia
+    father_of: Padre di
+    figured_bass_scores: Basso cifrato
+    fijian: Figi
+    fingerprint_identifier: Impronta
+    first_second_group: Primo/Secondo gruppo
+    form_subdivision: Suddivisione formale
+    format_extent: Categoria di fonte, estensione
+    former_owner: Proprietario precedente
+    fragments: Frammenti
+    friulano: Friulano
+    fs_major: Fa♯ maggiore
+    fs_minor: Fa♯ minore
+    full: Completo
+    function: Funzione
+    further_information: Note
+    g_major: Sol maggiore
+    g_minor: Sol minore
+    g_minus_1: G-1
+    g_minus_2_octave: g-2 (Chiave di violino ottavizzata)
+    g_minus_2_treble: G-2 (chiave di violino)
+    g_minus_3: G-3
+    g_minus_4: G-4
+    g_minus_5: G-5
+    g_plus_1: G+1
+    g_plus_2: G+2
+    g_plus_3: G+3
+    g_plus_4: G+4
+    g_plus_5: G+5
+    gender: Genere
+    general_abbreviations: Abbreviazioni generali e terminologia
+    general_cataloguing_guidelines: Regole generali di catalogazione
+    general_note: Nota generale
+    general_note_incipits: Commento all'incipit mus.
+    general_note_institution: Nota generale
+    general_note_personal: Nota generale
+    geographic_name: Nome geografico
+    geographic_subdivision: Suddivisione geografica
+    gf_major: Sol♭ maggiore
+    gf_minor: Sol♭ minore
+    gs_major: Sol♯ maggiore
+    gs_minor: Sol♯ minore
+    heading: Nome di persona
+    heading_composer_name: Compositore
+    heading_personal_name: Nome di persona
+    heading_personal_name1: Nome di persona
+    help_transposing_instruments: Tabella degli strumenti traspositori
+    history_institution: Storia dell'ente
+    holdings_location: Informazioni sul fondo
+    identity: Identità
+    identity_area: Identità
+    iiif_manifest: Manifesto IIIF
+    illustrator: Disegnatore
+    images: immagini
+    import: Dati importati
+    imprint: Dati editoriali
+    incipit: Incipit musicale
+    incipit_number: N.o dell'incipit
+    incipits: Incipit
+    index_terms: Descrittori
+    information_found: Riferimento dell'informazione
+    initial: Iniziali
+    initial_entry: Prima notizia
+    initials: Iniziali
+    insertions: Inserimenti
+    inserts: Inserimenti
+    institution: Istituzione
+    institutions: Istituzione
+    instrumentalist: Strumentista
+    internal_note: Nota interna
+    introduction: Introduzione
+    isbn: ISBN
+    ismn: ISMN
+    issn: ISSN
+    item_in_collection: Contenuto della raccolta
+    item_part_of: Fa parte di
+    items_in_source: Contenuto della raccolta
+    japanese: Giapponese
+    key: Tonalità
+    key_or_mode: Tonalità, modo
+    key_signature: Armatura di chiave
+    keyboards: Strumenti a tastiera
+    keys: Tonalità
+    language_code: Codice lingua
+    language_codes: Codici lingue
+    language_libretto: Lingua del libretto
+    language_note: Nota sulla lingua
+    language_of_cataloging: Lingua della catalogazione
+    language_original_text: Lingua del testo originale
+    language_text: Lingua del testo cantato
+    latitude: Latitudine
+    leader: Leader
+    library: Biblioteca
+    library_information: Biblioteca
+    library_information_relations: Biblioteca e relazione
+    library_siglum: Sigla della biblioteca
+    librettist: Librettista
+    licensee: Licenziatario
+    life_dates: Data di nascita e di morte
+    link_type: Tipo di collegamento
+    linkage: Collegamento
+    linking_entry_fields: Note su collegamenti
+    literature: Bibliografia
+    lithograph: Litografo
+    lithographer: Litografo
+    lithography: Litografia
+    liturgical_festival: Festa liturgica
+    liturgical_festivals: Feste liturgiche
+    local_id_number: Num. locale
+    local_note_field: Nota locale
+    local_notes_field: Nota interna
+    local_number: Num. locale
+    location: Luogo
+    location_and_address: Luogo ed indirizzo
+    location_insertion: Collocazione dell'inserimento nell'opera principale
+    location_on_source: Luogo sulla fonte
+    location_performance: Luogo di un'esecuzione
+    location_printer: Luogo di stampa
+    longitude: Longitudine
+    lyricist: Poeta
+    main_entry_fields: Campi principali
+    married_name: Nome da sposato
+    married_to: Sposato/sposata con
+    married_with: Sposato/sposata con
+    material_description: Descrizione del materiale
+    material_examined: Materiale esaminato
+    material_held: Materiale conservato
+    material_not_examined: Materiale non esaminato
+    media_type: Mezzo fisico
+    mensural_clefs: Chiavi mensurali
+    method_of_acquisition: Metodo d'acquisto
+    misattributed: Erronea
+    miscellaneous: Varia
+    mode_10t: 'Modo: 10t – Ipoeolio'
+    mode_10tt: 'Modo: 10tt – Ipoeolio, trasposto'
+    mode_11t: 'Modo: 11t – Ionico'
+    mode_11tt: 'Modo: 11tt – Ionico, trasposto'
+    mode_12t: 'Modo: 12t – Ipoionico'
+    mode_12tt: 'Modo: 12tt – Ipoionico, trasposto'
+    mode_1t: 'Modo:  1t – Dorico'
+    mode_1tt: 'Modo:  1tt – Dorico, trasposto'
+    mode_2t: 'Modo:  2t – Ipodorico'
+    mode_2tt: 'Modo:  2tt – Ipodorico, trasposto'
+    mode_3t: 'Modo:  3t – Frigio'
+    mode_3tt: 'Modo:  3tt – Frigio, trasposto'
+    mode_4t: 'Modo:  4t – Ipofrigio'
+    mode_4tt: 'Modo:  4tt – Ipofrigio, trasposto'
+    mode_5t: 'Modo:  5t – Lidio'
+    mode_5tt: 'Modo:  5tt – Lidio, trasposto'
+    mode_6t: 'Modo:  6t – Ipolidio'
+    mode_6tt: 'Modo:  6tt – Ipolidio, trasposto'
+    mode_7t: 'Modo:  7t – Misolidio'
+    mode_7tt: 'Modo:  7tt – Misolidio, trasposto'
+    mode_8t: 'Modo:  8t – Ipomisolidio'
+    mode_8tt: 'Modo:  8tt – Ipomisolidio, trasposto'
+    mode_9t: 'Modo:  9t – Eolico'
+    mode_9tt: 'Modo:  9tt – Eolico, trasposto'
+    modifying_agency: Agenzia della modifica
+    monogram: Monogramma
+    mother_of: Madre di
+    movement_number: N.o del movimento
+    multiple: Multiple
+    multiple_copies: Exemplari multipli
+    multiple_single_dates: Date singole multiple
+    museum: Museo
+    music_incipit: Incipit musicale
+    name: Nome
+    name_family: Nome di famiglia
+    name_printer: Stampatore, stamperia
+    name_variant: Varianti del nome
+    name_variants: Varianti del nome
+    named_dramatic_roles: Personaggi menzionati
+    nationality: Codice del Paese
+    nickname: Soprannome
+    no_linguistic_content: Senza contesto linguistico
+    non_migrated_bound: Non-migrated bound with value from 563
+    note_external_resource: Nota sulla risorsa esterna
+    note_fields: Campi note
+    note_on_performance: Nota sull'esecuzione
+    now_in: Ora in
+    number: Numero
+    number_page: Numero/pagina
+    number_part_section: Numero della parte/sezione di una composizione
+    number_volume_part: Numero del volume/parte
+    numbers_code_fields: Numeri e codici
+    octoechos1: 'Octoechos 1: Ēchos prōtos (primo modo nella musica bizantina)'
+    octoechos2: 'Octoechos 2: Ēchos deuteros (secondo modo nella musica bizantina)'
+    octoechos3: 'Octoechos 3: Ēchos tritos (terzo modo nella musica bizantina)'
+    octoechos4: 'Octoechos 4: Ēchos tetartos (quarto modo nella musica bizantina)'
+    octoechos5: 'Octoechos 5: Ēchos plagios prōtos (primo modo plagale nella musica
+      bizantina)'
+    octoechos6: 'Octoechos 6: Ēchos plagios deuteros (secondo modo plagale nella musica
+      bizantina)'
+    octoechos7: 'Octoechos 7: Ēchos barys (terzo modo plagale nella musica bizantina)'
+    octoechos8: 'Octoechos 8: Ēchos plagios tetartos (quarto modo plagale nella musica
+      bizantina)'
+    online_finding_aids: Strumenti di supporto alla ricerca online
+    opera_houses_concert_halls: Teatri e sale da concerto
+    opus_number: N.o d'opera
+    opus_thematic_index_number: Numero d'opera / del catalogo delle opere
+    order_name: Nome di religione
+    origin: Origine
+    original_cataloging_agency: Agenzia catalografica originale
+    other: Altra funzione
+    other_form: Ortografia alternativa
+    other_form_of_name: Altre forme del nome
+    other_function: Altra funzione
+    other_help: Altri aiuti
+    other_instruments: Altri strumenti
+    other_life_dates: Altre date
+    other_physical_details: Altri dettagli sul materiale
+    other_searchform: Altra forma di ricerca
+    other_shelfmark: Altra segnatura
+    other_standard_identifier: Riferimento autorità
+    other_variant: Altra forma di ricerca
+    paper_maker: Fabbricante di carta
+    papermaker: Fabbricante di carta
+    parallel_form: Forma parallela del nome
+    parent_record: Notizia principale
+    parts_held: Parti staccate esistenti
+    parts_held_extent: Parti staccate, estensione
+    patron: Committente
+    people_institutions: Persone ed istituzioni
+    percussion: Strumenti a percussione
+    performance: Esecutori
+    performances: Esecuzioni
+    performer: Interprete
+    performer_note: Nota sull'esecuzione
+    person: Persona
+    person_name: Nome di persona
+    personal_name: Nome di persona
+    personal_names: Nomi di persona
+    photoreproductive_process: Cianografia
+    physical_description: Descrizione fisica
+    physical_description_fields: Campi per la descrizione fisica
+    place: Luogo
+    place_active: Luogo di attività
+    place_activity: Luogo di attività
+    place_birth: Luogo di nascita
+    place_death: Luogo di morte
+    place_origin: Luogo di origine
+    place_publication: Luogo
+    places: Luoghi
+    plate_number: Numero della lastra
+    plucked_instruments: Strumenti a pizzico
+    postal_code: Codice postale
+    postal_place: Luogo postale
+    preceding_entry: Notizia precedente
+    printer: Stampatore
+    printing_technique: Tecnica di stampa
+    production: Produzione
+    production_personnel: Personale alla produzione
+    profession_or_function: Professione o funzione
+    provenance: Provenienza
+    provenance_notes: Nota di provenienza
+    pseudonym: Pseudonimo
+    public_note: Nota pubblica
+    publisher: Editore
+    publisher_copyist: Copista, editore, casa editrice
+    publishing_printing_production: Copia o dati editoriali
+    range_dates: Ambito di datazione
+    record_actions: Azioni per la scheda
+    record_audit: RECORD AUDIT
+    record_origin: Origine della scheda
+    record_status: Stato della scheda
+    reference_record_id: Numero identificativo della scheda di riferimento
+    references: Bibliografia
+    references_and_notes: Bibliografia e note
+    region_active: Regione di attività
+    region_of_activity: Regione di attività
+    related_institution: Istituzione correlata
+    related_personal_name: Nome di persona collegato
+    related_place: Luogo correlato
+    related_resources: Collegamenti
+    related_titles: Titoli connessi
+    related_to: Parente di
+    related_work: Opera correlata
+    relation: Relazione
+    relations: Relazioni
+    religious_name: Nome di religione
+    religious_order: Ordine religioso
+    reproduction: Riproduzione
+    research_institute: Istituto di ricerca
+    retrospective_conversion: Conversione retrospettiva
+    rism_id_number: Numero documento RISM
+    role: Personaggio
+    scoring_in_movement: Organico del movimento
+    scoring_summary: Organico sintetico
+    scribe: Copista
+    secondary_literature: Bibliografia
+    series: Serie
+    series_added_entry: Notizia secondaria sul titolo sovraordinato
+    series_statement: Informazioni sul titolo sovraordinato
+    set: Gruppo di materiale
+    shelfmark: Segnatura
+    shelfmark_olim: Segnatura antica (olim)
+    short_title: Titolo breve
+    sigla: Sigla
+    siglum: Sigla
+    single_date: Data singola
+    sister_of: Sorella di
+    sketches: Schizzi
+    solo_voice: Voce solista
+    soloist_instrument: Strumento solista
+    source_data_found: Fonte dei dati
+    source_data_not_found: Fonte consultata senza esito
+    source_description: Copa esaminata per la catalogazione
+    source_details: Descrizione fisica
+    source_number_code: Agenzia autorità
+    source_of_acquisition_note: Nota sulla fonte d'acquisto
+    source_type: Categoria di fonte
+    special_production_technique: Tecnica di produzione speciale
+    standard: Standard
+    standard_musical_terms: Terminologia musicale standard
+    standard_number_code: Riferimento autorità
+    standard_texts_sacred_works: Testi standard di composizioni sacre
+    standard_watermarks: Descrizione standard di filigrane
+    standardized_title: Titolo uniforme
+    standardized_titles_printed_music: Titolo uniforme di edizioni musicali a stampa
+    standardized_titles_subject_headings: Titolo uniforme - Soggetto
+    street_address: Via e numero civico
+    strings: Archi
+    subheading: Suddivisione formale
+    subheading_general: Suddivisione generale
+    subject_access_fields: Soggetto
+    subject_heading: Soggetto
+    subject_headings: Soggetto
+    subordinate_unit: Istituzione subordinata
+    succeeding_entry: Notizia successiva
+    summary: Riassunto
+    supplementary_material: Materiali allegati
+    technical_errors: Errori tecnici
+    technical_production: Produttore
+    temp_val: Temp val
+    templates: Modelli
+    terms_voices_instruments: Abbreviazioni RISM per gli strumenti
+    text_author: Poeta
+    text_incipit: Incipit testuale
+    third_fourth_group: Terzo/Quarto gruppo
+    time_signature: Misura
+    title: Titolo
+    title_content_description: Titolo e descrizione del contenuto
+    title_item: Titolo
+    title_movement_tempo: Intestazione, tempo
+    title_of_work: Titolo dell'opera
+    title_on_source: Titolo diplomatico
+    title_periodical_book_series: Titolo del periodico o della miscellanea
+    title_related_fields: Titolo e campi correlati
+    title_section_part: Titolo della sezione o parte
+    title_variants: Varianti del titolo
+    titles_text_incipits: Titoli / incipit testuali
+    topical_term: Termine tematico
+    total_scoring: Organico
+    transcribing_agency: Agenzia della trascrizione
+    translation: Traduzione
+    translator: Traduttore
+    transparency: Trasparente
+    type: Tipo
+    type_institution: Tipo di istituzione
+    type_name_variant: Descrizione della variante del nome
+    type_publication: Tipo di pubblicazione
+    type_relationship: Relazione
+    typescript: Dattiloscritto
+    typography: Stampa tipografica
+    unknown: Sconosciuto
+    unparsed_fingerprint: Impronta non analizzata
+    variant_ms_title: Varianti del titolo diplomatico
+    variant_source_title: Varianti del titolo diplomatico
+    variations: Variazioni
+    vocalist: Cantante
+    voice_instrument: Voce/strumento
+    volume_year_page: Volume, anno, pagina
+    watermark_description: Filigrana
+    woodwinds: Legni
+    work: Opera
+    work_number: Numero dell'opera
+    year: Anno
+    years_birth_death: Data di nascita e di morte

--- a/config/locales/marc_records/pl.yml
+++ b/config/locales/marc_records/pl.yml
@@ -1,0 +1,789 @@
+pl:
+  general:
+    e_mail: E-mail
+    editor_help: Pomoc do edycji
+    faq: Odpowiedzi na częste pytania
+    female: kobieta
+    how_do_i: Rady i wskazówki
+    index_marc_fields: Indeks pól MARC
+    male: mężczyzna
+    marc_tag_index: Indeks znaczników MARC
+    'no': Nie
+    rism: RISM
+    rism_best_practices: Dobre praktyki RISM
+    rism_instrument_abbreviations: Skróty instrumentów wg RISM
+    rism_series: Seria RISM
+    rism_series_a_b_references: Odniesienia do serii RISM A/I i B
+    rism_series_number: Nr seryjny RISM
+    rule_type: Standard
+    scope_printed_music_rism: Zakres druków muzycznych w RISM
+    searching: Wyszukiwanie
+    status: Status
+    undetermined: Nieokreślony
+    ungrouped_fields: Pola niezgrupowane
+    unknown_fields: Pola nieznane
+    unused: NIEWYKORZYSTANE – DO USUNIĘCIA
+    uri: URI
+    url: URL
+    using_muscat: Korzystanie z Muscatu
+    validity: Ważność
+    verified: Zweryfikowane
+    when_to_input_new_record: Kiedy wprowadzić nowy rekord (dla druków muzycznych)
+    workflow: Przepływ pracy
+    'yes': Tak
+  languages:
+    afrikaans: Afrykanerski
+    arabic: Arabski
+    aragonese: Aragoński
+    armenian: Armeński
+    basque: Baskijski
+    bosnian: Bośniacki
+    bulgarian: Bułgarski
+    catalan: Kataloński
+    celtic_other: Celtycki (inny)
+    chinese: Chiński
+    creoles_pidgins_other: Kreolski i Pidgin (inne)
+    croatian: Chorwacki
+    czech: Czeski
+    danish: Duński
+    dutch: Holenderski
+    english: Angielski
+    estonian: Estoński
+    ethiopic: Etiopski
+    finnish: Fiński
+    french: Francuski
+    french_middle: Średniofrancuski (ok. 1300-1600)
+    french_old: Starofrancuski (ok. 842-1300)
+    gallician: Galicyjski
+    german: Niemiecki
+    german_old_high: Staro-wysoko-niemiecki (ok. 750-1050)
+    germanic: Germański
+    greek_ancient: Grecki, historyczny (do 1453 r.)
+    greek_modern: Grecki, współczesny (1453-)
+    hebrew: Hebrajski
+    hungarian: Węgierski
+    icelandic: Islandzki
+    insari_sami: Samski inarski
+    irish: Irlandzki
+    italian: Włoski
+    korean: Koreański
+    latin: Łaciński
+    latvian: Łotewski
+    lithuanian: Litewski
+    low_german: Dolnoniemiecki
+    lower_sorbian: Dolnołużycki
+    luxembourgish: Luksemburski
+    macedonian: Macedoński
+    maori: Maoryski
+    middle_english: Środkowoangielski
+    middle_high_german: Średniowysokoniemiecki
+    mongolian: Mongolski
+    neapolitan: Neapolitański
+    north_frisian: Północnofryzyjski
+    norwegian: Norweski
+    occitan: Prowansalski
+    oirat: Ojracki
+    old_church_slavonic: Starocerkiewny
+    persian: Perski
+    polish: Polski
+    portugese: Portugalski
+    romani: Romski
+    romanian: Rumuński
+    romansh: Retoromański
+    russian: Rosyjski
+    sanskrit: Sanskryt
+    scots: Szkocki
+    serbian: Serbski
+    sichuan_yi: Syczuański Yi
+    sicilian: Sycylijski
+    slavic: Słowiański
+    slovak: Słowacki
+    slovenian: Słoweński
+    sorbian: Łużycki
+    spanish: Hiszpański
+    swedish: Szwedzki
+    swiss_german: Niemiecki szwajcarski
+    tagalog: Tagalski
+    tartar: Tatarski
+    thai: Tajski
+    tibetan: Tybetański
+    tsimshian: Tsimshiański
+    turkish: Turecki
+    ukrainian: Ukraiński
+    upper_sorbian: Gbórnołużycki
+    vietnamese: Wietnamska
+    welsh: Walijski
+    west_frisian: Zchodniofryzyjski
+    yiddish: Jidysz
+  places:
+    algeria: Algieria
+    andorra: Andora
+    argentina: Argentyna
+    armenia: Armenia
+    australia: Australia
+    austria: Austria
+    austria_carinthia: 'Austria: Karyntia'
+    austria_lower_austria: 'Austria: Dolna Austria'
+    austria_salzburg: 'Austria: Salzburg'
+    austria_styria: 'Austria: Styria'
+    austria_tyrol: 'Austria: Tyrol'
+    austria_upper_austria: 'Austria: Górna Austria'
+    austria_vienna: 'Austria: Wiedeń'
+    belgium: Belgia
+    benin: Benin
+    brazil: Brazylia
+    bulgaria: Bułgaria
+    cambodia: Kambodża
+    canada: Kanada
+    chile: Chile
+    china: Chiny
+    colombia: Kolumbia
+    croatia: Chorwacja
+    cuba: Kuba
+    czech_republic: Czechy
+    denmark: Dania
+    ecuador: Ekwador
+    egypt: Egipt
+    estonia: Estonia
+    finland: Finlandia
+    france: Francja
+    georgia: Gruzja
+    germany: Niemcy
+    germany_bavaria: 'Niemcy: Bawaria'
+    germany_saxony: 'Niemcy: Saksonia'
+    greece: Grecja
+    guatemala: Gwatemala
+    guinea: Gwinea
+    holy_see: Watykan
+    honduras: Honduras
+    hong_kong: Hongkong
+    hungary: Węgry
+    iceland: Islandia
+    india: Indie
+    indonesia: Indonezja
+    iran: Iran, Republika Islamska
+    iraq: Irak
+    ireland: Irlandia
+    israel: Izrael
+    italy: Włochy
+    italy_trentino_alto_adige: 'Włochy: Trentino-Alto Adige'
+    japan: Japonia
+    korea: Korea, Republika
+    latvia: Łotwa
+    lithuania: Litwa
+    luxembourg: Luksemburg
+    malta: Malta
+    mexico: Meksyk
+    moldavia: Mołdawia
+    monaco: Monako
+    montenegro: Czarnogóra
+    netherlands: Niderlandy
+    new_zealand: Nowa Zelandia
+    northern_ireland: Irlandia Północna
+    norway: Norwegia
+    papua_new_guinea: Papua Nowa Gwinea
+    paraguay: Paragwaj
+    peru: Peru
+    philippines: Filipiny
+    poland: Polska
+    portugal: Portugalia
+    puerto_rico: Portoryko
+    romania: Rumunia
+    russian_federation: Federacja Rosyjska
+    saudi_arabia: Arabia Saudyjska
+    serbia: Serbia
+    slovakia: Słowacja
+    slovenia: Słowenia
+    south_africa: Republika Południowej Afryki
+    spain: Hiszpania
+    sweden: Szwecja
+    switzerland: Szwajcaria
+    switzerland_vaud: 'Szwajcaria: kanton Vaud'
+    syrian_arab_republic: Syryjska Republika Arabska
+    taiwan: Tajwan (prowincja Chin)
+    trinidad_tobego: Trynidad i Tobago
+    turkey: Turcja
+    uk: Zjednoczone Królestwo
+    ukraine: Ukraina
+    uruguay: Urugwaj
+    usa: Stany Zjednoczone AP
+    venezuela: Wenezuela, Republika Boliwariańska
+    vietnam: Wietnam
+  records:
+    a_major: A-dur
+    a_minor: a-moll
+    abbreviations: Skróty
+    abbreviations_terminology: Skróty i pojęcia
+    access_restrictions: Ograniczenia dostępu
+    accession_number: Numer akcesji
+    added_entry_name: Dodana nazwa wpisu
+    additional_author: Dodatkowy autor
+    additional_bibliographic_information: Dodatkowe informacje bibliograficzne
+    additional_biographical_information: Dodatkowe informacje biograficzne
+    additional_choir_voice: Dodatkowy głos chóralny
+    additional_institution: Dodatkowa instytucja
+    additional_personal_name: Dodatkowa osoba
+    additional_personal_name_lit: Dodatkowa osoba
+    additional_solo_voice: Dodatkowy głos solowy
+    additional_title: Dodatkowy tytuł
+    additional_title_lit: Dodatkowy tytuł
+    administration: Administracja
+    af_major: As-dur
+    af_minor: as-moll
+    aide: Asystent
+    aids: Pomoce
+    alleged: Domniemane
+    alternate_spelling: Alternatywna pisownia
+    archive: Archiwum
+    arrangement: Aranżacja
+    arrangement_statement: Uwaga do aranżacji
+    arranger: Aranżer
+    artist: Artysta
+    artistic_production: Autor produkcji artystycznej
+    as_major: Ais-dur
+    as_minor: ais-moll
+    ascertained: Stwierdzone
+    assignee: Cesjonariusz
+    associated_institution: Powiązana instytucja
+    associated_name: Powiązana nazwa
+    associated_name_lit: Powiązana nazwa
+    associated_place: Powiązane miejsce
+    attribution_qualifier: Kwalifikator atrybucji
+    authentication_code: Kod uwierzytelnienia
+    author: Autor
+    author_editor: Autor / edytor
+    authorities: Hasła wzorcowe
+    authority_agency: Baza haseł wzorcowych
+    authority_reference: Odniesienie do bazy haseł wzorcowych
+    autography: Autografia
+    b_major: H-dur
+    b_minor: h-moll
+    baptismal_name: Imię z chrztu
+    basic_functions: Podstawowe funkcje
+    basso_continuo: Basso continuo
+    bf_major: B-dur
+    bf_minor: b-moll
+    bibliographic_reference: Odniesienie bibliograficzne
+    binder: Introligator
+    binding_note: Uwaga o oprawie
+    birth_name: Nazwisko rodowe
+    book_format: Format książki
+    bookseller: Księgarz
+    bound_with: Współoprawne z
+    brass_instruments: Instrumenty dęte blaszane
+    brief: Streszczenie
+    brother_of: Brat …
+    byname: Przydomek
+    c_major: C-dur
+    c_minor: c-moll
+    c_minus_1: C-1
+    c_minus_2: C-2
+    c_minus_3: C-3
+    c_minus_4: C-4
+    c_minus_5: C-5
+    c_plus_1: C+1
+    c_plus_2: C+2
+    c_plus_3: C+3
+    c_plus_4: C+4
+    c_plus_5: C+5
+    catalog_opus_number: Numer katalogu / numer opus
+    catalog_works: Katalog dzieł
+    cataloging_agency: Jednostka katalogująca
+    cataloging_collection_convoluta: Katalogowanie kolekcji i klocka introligatorskiego
+    cataloging_collections: Katalogowanie kolekcji
+    cataloging_forms: Formularze katalogowania
+    cataloging_language: Język katalogowania
+    cataloging_level: Poziom katalogowania
+    cataloging_musical_sources: Katalogowanie źródeł muzycznych
+    cataloging_source: Katalogowanie źródła
+    category: Kategoria
+    censor: Cenzor
+    cf_major: Ces-dur
+    cf_minor: ces-moll
+    child_of: Potomek …
+    choir_voice: Głos chóralny
+    choreographer: Choreograf
+    chronological_subdivision: Dalszy podział chronologiczny
+    chronological_term: Datowanie
+    city: Miejscowość
+    clef: Klucz
+    co-composer: Współkompozytor
+    coded_date: Znormalizowana data
+    coded_instrumentation: Standaryzowany zapis instrumentacji
+    collaborator: Współtwórca
+    colophon: Kolofon
+    common_clefs: Klucze współczesne
+    compiler: Kompilator
+    composer: Kompozytor
+    composer_author: Kompozytor / Autor
+    composer_cross_reference: Odniesienie do innego kompozytora
+    computer_printout: Wydruk komputerowy
+    conceptor: Autor koncepcji
+    conductor: Dyrygent
+    confused_with: Mylon(y/a) z …
+    conjectural: Spekulatywne
+    contact: Kontakt
+    contact_area: Obszar kontaktu
+    content: Zawartość
+    content_description: Opis źródła
+    contents_note: Uwaga do zawartości
+    contributor: Kontrybutor
+    control_fields: Pola kontrolne
+    control_number_identifier: Identyfikator numeru kontrolnego
+    copy_examined: Katalogowany egzemplarz
+    copyist: Kopista
+    copyright_holder: Posiadacz praw autorskich
+    costume_designer: Projektant kostiumów
+    countries_places: Kraje i miejsca
+    country: Kraj
+    country_active: Kraj aktywności artystycznej
+    country_activity: Kraj aktywności artystycznej
+    country_code: Kod kraju
+    country_of_publication: Kraj publikacji
+    county_province: Stan, hrabstwo, prowincja...
+    creation_production_note: Uwagi do wytworzenia / produkcji
+    cs_major: Cis-dur
+    cs_minor: cis-moll
+    d_major: D-dur
+    d_minor: d-moll
+    dancer: Tancerz
+    date: Data
+    date_of_acquisition: Data nabycia
+    date_of_creation: Data utworzenia
+    date_time_last_transaction: Data i godzina ostatniej operacji
+    date_type: Rodzaj daty
+    dates: Daty
+    dedicatee: Adresat dedykacji
+    department: Wydział
+    depositor: Deponent
+    description: Opis
+    description_area: Obszar opisu
+    description_summary: Podsumowanie
+    designer: Projektant
+    df_major: Des-dur
+    df_minor: des-moll
+    digitized_music: Cyfrowa reprodukcja źródła
+    digitized_source: Cyfrowa reprodukcja źródła
+    dimensions: Wymiary
+    diplomatic_title: Tytuł dyplomatyczny
+    dissertation_note: Uwaga do dysertacji
+    distribution: Dystrybucja
+    distributor: Dystrybutor
+    documentation_center: Centrum dokumentacji
+    donor: Donator
+    doubtful: Wątpliwe
+    dramatic_roles_original: Postaci w oryginalnej pisowni
+    dramatic_roles_standardized: Znormalizowane nazwy postaci
+    ds_major: Dis-dur
+    ds_minor: dis-moll
+    dubious: Wątpliwe
+    e_major: E-dur
+    e_minor: e-moll
+    ecclesiastical_modes: Skale kościelne
+    edition: Edycja
+    edition_imprint_fields: Edycja, stopka wydawnicza itp. pola
+    edition_statement: Wydanie
+    editor: Edytor
+    ef_major: Es-dur
+    ef_minor: es-moll
+    engraver: Rytownik
+    engraving: Sztych
+    event_organizer: Organizator wydarzenia
+    event_place: Miejsce wydarzenia
+    excerpts: Wyjątki
+    extent: Zakres
+    extent_parts: Objętność
+    external_resource: Zasób zewnętrzny
+    external_resource_uri: URI zasobu zewnętrznego
+    external_resource_url: URL zasobu zewnętrznego
+    f_major: F-dur
+    f_minor: f-moll
+    f_minus_1: F-1
+    f_minus_2: F-2
+    f_minus_3: F-3
+    f_minus_4_bass: F-4 (klucz basowy)
+    f_minus_5: F-5
+    f_plus_1: F+1
+    f_plus_2: F+2
+    f_plus_3: F+3
+    f_plus_4: F+4
+    f_plus_5: F+5
+    facsimile: Faksymile
+    family_name: Nazwisko rodowe
+    father_of: Ojciec …
+    figured_bass_scores: Bas cyfrowany w partyturze i / lub w innych częściach
+    fijian: Fidżyjski
+    fingerprint_identifier: Identyfikator odcisku palca
+    first_second_group: Pierwsza / druga grupa
+    form_subdivision: Dalszy podział formularza
+    format_extent: Rodzaj źródła, objętość
+    former_owner: Poprzedni właściciel
+    fragments: Fragmenty
+    friulano: Friulijski
+    fs_major: Fis-dur
+    fs_minor: fis-moll
+    full: Pełny
+    function: Funkcja
+    further_information: Dalsze informacje
+    g_major: G-dur
+    g_minor: g-moll
+    g_minus_1: G-1
+    g_minus_2_octave: g-2 (oktawowy klucz wiolinowy)
+    g_minus_2_treble: G-2 (klucz wiolinowy)
+    g_minus_3: G-3
+    g_minus_4: G-4
+    g_minus_5: G-5
+    g_plus_1: G+1
+    g_plus_2: G+2
+    g_plus_3: G+3
+    g_plus_4: G+4
+    g_plus_5: G+5
+    gender: Płeć społeczno-kulturowa
+    general_abbreviations: Ogólne skróty i pojęcia
+    general_cataloguing_guidelines: Ogólne wskazówki do katalogowania
+    general_note: Uwaga ogólna
+    general_note_incipits: Uwaga ogólna
+    general_note_institution: Uwaga ogólna
+    general_note_personal: Uwaga ogólna
+    geographic_name: Nazwa geograficzna
+    geographic_subdivision: Dalszy podział geograficzny
+    gf_major: Ges-dur
+    gf_minor: ges-moll
+    gs_major: Gis-dur
+    gs_minor: gis-moll
+    heading: Nagłówek
+    heading_composer_name: Nagłówek – imię i nazwisko kompozytora
+    heading_personal_name: Nagłówek – Osoba
+    heading_personal_name1: Nagłówek – nazwisko
+    help_transposing_instruments: Pomoc przy transpozycji instrumentów
+    history_institution: Historia instytucji
+    holdings_location: Pola egzemplarza, lokalizacji itp.
+    identity: Tożsamość
+    identity_area: Obszar tożsamości
+    iiif_manifest: Manifest IIIF
+    illustrator: Ilustrator
+    images: Obrazy
+    import: Import
+    imprint: Stopka wydawnicza
+    incipit: Incipit
+    incipit_number: Numer incipitu
+    incipits: Incipity
+    index_terms: Pojęcia indeksowane
+    information_found: Odnaleziona informacja
+    initial: Inicjały
+    initial_entry: Początkowy wpis
+    initials: Inicjały
+    insertions: Wstawienia
+    inserts: Wstawienia
+    institution: Instytucja
+    institutions: Instytucje
+    instrumentalist: Instrumentalista
+    internal_note: Uwaga wewnętrzna
+    introduction: Wprowadzenie
+    isbn: ISBN
+    ismn: ISMN
+    issn: ISSN
+    item_in_collection: Pozycja w tej kolekcji
+    item_part_of: Jest częścią…
+    items_in_source: Pozycje w tym źródle
+    japanese: Japoński
+    key: Tonacja
+    key_or_mode: Tonacja lub modus
+    key_signature: Znaki przykluczowe
+    keyboards: Instrumenty klawiszowe
+    keys: Tomacje
+    language_code: Kod języka
+    language_codes: Kody języków
+    language_libretto: Język libretta
+    language_note: Uwaga o języku
+    language_of_cataloging: Język katalogowania
+    language_original_text: Język tekstu oryginalnego
+    language_text: Język tekstu
+    latitude: Szerokość geograficzna
+    leader: Leader
+    library: Biblioteka
+    library_information: Informacje o bibliotece
+    library_information_relations: Informacje o bibliotece i powiązaniach
+    library_siglum: Siglum
+    librettist: Autor libretta
+    licensee: Licencjobiorca
+    life_dates: Daty urodzenia i śmierci
+    link_type: Typ odsyłacza
+    linkage: Powiązanie
+    linking_entry_fields: Łączenie pól wpisów
+    literature: Literatura
+    lithograph: Litograf
+    lithographer: Litograf
+    lithography: Litografia
+    liturgical_festival: Święto liturgiczne
+    liturgical_festivals: Święta liturgiczne
+    local_id_number: Local ID no.
+    local_note_field: Pole uwagi lokalnej
+    local_notes_field: Pole uwag wewnętrznych
+    local_number: Numer kontrolny
+    location: Lokalizacja
+    location_and_address: Lokalizacja i adres
+    location_insertion: Lokalizacja wstawienia
+    location_on_source: Lokalizacje w źródle
+    location_performance: Lokalizacja wykonania
+    location_printer: Lokalizacja drukarni
+    longitude: Długość geograficzna
+    lyricist: Autor słów
+    main_entry_fields: Główne pola edycji
+    married_name: Nazwisko po mężu
+    married_to: W małżeństwie z …
+    married_with: W małżeństwie z …
+    material_description: Opis materiału
+    material_examined: Zbadany materiał
+    material_held: Posiadany materiał
+    material_not_examined: Materiał nie zbadany
+    media_type: Rodzaj nośnika
+    mensural_clefs: Klucze menzuralne
+    method_of_acquisition: Sposób nabycia
+    misattributed: Błędnie przypisane
+    miscellaneous: Pozostałe
+    mode_10t: 'Skala: 10t – hypoeolska'
+    mode_10tt: 'Skala: 10tt – hypoeolska, transponowana'
+    mode_11t: 'Skala: 11t – jońska'
+    mode_11tt: 'Skala: 11tt – jońska, transponowana'
+    mode_12t: 'Skala: 12t – hypojońska'
+    mode_12tt: 'Skala: 12tt – hypojońska, transponowana'
+    mode_1t: 'Skala: 1t – dorycka'
+    mode_1tt: 'Skala: 1tt – dorycka, transponowana'
+    mode_2t: 'Skala: 2t – hypodorycka'
+    mode_2tt: 'Skala: 2tt – hypodorycka, transponowana'
+    mode_3t: 'Skala: 3t – frygijska'
+    mode_3tt: 'Skala: 3tt – frygijska, transponowana'
+    mode_4t: 'Skala: 4t – hypofrygijska'
+    mode_4tt: 'Skala: 4tt – hypofrygijska, transponowana'
+    mode_5t: 'Skala: 5t – lidyjska'
+    mode_5tt: 'Skala: 5tt – lidyjska, transponowana'
+    mode_6t: 'Skala: 6t – hypolidyjska'
+    mode_6tt: 'Skala: 6tt – hypolidyjska, transponowana'
+    mode_7t: 'Skala: 7t – miksolidyjska'
+    mode_7tt: 'Skala: 7tt – miksolidyjska, transponowana'
+    mode_8t: 'Skala: 8t – hypomiksolidyjska'
+    mode_8tt: 'Skala: 8tt – hypomiksolidyjska, transponowana'
+    mode_9t: 'Skala: 9t – eolska'
+    mode_9tt: 'Skala: 9tt – eolska, transponowana'
+    modifying_agency: Jednostka modyfikująca
+    monogram: Monogram
+    mother_of: Matka …
+    movement_number: Numer części
+    multiple: Wielojęzyczny
+    multiple_copies: Wiele kopii
+    multiple_single_dates: Wiele pojedynczych dat
+    museum: Muzeum
+    music_incipit: Incipit muzyczny
+    name: Imię i nazwisko
+    name_family: Nazwa rodziny
+    name_printer: Nazwa drukarni
+    name_variant: Alternatywna nazwa osoby
+    name_variants: Alternatywne nazwy osoby
+    named_dramatic_roles: Postaci
+    nationality: Narodowość
+    nickname: Przezwisko
+    no_linguistic_content: Brak zawartości językowej
+    non_migrated_bound: Non-migrated bound with value from 563
+    note_external_resource: Uwaga o zasobie zewnętrznym
+    note_fields: Pola uwag
+    note_on_performance: Uwaga o wykonaniu
+    now_in: Obecnie w …
+    number: Liczba
+    number_page: Numer / strona
+    number_part_section: Numer części / sekcji dzieła
+    number_volume_part: Numer wolumenu / części
+    numbers_code_fields: Pola liczb i kodów
+    octoechos1: 'Octoechos 1: Ēchos prōtos (pierwsza skala muzyki bizantyjskiej)'
+    octoechos2: 'Octoechos 2: Ēchos deuteros (druga skala muzyki bizantyjskiej)'
+    octoechos3: 'Octoechos 3: Ēchos tritos (trzecia skala muzyki bizantyjskiej)'
+    octoechos4: 'Octoechos 4: Ēchos tetartos (czwarta skala muzyki bizantyjskiej)'
+    octoechos5: 'Octoechos 5: Ēchos plagios prōtos (pierwsza skala plagalna muzyki
+      bizantyjskiej)'
+    octoechos6: 'Octoechos 6: Ēchos plagios deuteros (druga skala plagalna muzyki
+      bizantyjskiej)'
+    octoechos7: 'Octoechos 7: Ēchos barys (trzecia skala plagalna muzyki bizantyjskiej)'
+    octoechos8: 'Octoechos 8: Ēchos plagios tetartos (czwarta skala plagalna muzyki
+      bizantyjskiej)'
+    online_finding_aids: Pomoce archiwalne on-line
+    opera_houses_concert_halls: Opery i sale koncertowe
+    opus_number: Numer opus
+    opus_thematic_index_number: Opus / Numer z katalogu tematycznego
+    order_name: Imię zakonne
+    origin: Pochodzenie
+    original_cataloging_agency: Jednostka katalogująca pierwotny rekord
+    other: Pozostałe
+    other_form: Inna forma
+    other_form_of_name: Wariant nazwy instytucji
+    other_function: Inna funkcja
+    other_help: Inna pomoc
+    other_instruments: Pozostałe instrumenty
+    other_life_dates: Pozostałe daty urodzenia i śmierci
+    other_physical_details: Pozostałe dane fizyczne
+    other_searchform: Inna forma wyszukiwania
+    other_shelfmark: Inna sygnatura
+    other_standard_identifier: Identyfikator innego standardu
+    other_variant: Inny wariant
+    paper_maker: Producent papieru
+    papermaker: Producent papieru
+    parallel_form: Współistniejąca forma nazwy
+    parent_record: Rekord macierzysty
+    parts_held: Głosy
+    parts_held_extent: Głosy, objętość
+    patron: Sponsor
+    people_institutions: Osoby i instytucje
+    percussion: Perkusja
+    performance: Wykonanie
+    performances: Wykonania
+    performer: Wykonawca
+    performer_note: Uwaga o wykonaniu
+    person: Osoba
+    person_name: Imię i nazwisko
+    personal_name: Imię i nazwisko
+    personal_names: Osoby
+    photoreproductive_process: Proces optyczny (światłokopia)
+    physical_description: Opis fizyczny
+    physical_description_fields: Opis fizyczny itp. pola
+    place: Miejsce
+    place_active: Miejsce aktywności artystycznej
+    place_activity: Miejsce aktywności artystycznej
+    place_birth: Miejsce urodzenia
+    place_death: Miejsce śmierci
+    place_origin: Miejsce pochodzenia
+    place_publication: Miejsce publikacji
+    places: Miejsca
+    plate_number: Numer wydawniczy
+    plucked_instruments: Instrumenty szarpane
+    postal_code: Kod pocztowy
+    postal_place: Rejon pocztowy
+    preceding_entry: Poprzedzający wpis
+    printer: Drukarnia
+    printing_technique: Technika druku
+    production: Produkcja
+    production_personnel: Personel produkcyjny
+    profession_or_function: Zawód lub funkcja
+    provenance: Pochodzenie
+    provenance_notes: Uwagi o pochodzeniu
+    pseudonym: Pseudonim
+    public_note: Inne informacje kontaktowe
+    publisher: Wydawca
+    publisher_copyist: Wydawca, kopista
+    publishing_printing_production: Informacje o publikacji, druku i produkcji
+    range_dates: Zakres dat
+    record_actions: Działania na rekordzie
+    record_audit: RECORD AUDIT
+    record_origin: Pochodzenie rekordu
+    record_status: Status rekordu
+    reference_record_id: Referncyjny identyfikator RISM
+    references: Odniesienia
+    references_and_notes: Odniesienia i uwagi
+    region_active: Region aktywności artystycznej
+    region_of_activity: Region aktywności artystycznej
+    related_institution: Powiązana instytucja
+    related_personal_name: Powiązana osoba
+    related_place: Powiązane miejsce
+    related_resources: Powiązane zasoby
+    related_titles: Powiązane tytuły
+    related_to: W pokrewieństwie z …
+    related_work: Powiązane dzieło
+    relation: Relacja
+    relations: Relacje
+    religious_name: Imię z wyznania
+    religious_order: Zgromadzenie zakonne
+    reproduction: Reprodukcja
+    research_institute: Instytut badawczy
+    retrospective_conversion: Konwersja retrospektywna
+    rism_id_number: RISM ID
+    role: Rola
+    scoring_in_movement: Obsada w części
+    scoring_summary: Podsumowanie obsady
+    scribe: Kopista
+    secondary_literature: Literatura pomocnicza
+    series: Seria
+    series_added_entry: Dodatkowe wpisy tytułów
+    series_statement: Pola uwag do serii
+    set: Zbiór
+    shelfmark: Sygnatura
+    shelfmark_olim: Sygnatura (wcześniejsza)
+    short_title: Skrócony tytuł
+    sigla: Sigla
+    siglum: Siglum
+    single_date: Pojedyncza data
+    sister_of: Siostra …
+    sketches: Szkice
+    solo_voice: Głos solowy
+    soloist_instrument: Instrument solowy
+    source_data_found: Odnalezione źródło danych
+    source_data_not_found: Brak źródła danych
+    source_description: Uwaga o źródle opisu
+    source_details: Dane źródła
+    source_number_code: Źródło numeru lub kodu
+    source_of_acquisition_note: Uwaga o źródle nabycia
+    source_type: Rodzaj źródła
+    special_production_technique: Specjalna technika produkcji
+    standard: Standardowy
+    standard_musical_terms: Standardowe pojęcia muzyczne
+    standard_number_code: Standardowy numer lub kod
+    standard_texts_sacred_works: Standardowe teksty utworów sakralnych
+    standard_watermarks: Standardowe znaki wodne
+    standardized_title: Znormalizowany tytuł
+    standardized_titles_printed_music: Znormalizowane tytuły dla druków muzycznych
+    standardized_titles_subject_headings: Znormalizowane tytuły – słowa kluczowe
+    street_address: Ulica, numer, numer lokalu
+    strings: Instrumenty strunowe
+    subheading: Pod-nagłówek
+    subheading_general: Ogólny dalszy podział podnagłówków
+    subject_access_fields: Pola haseł tematycznych
+    subject_heading: Słowo kluczowe
+    subject_headings: Słowa kluczowe
+    subordinate_unit: Jednostka podporządkowana
+    succeeding_entry: Kolejny wpis
+    summary: Podsumowanie
+    supplementary_material: Materiał uzupełniający
+    technical_errors: Błędy techniczne
+    technical_production: Produkcja techniczna
+    temp_val: Temp val
+    templates: Szablony
+    terms_voices_instruments: Określenia głosów i instrumentów
+    text_author: Autor tekstu
+    text_incipit: Incipit tekstowy
+    third_fourth_group: Grupa trzecia / czwarta
+    time_signature: Metrum
+    title: Tytuł
+    title_content_description: Tytuł i opis źródła
+    title_item: Tytuł pozycji
+    title_movement_tempo: Tytuł części, tempo
+    title_of_work: Tytuł dzieła
+    title_on_source: Tytuł w źródle
+    title_periodical_book_series: Tytuł czasopisma, książki lub serii
+    title_related_fields: Tytuł i pola związane z tytułem
+    title_section_part: Tytuł sekcji lub części
+    title_variants: Warianty tytułu
+    titles_text_incipits: Tytuły / incipity tekstowe
+    topical_term: Pojęcie tematyczne
+    total_scoring: Szczegółowy opis obsady
+    transcribing_agency: Jednostka transkrybująca
+    translation: Tłumaczenie
+    translator: Tłumacz
+    transparency: Przezrocze
+    type: Rodzaj
+    type_institution: Rodzaj instytucji
+    type_name_variant: Typ alternatywnej nazwy osoby
+    type_publication: Rodzaj publikacji
+    type_relationship: Rodzaj relacji
+    typescript: Maszynopis
+    typography: Typografia
+    unknown: Nieznane
+    unparsed_fingerprint: Nieprzeanalizowany odcisk palca
+    variant_ms_title: Alternatywny tytuł w rękopisie
+    variant_source_title: Alternatywny tytuł w źródle
+    variations: Wariacje
+    vocalist: Wokalista
+    voice_instrument: Głos/instrument
+    volume_year_page: Wolumen, rok, strona
+    watermark_description: Opis znaku wodnego
+    woodwinds: Instrumenty dęte drewniane
+    work: Dzieło
+    work_number: Numer dzieła
+    year: Rok
+    years_birth_death: Lata urodzenia i śmierci

--- a/config/locales/marc_records/pt.yml
+++ b/config/locales/marc_records/pt.yml
@@ -1,0 +1,786 @@
+pt:
+  general:
+    e_mail: ''
+    editor_help: ''
+    faq: Questões frequentes
+    female: ''
+    how_do_i: Como faço ...dicas & truques
+    index_marc_fields: Índice dos campos MARC
+    male: ''
+    marc_tag_index: ''
+    'no': Não
+    rism: RISM
+    rism_best_practices: Boas práticas no RISM
+    rism_instrument_abbreviations: Abreviaturas de instrumentos do RISM
+    rism_series: Série RISM
+    rism_series_a_b_references: Referências às Séries RISM A/I e B
+    rism_series_number: Número de série RISM
+    rule_type: Regras de catalogação
+    scope_printed_music_rism: Âmbito da música impressa no RISM
+    searching: ''
+    status: ''
+    undetermined: Indeterminado
+    ungrouped_fields: ''
+    unknown_fields: ''
+    unused: UNUSED - WILL BE REMOVED
+    uri: URI
+    url: ''
+    using_muscat: Catalogando fontes
+    validity: Validade
+    verified: Verificada
+    when_to_input_new_record: Quando criar um novo registro (música impressa)
+    workflow: ''
+    'yes': Sim
+  languages:
+    afrikaans: Africânder
+    arabic: Árabe
+    aragonese: Aragonês
+    armenian: Arménio
+    basque: Basco
+    bosnian: Bósnio
+    bulgarian: Búlgaro
+    catalan: Catalão
+    celtic_other: Celtic (Other)
+    chinese: Chinês
+    creoles_pidgins_other: Creoles and Pidgins (Other)
+    croatian: Croata
+    czech: Tcheco
+    danish: Dinamarquês
+    dutch: Holandês
+    english: Inglês
+    estonian: Estoniano
+    ethiopic: Etíope
+    finnish: Finlandês
+    french: Francês
+    french_middle: Francês, Médio (ca. 1300-1600)
+    french_old: Francês, antigo (ca. 842-1300)
+    gallician: Galego
+    german: Alemão
+    german_old_high: German, Old High (ca. 750-1050)
+    germanic: ''
+    greek_ancient: Grego antigo (até 1453)
+    greek_modern: Grego moderno (1453-)
+    hebrew: Hebraico
+    hungarian: Húngaro
+    icelandic: Islandês
+    insari_sami: Inari Sami
+    irish: Irlandês
+    italian: Italiano
+    korean: Coreano
+    latin: Latim
+    latvian: Letão
+    lithuanian: Lituano
+    low_german: Baixo alemão
+    lower_sorbian: Sorábio, Baixo Sorábio
+    luxembourgish: Luxemburguês
+    macedonian: Macedônio
+    maori: Maori
+    middle_english: Inglês médio
+    middle_high_german: Alto-alemão médio
+    mongolian: Mongol
+    neapolitan: Napolitano
+    north_frisian: Frisão setentrional
+    norwegian: Norueguês
+    occitan: Occitano
+    oirat: Oirato
+    old_church_slavonic: Antigo eslavo eclesiástico
+    persian: Persa
+    polish: Polaco
+    portugese: Português
+    romani: Romani
+    romanian: Romeno
+    romansh: Reto-romano
+    russian: Russo
+    sanskrit: Sânscrito
+    scots: Escocês
+    serbian: Sérvio
+    sichuan_yi: Sichuan Yi
+    sicilian: Siciliano
+    slavic: Eslava
+    slovak: Eslovaco
+    slovenian: Esloveno
+    sorbian: Sorábio
+    spanish: Castelhano
+    swedish: Sueco
+    swiss_german: Suíço-alemão
+    tagalog: Tagalog
+    tartar: Tártaro
+    thai: Tailandês
+    tibetan: Tibetano
+    tsimshian: Tsimshian
+    turkish: Turco
+    ukrainian: Ucraniano
+    upper_sorbian: Sorábio, Alto Sorábio
+    vietnamese: Vietnamita
+    welsh: Galês
+    west_frisian: Frisão ocidental
+    yiddish: Iídiche
+  places:
+    algeria: ''
+    andorra: ''
+    argentina: ''
+    armenia: ''
+    australia: ''
+    austria: ''
+    austria_carinthia: ''
+    austria_lower_austria: ''
+    austria_salzburg: ''
+    austria_styria: ''
+    austria_tyrol: ''
+    austria_upper_austria: ''
+    austria_vienna: ''
+    belgium: ''
+    benin: ''
+    brazil: ''
+    bulgaria: ''
+    cambodia: ''
+    canada: ''
+    chile: ''
+    china: ''
+    colombia: ''
+    croatia: ''
+    cuba: ''
+    czech_republic: ''
+    denmark: ''
+    ecuador: ''
+    egypt: ''
+    estonia: ''
+    finland: ''
+    france: ''
+    georgia: ''
+    germany: ''
+    germany_bavaria: ''
+    germany_saxony: ''
+    greece: ''
+    guatemala: ''
+    guinea: ''
+    holy_see: ''
+    honduras: ''
+    hong_kong: Hong Kong
+    hungary: ''
+    iceland: ''
+    india: ''
+    indonesia: Indonésia
+    iran: ''
+    iraq: ''
+    ireland: ''
+    israel: ''
+    italy: ''
+    italy_trentino_alto_adige: ''
+    japan: ''
+    korea: ''
+    latvia: ''
+    lithuania: ''
+    luxembourg: ''
+    malta: ''
+    mexico: ''
+    moldavia: ''
+    monaco: ''
+    montenegro: Montenegro
+    netherlands: ''
+    new_zealand: Nova Zelândia
+    northern_ireland: Irlanda do Norte
+    norway: ''
+    papua_new_guinea: Papua Nova Guiné
+    paraguay: ''
+    peru: ''
+    philippines: Filipinas
+    poland: ''
+    portugal: ''
+    puerto_rico: ''
+    romania: ''
+    russian_federation: ''
+    saudi_arabia: Arábia Saudita
+    serbia: ''
+    slovakia: ''
+    slovenia: ''
+    south_africa: ''
+    spain: ''
+    sweden: ''
+    switzerland: ''
+    switzerland_vaud: ''
+    syrian_arab_republic: ''
+    taiwan: ''
+    trinidad_tobego: ''
+    turkey: ''
+    uk: ''
+    ukraine: ''
+    uruguay: ''
+    usa: ''
+    venezuela: ''
+    vietnam: ''
+  records:
+    a_major: Lá  maior
+    a_minor: Lá menor
+    abbreviations: ''
+    abbreviations_terminology: Abreviaturas e terminologia
+    access_restrictions: Restrições de acesso
+    accession_number: Número de aquisição
+    added_entry_name: ''
+    additional_author: ''
+    additional_bibliographic_information: ''
+    additional_biographical_information: Informação biográfica adicional
+    additional_choir_voice: ''
+    additional_institution: Instituição adicional
+    additional_personal_name: Nome de pessoa adicional
+    additional_personal_name_lit: Nome de pessoa adicional
+    additional_solo_voice: ''
+    additional_title: Título adicional
+    additional_title_lit: Título adicional
+    administration: Administração
+    af_major: Lá bemol maior
+    af_minor: Lá bemol menor
+    aide: assessor
+    aids: ''
+    alleged: Suposta
+    alternate_spelling: ''
+    archive: ''
+    arrangement: Arranjo
+    arrangement_statement: Menção de arranjo
+    arranger: Arranjador [arr]
+    artist: ''
+    artistic_production: ''
+    as_major: Lá sustenido maior
+    as_minor: Lá sustenido menor
+    ascertained: Certificada
+    assignee: Cessionário [asg]
+    associated_institution: Instituição associada
+    associated_name: Nome associado [asn]
+    associated_name_lit: Nome associado [asn]
+    associated_place: ''
+    attribution_qualifier: Atribuição
+    authentication_code: Código de autenticação
+    author: Autor [aut]
+    author_editor: Autor/editor
+    authorities: Autoridades
+    authority_agency: ''
+    authority_reference: Referência de autoridade
+    autography: Autografia
+    b_major: Si maior
+    b_minor: Si menor
+    baptismal_name: ''
+    basic_functions: Funções básicas
+    basso_continuo: Contínuo
+    bf_major: Si bemol maior
+    bf_minor: Si bemol menor
+    bibliographic_reference: Referência bibliográfica
+    binder: ''
+    binding_note: Nota de encadernação
+    birth_name: ''
+    book_format: Formato do livro
+    bookseller: Livreiro [bsl]
+    bound_with: ''
+    brass_instruments: Metais
+    brief: Breve
+    brother_of: ''
+    byname: ''
+    c_major: Dó maior
+    c_minor: Dó menor
+    c_minus_1: C-1
+    c_minus_2: C-2
+    c_minus_3: C-3
+    c_minus_4: C-4
+    c_minus_5: C-5
+    c_plus_1: C+1
+    c_plus_2: C+2
+    c_plus_3: C+3
+    c_plus_4: C+4
+    c_plus_5: C+5
+    catalog_opus_number: Número de catalogo/Número de Opus
+    catalog_works: Catálogo de obras
+    cataloging_agency: Agência catalogadora
+    cataloging_collection_convoluta: ''
+    cataloging_collections: Catalogação de coletâneas
+    cataloging_forms: ''
+    cataloging_language: Idioma de catalogação
+    cataloging_level: Nível de catalogação
+    cataloging_musical_sources: Catalogando fontes musicais
+    cataloging_source: Agência catalogadora
+    category: ''
+    censor: Censor [cns]
+    cf_major: Dó bemol maior
+    cf_minor: Dó bemol menor
+    child_of: ''
+    choir_voice: ''
+    choreographer: ''
+    chronological_subdivision: ''
+    chronological_term: ''
+    city: ''
+    clef: Clave
+    co-composer: Co-compositor [ctb]
+    coded_date: Data codificada
+    coded_instrumentation: Instrumentação codificada
+    collaborator: ''
+    colophon: Colofão
+    common_clefs: Claves comuns
+    compiler: ''
+    composer: ''
+    composer_author: Compositor/Autor
+    composer_cross_reference: Referência cruzada de compositor [cmp]
+    computer_printout: Impressão de computador
+    conceptor: Conceptor [ccp]
+    conductor: ''
+    confused_with: ''
+    conjectural: Conjetural
+    contact: ''
+    contact_area: Contato
+    content: ''
+    content_description: ''
+    contents_note: Nota de conteúdo
+    contributor: ''
+    control_fields: Campos de controle
+    control_number_identifier: Identificador de número de controle
+    copy_examined: Exemplar examinado para catalogação
+    copyist: Copista [scr]
+    copyright_holder: Detentor dos direitos de cópia/reprodução [cph]
+    costume_designer: ''
+    countries_places: ''
+    country: ''
+    country_active: ''
+    country_activity: ''
+    country_code: Código de país
+    country_of_publication: ''
+    county_province: ''
+    creation_production_note: Nota de produção/criação
+    cs_major: Dó sustenido maior
+    cs_minor: Dó sustenido menor
+    d_major: Ré maior
+    d_minor: Ré menor
+    dancer: ''
+    date: Data
+    date_of_acquisition: Data de aquisição
+    date_of_creation: Data de criação
+    date_time_last_transaction: Data e hora da última transação
+    date_type: Tipo de data
+    dates: Datas
+    dedicatee: Dedicatário(a) [dte]
+    department: Departamento
+    depositor: Depositante [dpt]
+    description: ''
+    description_area: Descrição
+    description_summary: Síntese da descrição
+    designer: ''
+    df_major: Ré bemol maior
+    df_minor: Ré bemol menor
+    digitized_music: ''
+    digitized_source: Fonte digitalizada
+    dimensions: Dimensões
+    diplomatic_title: ''
+    dissertation_note: ''
+    distribution: ''
+    distributor: Distribuidor [dst]
+    documentation_center: ''
+    donor: ''
+    doubtful: Duvidosa
+    dramatic_roles_original: Papéis dramáticos mencionado, grafia original
+    dramatic_roles_standardized: Papéis dramáticos identificados, normalizados
+    ds_major: Ré sustenido maior
+    ds_minor: Ré sustenido menor
+    dubious: ''
+    e_major: Mi maior
+    e_minor: Mi menor
+    ecclesiastical_modes: Modos eclesiásticos ocidentais
+    edition: ''
+    edition_imprint_fields: ''
+    edition_statement: ''
+    editor: Editor [edt]
+    ef_major: Mi bemol maior
+    ef_minor: Mi bemol menor
+    engraver: Gravador [egr]
+    engraving: Gravação
+    event_organizer: ''
+    event_place: Local do evento [evp]
+    excerpts: Excertos
+    extent: ''
+    extent_parts: Extensão das partes
+    external_resource: Recurso externo
+    external_resource_uri: ''
+    external_resource_url: ''
+    f_major: Fá maior
+    f_minor: Fá menor
+    f_minus_1: F-1
+    f_minus_2: F-2
+    f_minus_3: F-3
+    f_minus_4_bass: F-4 (clave grave)
+    f_minus_5: F-5
+    f_plus_1: F+1
+    f_plus_2: F+2
+    f_plus_3: F+3
+    f_plus_4: F+4
+    f_plus_5: F+5
+    facsimile: Fac-símile
+    family_name: ''
+    father_of: ''
+    figured_bass_scores: Baixo cifrado
+    fijian: Fijianas
+    fingerprint_identifier: Identificador de impressão
+    first_second_group: Primeiro/Segundo grupo
+    form_subdivision: ''
+    format_extent: Formato, extensão
+    former_owner: Proprietário anterior [fmo]
+    fragments: Fragmentos
+    friulano: Friulano
+    fs_major: Fá sustenido maior
+    fs_minor: Fá sustenido menor
+    full: Completo
+    function: Função
+    further_information: ''
+    g_major: Sol maior
+    g_minor: Sol menor
+    g_minus_1: G-1
+    g_minus_2_octave: g-2 (clave aguda à oitava)
+    g_minus_2_treble: G-2 (clave aguda)
+    g_minus_3: G-3
+    g_minus_4: G-4
+    g_minus_5: G-5
+    g_plus_1: G+1
+    g_plus_2: G+2
+    g_plus_3: G+3
+    g_plus_4: G+4
+    g_plus_5: G+5
+    gender: ''
+    general_abbreviations: Abreviaturas e termos gerais
+    general_cataloguing_guidelines: Diretrizes gerais para catalogação
+    general_note: Nota geral
+    general_note_incipits: Nota geral
+    general_note_institution: Nota geral
+    general_note_personal: Nota geral
+    geographic_name: Nome geográfico
+    geographic_subdivision: ''
+    gf_major: Sol bemol maior
+    gf_minor: Sol bemol menor
+    gs_major: Sol sustenido maior
+    gs_minor: Sol sustenido menor
+    heading: ''
+    heading_composer_name: ''
+    heading_personal_name: ''
+    heading_personal_name1: Título-Nome de pessoa
+    help_transposing_instruments: Ajuda para instrumentos transpositores
+    history_institution: História da instituição
+    holdings_location: ''
+    identity: ''
+    identity_area: Identidade
+    iiif_manifest: Manifesto IIIF
+    illustrator: Ilustrador [ill]
+    images: Imagens
+    import: Importação
+    imprint: Carimbo/marca
+    incipit: Incipit
+    incipit_number: Número de incipit
+    incipits: Incipit
+    index_terms: ''
+    information_found: ''
+    initial: ''
+    initial_entry: Entrada inicial
+    initials: ''
+    insertions: Inserções
+    inserts: Inserções
+    institution: Instituição
+    institutions: Instituições
+    instrumentalist: ''
+    internal_note: Nota interna
+    introduction: Introdução
+    isbn: ISBN
+    ismn: ISMN
+    issn: ISSN
+    item_in_collection: Itens nesta fonte
+    item_part_of: Item parte de
+    items_in_source: Itens nesta fonte
+    japanese: Japonês
+    key: Tonalidade
+    key_or_mode: ''
+    key_signature: Armadura de clave
+    keyboards: Teclados
+    keys: Tonalidades
+    language_code: Código de idioma
+    language_codes: Código de idioma
+    language_libretto: Idioma do libreto
+    language_note: Nota de idioma
+    language_of_cataloging: Idioma de catalogação
+    language_original_text: Idioma do texto original
+    language_text: Idioma do texto
+    latitude: ''
+    leader: Líder
+    library: Instituição
+    library_information: Informação da instituição
+    library_information_relations: Informação da instituição e relações
+    library_siglum: Sigla da Instituição
+    librettist: Libretista [lbt]
+    licensee: Titular [lse]
+    life_dates: Datas de nascimento e morte
+    link_type: Tipo de Link
+    linkage: ''
+    linking_entry_fields: ''
+    literature: Literatura
+    lithograph: ''
+    lithographer: Litógrafo [ltg]
+    lithography: Litografia
+    liturgical_festival: Festa litúrgica
+    liturgical_festivals: Festas litúrgicas
+    local_id_number: Número local
+    local_note_field: Campo de nota local
+    local_notes_field: ''
+    local_number: Número local
+    location: Local
+    location_and_address: Local e endereço
+    location_insertion: Localização da inserção
+    location_on_source: ''
+    location_performance: Local de performance
+    location_printer: Local de impressão
+    longitude: ''
+    lyricist: ''
+    main_entry_fields: Campos de entrada principal
+    married_name: ''
+    married_to: ''
+    married_with: ''
+    material_description: Descrição de material
+    material_examined: Material examinado
+    material_held: Material existente
+    material_not_examined: Material não examinado
+    media_type: Tipo de mídia
+    mensural_clefs: Claves mensurais
+    method_of_acquisition: Método de aquisição
+    misattributed: Equivocada
+    miscellaneous: ''
+    mode_10t: 'Modo: 10º tom (Hipoeólio)'
+    mode_10tt: 'Modo: 10º tom (Hipoeólio), transposta'
+    mode_11t: 'Modo:  11º tom (Jônio)'
+    mode_11tt: 'Modo:  11º tom (Jônio), transposta'
+    mode_12t: 'Modo:  12º modo (Hipojônio)'
+    mode_12tt: 'Modo:  12º modo (Hipojônio), transposta'
+    mode_1t: 'Modo:  1º tom (Dórico)'
+    mode_1tt: 'Modo:  1º tom (Dórico), transposta'
+    mode_2t: 'Modo:  2º tom (Hipodórico)'
+    mode_2tt: 'Modo:  2º tom (Hipodórico), transposta'
+    mode_3t: 'Modo:  3º tom (Frígio)'
+    mode_3tt: 'Modo:  3º tom (Frígio), transposta'
+    mode_4t: 'Modo:  4º tom (Hipofrígio)'
+    mode_4tt: 'Modo:  4º tom (Hipofrígio), transposta'
+    mode_5t: 'Modo:  5º tom (Lídio)'
+    mode_5tt: 'Modo:  5º tom (Lídio), transposta'
+    mode_6t: 'Modo:  6º tom (Hipolídio)'
+    mode_6tt: 'Modo:  6º tom (Hipolídio), transposta'
+    mode_7t: 'Modo:  7º tom (Mixolídio)'
+    mode_7tt: 'Modo:  7º tom (Mixolídio), transposta'
+    mode_8t: 'Modo:  8º tom (Hipomixolídio)'
+    mode_8tt: 'Modo:  8º tom (Hipomixolídio), transposta'
+    mode_9t: 'Modo:  9º tom (Eólio)'
+    mode_9tt: 'Modo:  9º tom (Eólio), transposta'
+    modifying_agency: ''
+    monogram: ''
+    mother_of: ''
+    movement_number: Número de movimento
+    multiple: Múltiplos
+    multiple_copies: Múltiplos exemplares em uma instituição
+    multiple_single_dates: Datas múltiplas
+    museum: ''
+    music_incipit: Incipit musical
+    name: Nome
+    name_family: ''
+    name_printer: Nome do impressor
+    name_variant: Variante de nome
+    name_variants: Variantes de nome
+    named_dramatic_roles: Papéis dramáticos identificados
+    nationality: Nacionalidade
+    nickname: ''
+    no_linguistic_content: ''
+    non_migrated_bound: ''
+    note_external_resource: Nota sobre recurso externo
+    note_fields: Campos de notas
+    note_on_performance: Nota sobre performance
+    now_in: Agora em
+    number: Número
+    number_page: Número/página
+    number_part_section: ''
+    number_volume_part: Número de volume/parte
+    numbers_code_fields: Números e campos de código
+    octoechos1: 'Octoechos 1: Ēchos prōtos (Primeiro modo bizantino)'
+    octoechos2: 'Octoechos 2: Ēchos deuteros (Segundo modo bizantino)'
+    octoechos3: 'Octoechos 3: Ēchos tritos (Terceiro modo bizantino)'
+    octoechos4: 'Octoechos 4: Ēchos tetartos (Quarto modo bizantino)'
+    octoechos5: 'Octoechos 5: Ēchos plagios prōtos (Primeiro modo bizantino plagal)'
+    octoechos6: 'Octoechos 6: Ēchos plagios deuteros (Segundo modo bizantino plagal)'
+    octoechos7: 'Octoechos 7: Ēchos barys (Terceiro modo bizantino plagal)'
+    octoechos8: 'Octoechos 8: Ēchos plagios tetartos (Quarto modo bizantino plagal)'
+    online_finding_aids: Instrumentos de pesquisa on-line
+    opera_houses_concert_halls: Teatros de ópera e salas de concerto
+    opus_number: Número de opus
+    opus_thematic_index_number: ''
+    order_name: ''
+    origin: Origem
+    original_cataloging_agency: ''
+    other: Outro(a) [oth]
+    other_form: ''
+    other_form_of_name: Outra forma do nome
+    other_function: ''
+    other_help: Outra ajuda
+    other_instruments: Outros instrumentos
+    other_life_dates: ''
+    other_physical_details: Outros detalhes físicos
+    other_searchform: ''
+    other_shelfmark: Outro código
+    other_standard_identifier: Outro identificador padronizado
+    other_variant: ''
+    paper_maker: ''
+    papermaker: Fabricante de papel [ppm]
+    parallel_form: Forma paralela do nome
+    parent_record: Registro principal
+    parts_held: Partes existentes
+    parts_held_extent: Partes existentes e extensão
+    patron: ''
+    people_institutions: Pessoas e instituições
+    percussion: Percussão
+    performance: ''
+    performances: ''
+    performer: Intérprete [prf]
+    performer_note: ''
+    person: Pessoa
+    person_name: ''
+    personal_name: ''
+    personal_names: Nomes de pessoas
+    photoreproductive_process: Processo foto-reprodutivo
+    physical_description: Descrição física
+    physical_description_fields: ''
+    place: Local
+    place_active: ''
+    place_activity: ''
+    place_birth: ''
+    place_death: ''
+    place_origin: ''
+    place_publication: ''
+    places: Locais
+    plate_number: Número de chapa
+    plucked_instruments: Cordas dedilhadas
+    postal_code: ''
+    postal_place: ''
+    preceding_entry: Registro precedente
+    printer: Impressor(a) [prt]
+    printing_technique: Técnica de impressão
+    production: ''
+    production_personnel: ''
+    profession_or_function: ''
+    provenance: Proveniência
+    provenance_notes: Nota de proveniência
+    pseudonym: ''
+    public_note: ''
+    publisher: Casa editora [pbl]
+    publisher_copyist: Editor, copista
+    publishing_printing_production: Informação de publicação, impressão e produção
+    range_dates: Faixa de datas
+    record_actions: Ações do registro
+    record_audit: RECORD AUDIT
+    record_origin: Origem do registro
+    record_status: Estado do registro
+    reference_record_id: REFERENCE RECORD ID
+    references: Referências
+    references_and_notes: Notas e referências
+    region_active: ''
+    region_of_activity: ''
+    related_institution: Instituição relacionada
+    related_personal_name: Nome de pessoa relacionado
+    related_place: Local relacionado
+    related_resources: ''
+    related_titles: ''
+    related_to: ''
+    related_work: ''
+    relation: ''
+    relations: Relacionamentos
+    religious_name: ''
+    religious_order: ''
+    reproduction: Reprodução
+    research_institute: ''
+    retrospective_conversion: Conversão restropectiva
+    rism_id_number: Número ID RISM
+    role: Personagem
+    scoring_in_movement: Formação instrumental no movimento
+    scoring_summary: Sintese da formação instrumental
+    scribe: ''
+    secondary_literature: Literatura secundária
+    series: Séries
+    series_added_entry: ''
+    series_statement: ''
+    set: ''
+    shelfmark: Código
+    shelfmark_olim: Código antigo (olim)
+    short_title: Título abreviado
+    sigla: ''
+    siglum: ''
+    single_date: Data única
+    sister_of: ''
+    sketches: Esboços
+    solo_voice: Voz solista
+    soloist_instrument: ''
+    source_data_found: Fonte dos dados encontrados
+    source_data_not_found: ''
+    source_description: Exemplar examinado para catalogação
+    source_details: ''
+    source_number_code: ''
+    source_of_acquisition_note: Nota de origem da aquisição
+    source_type: Tipo de fonte
+    special_production_technique: Técnica de produção especial
+    standard: Normalizado
+    standard_musical_terms: Termos musicais normalizados
+    standard_number_code: ''
+    standard_texts_sacred_works: Textos padronizados de obras sacras
+    standard_watermarks: Marcas d'água normalizadas
+    standardized_title: Título uniforme
+    standardized_titles_printed_music: Títulos uniformes para música impressa
+    standardized_titles_subject_headings: Títulos uniformes – Cabeçalhos de assunto
+    street_address: ''
+    strings: Cordas
+    subheading: Subdivisão de forma
+    subheading_general: ''
+    subject_access_fields: Campos de acesso por assunto
+    subject_heading: Assunto
+    subject_headings: Cabeçalhos de assunto
+    subordinate_unit: ''
+    succeeding_entry: Registro subsequente
+    summary: ''
+    supplementary_material: Material suplementar
+    technical_errors: Problemas técnicos
+    technical_production: ''
+    temp_val: ''
+    templates: Modelos
+    terms_voices_instruments: Termos para vozes e instrumentos
+    text_author: Autor literário [lyr]
+    text_incipit: Incipit literário
+    third_fourth_group: Terceiro/Quarto grupo
+    time_signature: Compasso
+    title: ''
+    title_content_description: Título e descrição do conteúdo
+    title_item: Título do item
+    title_movement_tempo: Título do movimento, tempo
+    title_of_work: ''
+    title_on_source: Título na fonte
+    title_periodical_book_series: ''
+    title_related_fields: ''
+    title_section_part: ''
+    title_variants: ''
+    titles_text_incipits: Títulos / incipits literários
+    topical_term: ''
+    total_scoring: Formação total
+    transcribing_agency: ''
+    translation: Tradução
+    translator: Tradutor [trl]
+    transparency: Transparência
+    type: Tipo
+    type_institution: Tipo de instituição
+    type_name_variant: ''
+    type_publication: ''
+    type_relationship: ''
+    typescript: Datilografia
+    typography: Tipografia
+    unknown: ''
+    unparsed_fingerprint: Identificador de impressão não analisado
+    variant_ms_title: Variante de título na fonte
+    variant_source_title: Título variante na fonte
+    variations: ''
+    vocalist: ''
+    voice_instrument: Voz/instrumento
+    volume_year_page: ''
+    watermark_description: Descrição de Marca de água
+    woodwinds: Madeiras
+    work: Obra
+    work_number: Número de obra
+    year: ''
+    years_birth_death: ''

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -1,5 +1,5 @@
 
-en:
+pl:
   active_admin:
 # Pad for italian, it has 2 missing items
 #
@@ -56,6 +56,7 @@ en:
       empty: Nie znaleziono %{model}
       one: Wyświetlany <b>1</b> %{model}
       one_page: Wyświetlane <b>wszystkie %{n}</b> %{model}
+      few: Kilka
       multiple: Wyświetlane %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b> z <b>%{total}</b> łącznie
       multiple_without_total: Wyświetlane %{model} <b>%{from}&nbsp;-&nbsp;%{to}</b>
       per_page: "Liczba elementów na stronie:"

--- a/config/locales/plurals.rb
+++ b/config/locales/plurals.rb
@@ -1,0 +1,14 @@
+
+# See https://github.com/ruby-i18n/i18n/blob/master/test/test_data/locales/plurals.rb
+# This is an interim fix for pl not having the 'few' key for items with 2 elements
+# All the languages now are forced to have keys only for singular (1) or plural (>2)
+# This can be fixed with a review of the translations
+{
+    :de => { :i18n => { :plural => { :keys => [:one, :other], :rule => lambda { |n| n == 1 ? :one : :other } } } },
+    :en => { :i18n => { :plural => { :keys => [:one, :other], :rule => lambda { |n| n == 1 ? :one : :other } } } },
+    :es => { :i18n => { :plural => { :keys => [:one, :other], :rule => lambda { |n| n == 1 ? :one : :other } } } },
+    :fr => { :i18n => { :plural => { :keys => [:one, :other], :rule => lambda { |n| n == 1 ? :one : :other } } } },
+    :it => { :i18n => { :plural => { :keys => [:one, :other], :rule => lambda { |n| n == 1 ? :one : :other } } } },
+    :pl => { :i18n => { :plural => { :keys => [:one, :other], :rule => lambda { |n| n == 1 ? :one : :other } } } },
+    :pt => { :i18n => { :plural => { :keys => [:one, :other], :rule => lambda { |n| n == 1 ? :one : :other } } } },
+}


### PR DESCRIPTION
This commit adds the new translations and editor configuration files for moving the translation mechanism to the standard Rails system.

Will require a small change to the translation loading system for the editor, which @xhero has tested on his side. 

Fixes #1004