### PR TITLE
Fixed: Improved output of the IIIF manifest script

### DIFF
--- a/housekeeping/make_manifest.rb
+++ b/housekeeping/make_manifest.rb
@@ -36,7 +36,8 @@ module Faraday
 end
 
 #IIF_PATH="http://d-lib.rism-ch.org/cgi-bin/iipsrv.fcgi?IIIF=/usr/local/images/ch/"
-IIF_PATH="https://iiif.rism-ch.org/iiif/"
+# Should not have a trailing slash!
+IIIF_PATH="https://iiif.rism.digital"
 
 if ARGV[0].include?("yml")
   dirs  = YAML.load_file(ARGV[0])
@@ -71,22 +72,27 @@ dirs.keys.each do |dir|
   end
   
   # Create the base manifest file
+  related = {
+    "@id" => "http://www.rism-ch.org/catalog/#{dir}",
+    "format" => "text/html",
+    "label" => "RISM Catalogue Record"
+  }
   seed = {
-      '@id' => "https://iiif.rism-ch.org/manifest/#{dir}.json",
+      '@id' => "#{IIIF_PATH}/manifest/#{dir}.json",
       'label' => title,
-      'related' => "http://www.rism-ch.org/catalog/#{dir}"
+      'related' => related
   }
   # Any options you add are added to the object
   manifest = IIIF::Presentation::Manifest.new(seed)
   sequence = IIIF::Presentation::Sequence.new
   manifest.sequences << sequence
   
-  images.each do |image_name|
+  images.each_with_index do |image_name, idx|
     canvas = IIIF::Presentation::Canvas.new()
-    canvas['@id'] = "#{dir}/#{image_name}"
-    canvas.label = image_name
+    canvas['@id'] = "#{IIIF_PATH}/canvas/#{dir}/#{image_name}"
+    canvas.label = "[Image #{idx}]"
     
-    image_url = IIF_PATH + dir + "/" + image_name
+    image_url = "#{IIIF_PATH}/image/#{dir}/#{image_name}"
     
     image = IIIF::Presentation::Annotation.new
     image["on"] = canvas['@id']
@@ -121,7 +127,7 @@ dirs.keys.each do |dir|
     # -01 -02 etc
     new_tag = MarcNode.new("source", "856", "", "##")
     new_tag.add_at(MarcNode.new("source", "x", "IIIF", nil), 0)
-    new_tag.add_at(MarcNode.new("source", "u", "https://iiif.rism-ch.org/manifest/#{dir}.json", nil), 0)
+    new_tag.add_at(MarcNode.new("source", "u", "https://iiif.rism.digital/manifest/#{dir}.json", nil), 0)
 
     pi = marc.get_insert_position("856")
     marc.root.children.insert(pi, new_tag)


### PR DESCRIPTION
Some improvements to the manifest generation script for Muscat. Note that this hasn't actually been tested, since I don't have a working Muscat installation locally.

 - Changes the path to the new RISM Digital IIIF server
 - Fixes the canvas ID property to be a full URI
 - Improves the 'related' property with a label and format per the spec recommendations
 - Improves the human readable label of the canvas to an enumerated image value instead of the filename
 - Updates the value written back to Muscat