### PR TITLE
Fix edit link for sources in faceted search

### DIFF
--- a/app/views/catalog/_previous_next_doc.html.erb
+++ b/app/views/catalog/_previous_next_doc.html.erb
@@ -16,7 +16,7 @@
 
       <%=link_to t('blacklight.search.start_over'), start_over_path(current_search_session.try(:query_params) || {}), id: 'startOverLink', class: 'btn' %>
 
-      <% if @document.id.start_with? "Sources" %>
+      <% if @document.id.start_with? "Source" %>
           <%=link_to t('active_admin.edit'), "/admin/sources/#{@document.id.split(" ")[1]}/edit", class: 'btn' %>
       <% else %>
           <%=link_to t('active_admin.edit'), "/admin/publications/#{@document.id.split(" ")[1]}/edit", class: 'btn' %>


### PR DESCRIPTION
Record type is in singular (Source) not plural (Sources). Fixes #1057