### PR TITLE
Fix asset compilation in 7.0.2

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,0 +1,3 @@
+//= link_tree ../images
+//= link_directory ../javascripts .js
+//= link_directory ../stylesheets .css


### PR DESCRIPTION
Due to a change in sprockets 4, the asset precompiling pipeline no longer worked to compile assets in the Muscat app folder.

The fix was to add the paths in the app/assets/config/manifest.js. This is documented in the Sprockets upgrading documentation here: https://github.com/rails/sprockets/blob/master/UPGRADING.md#manifestjs